### PR TITLE
Align PlanOpticon ingestion with current outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.0 — 2026-04-13
+
+### Interoperability
+
+- **PlanOpticon format alignment** — auto-detect current batch `manifest.json` outputs separately from single-run manifests and accept `exchange.json` as the interchange format
+- **PlanOpticon docs refresh** — updated the integration guide and API reference to match current manifest, knowledge graph, exchange, and batch payload shapes
+- **Neutral memory terminology** — replaced public `CONFLICT-format memory` wording with `structured memory`
+
 ## 1.0.1 — 2026-04-13
 
 ### Release Readiness

--- a/docs/api/ingestion.md
+++ b/docs/api/ingestion.md
@@ -1,10 +1,10 @@
 # Ingestion API
 
-All ingesters accept a `GraphStore` instance and return an `IngestionResult` dataclass.
+Core ingesters accept a `GraphStore` instance. The repo ingester uses the `IngestionResult` dataclass shown below; newer specialized ingesters may return plain summary dictionaries instead.
 
 ```python
 from navegador.graph import GraphStore
-from navegador.ingest import RepoIngester, KnowledgeIngester, WikiIngester, PlanopticonIngester
+from navegador.ingestion import RepoIngester, KnowledgeIngester, WikiIngester, PlanopticonIngester
 ```
 
 ---
@@ -265,46 +265,30 @@ Ingests Planopticon knowledge graph output into the knowledge layer.
 
 ```python
 class PlanopticonIngester:
-    def __init__(self, store: GraphStore) -> None: ...
-
-    def ingest(
-        self,
-        path: str | Path,
-        *,
-        input_type: str = "auto",
-        source: str = "",
-    ) -> IngestionResult: ...
+    def __init__(self, store: GraphStore, source_tag: str = "") -> None: ...
 
     def ingest_manifest(
-        self,
-        path: str | Path,
-        *,
-        source: str = "",
-    ) -> IngestionResult: ...
+        self, path: str | Path
+    ) -> dict[str, int]: ...
 
     def ingest_kg(
-        self,
-        path: str | Path,
-        *,
-        source: str = "",
-    ) -> IngestionResult: ...
+        self, path: str | Path
+    ) -> dict[str, int]: ...
 
     def ingest_interchange(
-        self,
-        path: str | Path,
-        *,
-        source: str = "",
-    ) -> IngestionResult: ...
+        self, path: str | Path
+    ) -> dict[str, int]: ...
 
     def ingest_batch(
-        self,
-        path: str | Path,
-        *,
-        source: str = "",
-    ) -> IngestionResult: ...
+        self, path: str | Path
+    ) -> dict[str, int]: ...
 ```
 
-`input_type` values: `"auto"`, `"manifest"`, `"kg"`, `"interchange"`, `"batch"`.
+Typical return value:
+
+```python
+{"nodes": 42, "edges": 19}
+```
 
 See [Planopticon guide](../guide/planopticon.md) for format details and entity mapping.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -90,7 +90,7 @@ navegador --version
 Expected output:
 
 ```
-navegador, version 0.8.0
+navegador, version 1.1.0
 ```
 
 ## Shell completions

--- a/docs/guide/planopticon.md
+++ b/docs/guide/planopticon.md
@@ -2,7 +2,7 @@
 
 ## What is Planopticon
 
-Planopticon is a video and meeting knowledge extraction tool. It ingests recordings, transcripts, and meeting notes and produces structured knowledge graphs: entities (people, concepts, decisions), relationships, action items, and diagrams extracted from the meeting content.
+Planopticon is a video, meeting, and document knowledge extraction tool. It ingests recordings, transcripts, notes, and supporting documents and produces structured knowledge artifacts: knowledge graphs, manifests, action items, key points, and exchange payloads.
 
 Navegador treats Planopticon output as a first-class knowledge source. Where `navegador add concept` requires manual entry, Planopticon extracts concepts, rules, and decisions from meeting recordings automatically and navegador stores them alongside your code graph.
 
@@ -15,7 +15,7 @@ Video / transcript
        ↓
   Planopticon
        ↓  produces
-  knowledge_graph.json / interchange.json / manifest.json
+  manifest.json / results/knowledge_graph.json / exchange.json
        ↓
   navegador planopticon ingest
        ↓  creates
@@ -33,61 +33,69 @@ Planopticon produces several output formats. Navegador accepts all of them and a
 
 ### manifest.json
 
-Top-level manifest for a multi-file Planopticon output package. Points to the knowledge graph, interchange, and supporting files.
+Single-run PlanOpticon manifest. This is the primary entry point for a completed analysis directory.
 
 ```json
 {
   "version": "1.0",
-  "source": "zoom-meeting-2026-03-15",
-  "knowledge_graph": "knowledge_graph.json",
-  "interchange": "interchange.json",
-  "diagrams": ["arch-diagram.png"]
-}
-```
-
-### knowledge_graph.json
-
-Planopticon's native graph format. Contains typed entities and relationships:
-
-```json
-{
-  "entities": [
-    { "id": "e1", "type": "Decision", "name": "UseRedisForSessions", "description": "...", "rationale": "..." },
-    { "id": "e2", "type": "Person", "name": "Alice Chen", "role": "Lead Engineer" },
-    { "id": "e3", "type": "Concept", "name": "SessionAffinity", "description": "..." }
-  ],
-  "relationships": [
-    { "from": "e2", "to": "e1", "type": "DECIDED_BY" },
-    { "from": "e1", "to": "e3", "type": "RELATED_TO" }
-  ]
-}
-```
-
-### interchange.json
-
-A normalized interchange format, flatter than the native graph. Used when exporting from Planopticon for consumption by downstream tools.
-
-```json
-{
-  "concepts": [...],
-  "rules": [...],
-  "decisions": [...],
-  "people": [...],
+  "video": { "title": "Sprint Planning" },
+  "knowledge_graph_json": "results/knowledge_graph.json",
+  "key_points_json": "results/key_points.json",
+  "action_items_json": "results/action_items.json",
+  "key_points": [...],
   "action_items": [...],
   "diagrams": [...]
 }
 ```
 
-### Batch manifest
+### knowledge_graph.json
 
-A JSON file listing multiple Planopticon output directories or archive paths for bulk ingestion:
+PlanOpticon's native graph export. Contains `nodes`, `relationships`, and optional `sources`:
 
 ```json
 {
-  "batch": [
-    { "path": "./meetings/2026-03-15/", "source": "arch-review" },
-    { "path": "./meetings/2026-02-20/", "source": "sprint-planning" }
+  "nodes": [
+    { "name": "Redis", "type": "technology", "descriptions": ["Session storage"] },
+    { "name": "Alice Chen", "type": "person", "descriptions": ["Lead engineer"] }
+  ],
+  "relationships": [
+    { "source": "Redis", "target": "Session Store", "type": "depends_on" }
+  ],
+  "sources": [
+    { "source_id": "meeting-1", "source_type": "video", "title": "Sprint Planning" }
   ]
+}
+```
+
+### exchange.json / interchange.json
+
+A PlanOpticonExchange payload used for interchange with downstream tools. `navegador` still uses the `interchange` type name for this format.
+
+```json
+{
+  "version": "1.0",
+  "project": { "name": "Sprint Reviews", "tags": ["backend", "payments"] },
+  "entities": [...],
+  "relationships": [...],
+  "artifacts": [...],
+  "sources": [...]
+}
+```
+
+### Batch manifest
+
+Current batch outputs also use `manifest.json` at the batch root. Older corpora may still contain `batch_manifest.json`, which `navegador` accepts as a legacy alias.
+
+```json
+{
+  "version": "1.0",
+  "title": "Sprint Reviews",
+  "videos": [
+    { "video_name": "meeting-01", "manifest_path": "videos/meeting-01/manifest.json", "status": "completed" }
+  ],
+  "total_videos": 2,
+  "completed_videos": 2,
+  "merged_knowledge_graph_json": "knowledge_graph.json"
 }
 ```
 
@@ -120,10 +128,10 @@ navegador planopticon ingest ./meeting-output/ --type auto
 ### Explicit format
 
 ```bash
-navegador planopticon ingest ./meeting-output/knowledge_graph.json --type kg
-navegador planopticon ingest ./meeting-output/interchange.json --type interchange
-navegador planopticon ingest ./manifest.json --type manifest
-navegador planopticon ingest ./batch.json --type batch
+navegador planopticon ingest ./meeting-output/results/knowledge_graph.json --type kg
+navegador planopticon ingest ./exchange.json --type interchange
+navegador planopticon ingest ./meeting-output/manifest.json --type manifest
+navegador planopticon ingest ./batch-output/manifest.json --type batch
 ```
 
 ### Label the source
@@ -149,27 +157,26 @@ Returns a summary of nodes and edges created.
 ## Python API
 
 ```python
-from navegador.ingest import PlanopticonIngester
 from navegador.graph import GraphStore
+from navegador.ingestion import PlanopticonIngester
 
 store = GraphStore.sqlite(".navegador/navegador.db")
-ingester = PlanopticonIngester(store)
+ingester = PlanopticonIngester(store, source_tag="arch-review")
 
-# auto-detect format
-result = ingester.ingest("./meeting-output/", input_type="auto", source="arch-review")
+# ingest a completed analysis run
+stats = ingester.ingest_manifest("./meeting-output/manifest.json")
 
-print(f"Created {result.nodes_created} nodes, {result.edges_created} edges")
+print(f"Created {stats['nodes']} nodes, {stats['edges']} edges")
 
-# ingest a specific interchange file
-result = ingester.ingest_interchange("./interchange.json", source="sprint-planning")
+# ingest an exchange/interchange file
+stats = ingester.ingest_interchange("./exchange.json")
 ```
 
 ### PlanopticonIngester methods
 
 | Method | Description |
 |---|---|
-| `ingest(path, input_type, source)` | Auto or explicit ingest from path |
-| `ingest_manifest(path, source)` | Ingest a manifest.json package |
-| `ingest_kg(path, source)` | Ingest a knowledge_graph.json file |
-| `ingest_interchange(path, source)` | Ingest an interchange.json file |
-| `ingest_batch(path, source)` | Ingest a batch manifest |
+| `ingest_manifest(path)` | Ingest a manifest.json package |
+| `ingest_kg(path)` | Ingest a knowledge_graph.json file |
+| `ingest_interchange(path)` | Ingest an exchange/interchange JSON file |
+| `ingest_batch(path)` | Ingest a batch manifest (`manifest.json` or legacy `batch_manifest.json`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Navegador <small>v0.7</small>
+# Navegador <small>v1.1</small>
 
 **The project knowledge graph for AI coding agents.**
 
@@ -6,7 +6,7 @@ Navegador builds and maintains a queryable graph of your software project — co
 
 > *navegador* — Spanish for *navigator / sailor*. It helps agents navigate your code.
 >
-> **Current version: 0.7.0**
+> **Current version: 1.1.0**
 
 ---
 
@@ -138,7 +138,7 @@ print(bundle.to_markdown())
 
 ---
 
-## What's new in 0.7.0
+## Highlights
 
 | Feature | Command / API |
 |---|---|

--- a/navegador/__init__.py
+++ b/navegador/__init__.py
@@ -2,7 +2,7 @@
 Navegador — AST + knowledge graph context engine for AI coding agents.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 __author__ = "CONFLICT LLC"
 
 from navegador.sdk import Navegador

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -581,7 +581,7 @@ def concept(name: str, db: str, fmt: str):
 
 @main.group()
 def memory():
-    """Ingest and query CONFLICT-format memory/ directories."""
+    """Ingest and query structured memory/ directories."""
 
 
 @memory.command("ingest")
@@ -598,7 +598,7 @@ def memory():
 def memory_ingest(
     memory_path: str, repo_name: str, clear: bool, workspace: bool, recursive: bool, db: str
 ):
-    """Ingest a CONFLICT-format memory/ directory into the graph."""
+    """Ingest a structured memory/ directory into the graph."""
     from navegador.ingestion import MemoryIngester
 
     ingester = MemoryIngester(_get_store(db))
@@ -963,36 +963,17 @@ def planopticon_ingest(path: str, input_type: str, source: str, as_json: bool, d
     PATH can be:
       - A manifest.json file
       - A knowledge_graph.json file
-      - An interchange.json file
+      - A PlanOpticonExchange JSON file (exchange.json / interchange.json)
       - A batch manifest JSON
-      - A planopticon output directory (auto-detects manifest.json inside)
+      - A planopticon output directory (auto-detects current PlanOpticon layouts)
     """
-    from pathlib import Path as P
-
     from navegador.ingestion import PlanopticonIngester
+    from navegador.ingestion.planopticon import resolve_planopticon_input
 
-    p = P(path)
-    # Resolve directory → manifest.json
-    if p.is_dir():
-        candidates = ["manifest.json", "results/knowledge_graph.json", "interchange.json"]
-        for c in candidates:
-            if (p / c).exists():
-                p = p / c
-                break
-        else:
-            raise click.UsageError(f"No recognised planopticon file found in {path}")
-
-    # Auto-detect type from filename
-    if input_type == "auto":
-        name = p.name.lower()
-        if "manifest" in name:
-            input_type = "manifest"
-        elif "interchange" in name:
-            input_type = "interchange"
-        elif "batch" in name:
-            input_type = "batch"
-        else:
-            input_type = "kg"
+    try:
+        input_type, p = resolve_planopticon_input(path, input_type=input_type)
+    except FileNotFoundError as exc:
+        raise click.UsageError(str(exc)) from exc
 
     ing = PlanopticonIngester(_get_store(db), source_tag=source)
 

--- a/navegador/graph/queries.py
+++ b/navegador/graph/queries.py
@@ -252,7 +252,7 @@ MATCH (d:Document {path: $path})
 DETACH DELETE d
 """
 
-# ── Memory: CONFLICT-format knowledge nodes ──────────────────────────────────
+# ── Memory-backed knowledge nodes ─────────────────────────────────────────────
 
 MEMORY_LIST = """
 MATCH (n)

--- a/navegador/ingestion/memory.py
+++ b/navegador/ingestion/memory.py
@@ -1,5 +1,5 @@
 """
-MemoryIngester — ingests CONFLICT-format memory/ directories into the graph.
+MemoryIngester — ingests structured memory/ directories into the graph.
 
 Supports two file formats:
 
@@ -29,7 +29,7 @@ Type mapping:
     user      → Person      (user profile, role, responsibilities)
 
 All memory nodes carry two extra properties:
-    memory_type  — the original CONFLICT type string
+    memory_type  — the original memory type string
     repo         — the repository name this memory was ingested from
 """
 
@@ -43,7 +43,7 @@ from navegador.graph.store import GraphStore
 
 logger = logging.getLogger(__name__)
 
-# CONFLICT type → NodeLabel
+# memory type → NodeLabel
 _TYPE_MAP: dict[str, NodeLabel] = {
     "feedback": NodeLabel.Rule,
     "project": NodeLabel.Decision,
@@ -106,7 +106,7 @@ def _first_line(text: str) -> str:
 
 class MemoryIngester:
     """
-    Ingests CONFLICT-format memory/ directories into the navegador graph.
+    Ingests structured memory/ directories into the navegador graph.
 
     Usage:
         ingester = MemoryIngester(store)

--- a/navegador/ingestion/planopticon.py
+++ b/navegador/ingestion/planopticon.py
@@ -93,6 +93,102 @@ PLANNING_TYPE_MAP: dict[str, NodeLabel] = {
 }
 
 
+def _manifest_input_type(manifest_path: Path) -> str:
+    """
+    Distinguish a single-run ``manifest.json`` from a batch ``manifest.json``.
+
+    PlanOpticon now uses ``manifest.json`` for both single-video and batch
+    outputs, so filename-based detection is not enough.
+    """
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        return "manifest"
+
+    if not isinstance(data, dict):
+        return "manifest"
+
+    if (
+        isinstance(data.get("videos"), list)
+        or "merged_knowledge_graph_json" in data
+        or "merged_knowledge_graph_db" in data
+        or "total_videos" in data
+        or "completed_videos" in data
+        or "failed_videos" in data
+    ):
+        return "batch"
+
+    return "manifest"
+
+
+def resolve_planopticon_input(path: str | Path, input_type: str = "auto") -> tuple[str, Path]:
+    """
+    Resolve a PlanOpticon input path to a concrete file path and normalized type.
+
+    Supports both the current batch ``manifest.json`` shape and the older
+    ``batch_manifest.json`` filename.
+    """
+    p = Path(path)
+
+    if p.is_dir():
+        if input_type == "auto":
+            manifest = p / "manifest.json"
+            if manifest.exists():
+                return _manifest_input_type(manifest), manifest
+
+            candidates = [
+                ("batch", p / "batch_manifest.json"),
+                ("interchange", p / "exchange.json"),
+                ("interchange", p / "interchange.json"),
+                ("kg", p / "results" / "knowledge_graph.json"),
+                ("kg", p / "knowledge_graph.json"),
+            ]
+            for detected_type, candidate in candidates:
+                if candidate.exists():
+                    return detected_type, candidate
+            raise FileNotFoundError(
+                f"No recognised planopticon file found in {p}. "
+                "Expected manifest.json, exchange.json, interchange.json, "
+                "knowledge_graph.json, or legacy batch_manifest.json."
+            )
+
+        if input_type == "manifest":
+            candidate = p / "manifest.json"
+            if candidate.exists():
+                return input_type, candidate
+        elif input_type == "batch":
+            current = p / "manifest.json"
+            if current.exists():
+                return input_type, current
+            legacy = p / "batch_manifest.json"
+            if legacy.exists():
+                return input_type, legacy
+        elif input_type == "interchange":
+            for candidate in (p / "exchange.json", p / "interchange.json"):
+                if candidate.exists():
+                    return input_type, candidate
+        elif input_type == "kg":
+            for candidate in (p / "results" / "knowledge_graph.json", p / "knowledge_graph.json"):
+                if candidate.exists():
+                    return input_type, candidate
+
+        raise FileNotFoundError(
+            f"Could not resolve planopticon {input_type} input from directory {p}"
+        )
+
+    if input_type != "auto":
+        return input_type, p
+
+    name = p.name.lower()
+    if name == "manifest.json":
+        return _manifest_input_type(p), p
+    if "interchange" in name or "exchange" in name:
+        return "interchange", p
+    if "batch" in name:
+        return "batch", p
+    return "kg", p
+
+
 class PlanopticonIngester:
     """
     Reads planopticon output and writes it into a GraphStore.

--- a/navegador/mcp/server.py
+++ b/navegador/mcp/server.py
@@ -214,7 +214,7 @@ def create_mcp_server(store_factory, read_only: bool = False):
             Tool(
                 name="memory_list",
                 description=(
-                    "List behavioral knowledge nodes ingested from CONFLICT-format memory/ "
+                    "List behavioral knowledge nodes ingested from structured memory/ "
                     "directories. Returns rules, project context, references, and user profiles."
                 ),
                 inputSchema={

--- a/navegador/planopticon_pipeline.py
+++ b/navegador/planopticon_pipeline.py
@@ -79,7 +79,7 @@ class PlanopticonPipeline:
         Parameters
         ----------
         input_path:
-            Path to a manifest.json, interchange.json, batch manifest,
+            Path to a manifest.json, exchange/interchange JSON, batch manifest,
             knowledge_graph.json, or a planopticon output directory.
         source_tag:
             Optional label for provenance tracking (overrides self.source_tag).
@@ -130,7 +130,7 @@ class PlanopticonPipeline:
         Parameters
         ----------
         kg_data:
-            A dict as loaded from manifest.json, interchange.json,
+            A dict as loaded from manifest.json, exchange/interchange JSON,
             knowledge_graph.json, or any combination that may contain an
             ``action_items`` list or ``entities``/``nodes`` with task types.
         """
@@ -293,29 +293,6 @@ class PlanopticonPipeline:
         (input_type, resolved_path) where input_type is one of:
         "manifest", "interchange", "batch", "kg"
         """
-        if p.is_dir():
-            candidates = [
-                ("manifest", p / "manifest.json"),
-                ("interchange", p / "interchange.json"),
-                ("batch", p / "batch_manifest.json"),
-                ("kg", p / "results" / "knowledge_graph.json"),
-                ("kg", p / "knowledge_graph.json"),
-            ]
-            for itype, candidate in candidates:
-                if candidate.exists():
-                    return itype, candidate
-            raise FileNotFoundError(
-                f"No recognised planopticon file found in {p}. "
-                "Expected manifest.json, interchange.json, "
-                "batch_manifest.json, or knowledge_graph.json."
-            )
+        from navegador.ingestion.planopticon import resolve_planopticon_input
 
-        name = p.name.lower()
-        if "manifest" in name and "batch" not in name:
-            return "manifest", p
-        if "interchange" in name:
-            return "interchange", p
-        if "batch" in name:
-            return "batch", p
-        # Default: treat as knowledge_graph.json
-        return "kg", p
+        return resolve_planopticon_input(p, input_type="auto")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "navegador"
-version = "1.0.1"
+version = "1.1.0"
 description = "AST + knowledge graph context engine for AI coding agents"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -497,13 +497,27 @@ class TestPlanopticonIngestCommand:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("output").mkdir()
-            Path("output/manifest.json").write_text("{}")
+            Path("output/manifest.json").write_text('{"video":{"title":"Sprint Review"}}')
             with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
                  patch("navegador.ingestion.PlanopticonIngester") as MockPI:
                 MockPI.return_value.ingest_manifest.return_value = {"nodes": 0, "edges": 0}
                 result = runner.invoke(main, ["planopticon", "ingest", "output"])
                 assert result.exit_code == 0
                 MockPI.return_value.ingest_manifest.assert_called_once()
+
+    def test_directory_resolves_batch_manifest(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("output").mkdir()
+            Path("output/manifest.json").write_text(
+                '{"videos":[],"total_videos":0,"completed_videos":0}'
+            )
+            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
+                 patch("navegador.ingestion.PlanopticonIngester") as MockPI:
+                MockPI.return_value.ingest_batch.return_value = {"nodes": 0, "edges": 0}
+                result = runner.invoke(main, ["planopticon", "ingest", "output"])
+                assert result.exit_code == 0
+                MockPI.return_value.ingest_batch.assert_called_once()
 
 
 # ── --help smoke tests ─────────────────────────────────────────────────────────
@@ -625,6 +639,17 @@ class TestPlanopticonAutoDetect:
                  patch("navegador.ingestion.PlanopticonIngester") as MockPI:
                 MockPI.return_value.ingest_interchange.return_value = {"nodes": 0, "edges": 0}
                 result = runner.invoke(main, ["planopticon", "ingest", "interchange.json"])
+                assert result.exit_code == 0
+                MockPI.return_value.ingest_interchange.assert_called_once()
+
+    def test_auto_detect_exchange(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("exchange.json").write_text("{}")
+            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
+                 patch("navegador.ingestion.PlanopticonIngester") as MockPI:
+                MockPI.return_value.ingest_interchange.return_value = {"nodes": 0, "edges": 0}
+                result = runner.invoke(main, ["planopticon", "ingest", "exchange.json"])
                 assert result.exit_code == 0
                 MockPI.return_value.ingest_interchange.assert_called_once()
 

--- a/tests/test_v04_batch3.py
+++ b/tests/test_v04_batch3.py
@@ -53,7 +53,23 @@ class TestPlanopticonPipelineDetectInput:
         itype, _ = PlanopticonPipeline._detect_input(f)
         assert itype == "interchange"
 
+    def test_exchange_file(self, tmp_path):
+        from navegador.planopticon_pipeline import PlanopticonPipeline
+
+        f = tmp_path / "exchange.json"
+        f.write_text("{}")
+        itype, _ = PlanopticonPipeline._detect_input(f)
+        assert itype == "interchange"
+
     def test_batch_file(self, tmp_path):
+        from navegador.planopticon_pipeline import PlanopticonPipeline
+
+        f = tmp_path / "manifest.json"
+        f.write_text('{"videos":[],"total_videos":0}')
+        itype, _ = PlanopticonPipeline._detect_input(f)
+        assert itype == "batch"
+
+    def test_legacy_batch_file(self, tmp_path):
         from navegador.planopticon_pipeline import PlanopticonPipeline
 
         f = tmp_path / "batch_manifest.json"
@@ -72,9 +88,17 @@ class TestPlanopticonPipelineDetectInput:
     def test_directory_with_manifest(self, tmp_path):
         from navegador.planopticon_pipeline import PlanopticonPipeline
 
-        (tmp_path / "manifest.json").write_text("{}")
+        (tmp_path / "manifest.json").write_text('{"video":{"title":"Sprint Review"}}')
         itype, resolved = PlanopticonPipeline._detect_input(tmp_path)
         assert itype == "manifest"
+
+    def test_directory_with_batch_manifest(self, tmp_path):
+        from navegador.planopticon_pipeline import PlanopticonPipeline
+
+        (tmp_path / "manifest.json").write_text('{"videos":[],"completed_videos":0}')
+        itype, resolved = PlanopticonPipeline._detect_input(tmp_path)
+        assert itype == "batch"
+        assert resolved == tmp_path / "manifest.json"
 
     def test_directory_without_known_files_raises(self, tmp_path):
         from navegador.planopticon_pipeline import PlanopticonPipeline


### PR DESCRIPTION
## Summary
- detect current PlanOpticon manifests by shape instead of filename alone
- support current batch root manifest and exchange file naming
- neutralize conflict-specific memory wording
- sync docs/tests and bump to 1.1.0

## Testing
- python3 -m pytest tests/test_cli.py -k 'planopticon' tests/test_v04_batch3.py -k 'PlanopticonPipelineDetectInput'
- python3 -m build

Closes #105