### PR TITLE
Add CONFLICT primer scaffold: bootstrap.md and agent shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ ENV/
 .aider/
 .continue/
 .copilot/
-AGENTS.md
 GEMINI.md
 
 # API keys and secrets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agents — Navegador
+
+Primary conventions doc: [`bootstrap.md`](bootstrap.md)
+
+Read it before writing any code.

--- a/CALLIOPE.md
+++ b/CALLIOPE.md
@@ -1,0 +1,18 @@
+# Calliope — Navegador
+<!-- Agent shim for https://github.com/calliopeai/calliope-cli -->
+
+Primary conventions doc: [`bootstrap.md`](bootstrap.md)
+
+Read it before writing any code.
+
+---
+
+## Project-specific notes
+
+- Python 3.12+ standalone package (no Django) — CLI + library + MCP server
+- CLI: Click + Rich, entry point `navegador`, 50+ subcommands in `navegador/cli/`
+- Graph store: FalkorDB (Redis, production) or falkordblite (embedded SQLite, local zero-infra)
+- Parsing: tree-sitter, 13 languages — core 6 bundled, extras via `.[languages]` / `.[iac]`
+- Tests: `pytest tests/ -v` (coverage on by default); install with `pip install -e ".[dev]"`
+- Lint/format: `ruff check navegador/` + `ruff format navegador/` — line length 100, py312
+- Docs: mkdocs-material — `mkdocs serve` locally, `mkdocs gh-deploy --force` → navegador.dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Navegador — Claude Context
 
+Primary conventions doc: [`bootstrap.md`](bootstrap.md) — read it before writing any code.
+
 ## What it is
 
 AST + knowledge graph context engine for AI coding agents. Parses codebases into a FalkorDB property graph. Agents query via MCP or Python API.

--- a/bootstrap.md
+++ b/bootstrap.md
@@ -1,0 +1,118 @@
+# Navegador Bootstrap
+
+This is the primary conventions document. All agent shims (`CLAUDE.md`, `AGENTS.md`, `calliope.md`) point here. `AGENTS.md` is also used by OpenAI Codex.
+
+An agent given this document and a business requirement should be able to generate correct, idiomatic code without exploring the codebase.
+
+---
+
+## What's Already Built
+
+| Layer | What's there |
+|-------|-------------|
+| Graph store | `navegador/graph/` — GraphStore + schema + queries + migrations + export, backed by FalkorDB |
+| Ingestion | `navegador/ingestion/` — RepoIngester + 13 tree-sitter language parsers + optimization |
+| Context | `navegador/context/` — ContextLoader + ContextBundle (JSON/markdown output) |
+| MCP server | `navegador/mcp/` — 11 tools + security hardening, via the `mcp` Python SDK |
+| CLI | `navegador/cli/` — Click + Rich, 50+ subcommands, entry point `navegador` |
+| Enrichment | `navegador/enrichment/` — FrameworkEnricher base + 8 framework enrichers, auto-discovered via `pkgutil` |
+| Analysis | `navegador/analysis/` — impact, flow tracing, dead code, cycles, test mapping |
+| Intelligence | `navegador/intelligence/` — semantic search, community detection, NLP, doc generation |
+| Cluster | `navegador/cluster/` — Redis pub/sub, task queue, locking, sessions, messaging |
+| SDK | `navegador/sdk.py` — Python SDK (`Navegador` class) |
+| LLM | `navegador/llm.py` — provider abstraction (Anthropic, OpenAI, Ollama) |
+| VCS | `navegador/vcs.py` — Git + Fossil abstraction; `diff.py` (diff → graph impact), `churn.py` (behavioural coupling) |
+| Monorepo | `navegador/monorepo.py` — workspace detection + ingestion |
+| Security | `navegador/security.py` — sensitive content detection + redaction |
+| Explorer | `navegador/explorer/` — HTTP server + browser-based graph visualization |
+| Docs | `docs/` + `mkdocs.yml` — mkdocs-material, deployed to navegador.dev |
+
+Stack: **Python 3.12+**, standalone (no Django). tree-sitter for AST parsing, FalkorDB property graph, Pydantic models, Click + Rich CLI, Ruff for lint/format.
+
+---
+
+## FalkorDB Connection
+
+```python
+# SQLite (local, zero-infra) — uses falkordblite
+from redislite import FalkorDB   # falkordblite provides this
+db = FalkorDB("path/to/graph.db")
+graph = db.select_graph("navegador")
+
+# Redis (production)
+import falkordb
+client = falkordb.FalkorDB.from_url("redis://localhost:6379")
+```
+
+---
+
+## Conventions
+
+### Data Models
+
+Pydantic (v2) models throughout. Graph node/edge shapes are defined in `navegador/graph/schema.py` — extend the schema there, never ad-hoc.
+
+### CLI
+
+Click commands under `navegador/cli/`, output via Rich. New subcommands follow the existing command-group structure in `cli/commands.py`.
+
+### MCP Server
+
+Tools are declared in `list_tools()` and dispatched in `call_tool()` in `mcp/server.py`. Security hardening (path validation, redaction) applies to every tool — new tools must go through the same guards.
+
+### Extension Points
+
+**New language parser:**
+1. Create `navegador/ingestion/<lang>.py` subclassing `LanguageParser`
+2. Implement `parse_file(path, repo_root, store) -> dict[str, int]`
+3. Add the extension + language key to `LANGUAGE_MAP` in `parser.py`
+4. Register in `RepoIngester._get_parser()`
+
+**New framework enricher:**
+1. Create `navegador/enrichment/<framework>.py` subclassing `FrameworkEnricher`
+2. Implement `framework_name`, `detection_patterns`, `enrich()`
+3. Auto-discovered via `pkgutil` — no registration needed
+
+**New MCP tool:**
+1. Add a `Tool(...)` entry in `list_tools()` in `mcp/server.py`
+2. Add a handler branch in `call_tool()`
+
+### Tests
+
+- pytest, tests in `tests/`, files named `test_*.py`
+- Coverage is on by default (`addopts = "--cov=navegador"`)
+- Tests run against a **real graph store** (falkordblite embedded) — never mock the graph database
+- Parser tests: real source-file fixtures in, assert node/edge counts and graph state out
+- Cover happy path AND error/edge cases (unparseable files, empty repos, missing grammars)
+
+### Code Style
+
+- Ruff for both lint and format: line length **100**, target **py312**, rules `E, F, W, I`
+- Per-file ignores: `explorer/templates.py` and `tests/*` are exempt from E501
+- mypy configured (`warn_return_any`, py312)
+- Package manager: pip (editable installs); lockfile-free library — version bounds live in `pyproject.toml`
+- venv mandatory — never install into system Python
+
+---
+
+## Ports (local)
+
+| Service | URL |
+|---------|-----|
+| mkdocs preview | http://localhost:8000 |
+
+The explorer server and MCP server are started via the `navegador` CLI; ports are configured per-invocation.
+
+---
+
+## Common Commands
+
+```bash
+pip install -e ".[dev]"          # dev install (add .[all] for every extra)
+pytest tests/ -v                 # run tests (coverage included)
+ruff check navegador/            # lint
+ruff format navegador/           # format
+mkdocs serve                     # docs preview at :8000 (needs .[docs])
+mkdocs gh-deploy --force         # deploy docs to navegador.dev
+navegador --help                 # CLI entry point
+```


### PR DESCRIPTION
## Summary
- Add `bootstrap.md` as the primary conventions document (module map, FalkorDB connection patterns, extension-point recipes, test + style conventions, common commands)
- Add `AGENTS.md` and `CALLIOPE.md` agent shims pointing to `bootstrap.md`
- Add a pointer line to the existing `CLAUDE.md` (otherwise untouched)
- Remove `AGENTS.md` from `.gitignore` — shims are committed per the primer pattern

## Test plan
- Docs-only change; no runtime surface. Verified all shim links resolve to `bootstrap.md`.