### PR TITLE
Relax tree-sitter-swift pin so the languages extra installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ languages = [
     "tree-sitter-c-sharp>=0.23.0",
     "tree-sitter-php>=0.23.0",
     "tree-sitter-ruby>=0.23.0",
-    "tree-sitter-swift>=0.23.0",
+    "tree-sitter-swift>=0.7.3",  # Swift grammar versions independently; 0.23.x does not exist on PyPI
     "tree-sitter-c>=0.23.0",
     "tree-sitter-cpp>=0.23.0",
 ]


### PR DESCRIPTION
## Summary
- `tree-sitter-swift>=0.23.0` can never resolve — PyPI only has 0.0.1/0.7.2/0.7.3 — so `navegador[languages]` and `navegador[all]` were uninstallable
- Relax to `>=0.7.3` with a comment noting the Swift grammar versions independently

## Test plan
- `uv pip compile pyproject.toml --all-extras` resolves (failed before)
- Grammar 0.7.3 loads via `tree_sitter.Language(tree_sitter_swift.language())` and parses Swift source
- All 10 Swift parser tests pass with 0.7.3 installed
- `pip-audit` on the fully-resolved tree: no known vulnerabilities

Closes #113