### PR TITLE
Add conflict-kg/v1 canonical interchange format

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -146,7 +146,7 @@ print(bundle.to_markdown())
 | **Python SDK** | `from navegador import Navegador` |
 | **Incremental ingestion** | `navegador ingest --incremental`, `--watch` |
 | **Schema migrations** | `navegador migrate` |
-| **Export / import** | `navegador export`, `navegador import` (JSONL) |
+| **Export / import** | `navegador export`, `navegador import` (JSONL, or `--format conflict-kg` for canonical conflict-kg/v1 JSON/SQLite) |
 | **Editor integrations** | `navegador editor setup <editor>` |
 | **Analysis commands** | `navegador diff`, `navegador churn`, `navegador impact`, `navegador trace`, `navegador deadcode`, `navegador cycles`, `navegador testmap` |
 | **Multi-repo** | `navegador repo add/list/ingest-all/search` |

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -1002,13 +1002,26 @@ def planopticon_ingest(path: str, input_type: str, source: str, as_json: bool, d
 @main.command("export")
 @click.argument("output", type=click.Path())
 @DB_OPTION
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["jsonl", "conflict-kg"]),
+    default="jsonl",
+    help="Export format: jsonl (legacy) or conflict-kg (canonical conflict-kg/v1; "
+    "writes SQLite for .db/.sqlite outputs, JSON otherwise).",
+)
 @click.option("--json", "as_json", is_flag=True, help="Output stats as JSON.")
-def export_cmd(output: str, db: str, as_json: bool):
+def export_cmd(output: str, db: str, fmt: str, as_json: bool):
     """Export the graph to a text-based JSONL file (git-friendly)."""
-    from navegador.graph.export import export_graph
-
     store = _get_store(db)
-    stats = export_graph(store, output)
+    if fmt == "conflict-kg":
+        from navegador.graph.interchange import export_conflict_kg
+
+        stats = export_conflict_kg(store, output)
+    else:
+        from navegador.graph.export import export_graph
+
+        stats = export_graph(store, output)
 
     if as_json:
         click.echo(json.dumps(stats, indent=2))
@@ -1024,11 +1037,20 @@ def export_cmd(output: str, db: str, as_json: bool):
 @click.option("--no-clear", is_flag=True, help="Don't wipe graph before importing.")
 @click.option("--json", "as_json", is_flag=True, help="Output stats as JSON.")
 def import_cmd(input_path: str, db: str, no_clear: bool, as_json: bool):
-    """Import a graph from a JSONL export file."""
-    from navegador.graph.export import import_graph
+    """Import a graph from a JSONL or conflict-kg/v1 export file (auto-detected)."""
+    from navegador.graph.interchange import (
+        import_conflict_kg,
+        is_conflict_kg_json,
+        is_sqlite_file,
+    )
 
     store = _get_store(db)
-    stats = import_graph(store, input_path, clear=not no_clear)
+    if is_sqlite_file(input_path) or is_conflict_kg_json(input_path):
+        stats = import_conflict_kg(store, input_path, clear=not no_clear)
+    else:
+        from navegador.graph.export import import_graph
+
+        stats = import_graph(store, input_path, clear=not no_clear)
 
     if as_json:
         click.echo(json.dumps(stats, indent=2))

--- a/navegador/explorer/server.py
+++ b/navegador/explorer/server.py
@@ -296,9 +296,16 @@ def _make_handler(store: "GraphStore"):
 
             # ── Full graph
             elif path == "/api/graph":
-                nodes = _get_all_nodes(self._store)
-                edges = _get_all_edges(self._store)
-                self._send_json({"nodes": nodes, "edges": edges})
+                fmt = qs.get("format", [""])[0]
+                if fmt == "conflict-kg":
+                    from navegador.graph.interchange import FORMAT, collect_graph
+
+                    kg_nodes, kg_edges = collect_graph(self._store)
+                    self._send_json({"format": FORMAT, "nodes": kg_nodes, "edges": kg_edges})
+                else:
+                    nodes = _get_all_nodes(self._store)
+                    edges = _get_all_edges(self._store)
+                    self._send_json({"nodes": nodes, "edges": edges})
 
             # ── Search
             elif path == "/api/search":

--- a/navegador/graph/interchange.py
+++ b/navegador/graph/interchange.py
@@ -1,0 +1,243 @@
+"""
+conflict-kg/v1 — canonical KG interchange format shared across Conflict tools.
+
+One contract, two encodings (same field names):
+
+JSON (small/medium graphs):
+  {
+    "format": "conflict-kg/v1",
+    "nodes": [{"id": "str-unique", "name": "display", "type": "NodeType", "props": {}}],
+    "edges": [{"source": "node-id", "target": "node-id", "type": "REL", "props": {}}]
+  }
+
+SQLite (large graphs):
+  nodes(id TEXT PRIMARY KEY, name TEXT, type TEXT, props JSON)
+  edges(source TEXT, target TEXT, type TEXT, props JSON)
+  with indexes on edges(source) and edges(target)
+
+Node ids are content-derived (type + path + name) so they are stable across
+re-exports; edges reference node ids, never property dicts.
+"""
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+from navegador.graph.store import GraphStore
+
+logger = logging.getLogger(__name__)
+
+FORMAT = "conflict-kg/v1"
+
+_SQLITE_EXTENSIONS = {".db", ".sqlite", ".sqlite3"}
+
+_SQLITE_SCHEMA = [
+    "CREATE TABLE nodes (id TEXT PRIMARY KEY, name TEXT, type TEXT, props JSON)",
+    "CREATE TABLE edges (source TEXT, target TEXT, type TEXT, props JSON)",
+    "CREATE INDEX idx_edges_source ON edges(source)",
+    "CREATE INDEX idx_edges_target ON edges(target)",
+]
+
+
+def collect_graph(store: GraphStore) -> tuple[list[dict], list[dict]]:
+    """
+    Read the full graph into canonical conflict-kg/v1 node and edge dicts.
+
+    Returns:
+        (nodes, edges) — deterministically ordered, edges referencing node ids.
+    """
+    result = store.query("MATCH (n) RETURN id(n) AS iid, labels(n)[0] AS label, properties(n)")
+    raw_nodes = []
+    for row in result.result_set or []:
+        iid, label = row[0], row[1] or "default"
+        props = dict(row[2]) if isinstance(row[2], dict) else {}
+        name = str(props.pop("name", "") or "")
+        path = str(props.get("file_path") or props.get("path") or "")
+        raw_nodes.append((label, path, name, iid, props))
+
+    # Deterministic order, then content-derived ids with collision suffixes
+    raw_nodes.sort(key=lambda n: (n[0], n[1], n[2], n[3]))
+    nodes = []
+    id_map: dict[int, str] = {}
+    seen: dict[str, int] = {}
+    for label, path, name, iid, props in raw_nodes:
+        node_id = f"{label}:{path}:{name}"
+        count = seen.get(node_id, 0)
+        seen[node_id] = count + 1
+        if count:
+            node_id = f"{node_id}#{count}"
+        id_map[iid] = node_id
+        nodes.append({"id": node_id, "name": name, "type": label, "props": props})
+
+    result = store.query(
+        "MATCH (a)-[r]->(b) RETURN id(a) AS src, id(b) AS tgt, type(r) AS type, properties(r)"
+    )
+    edges = []
+    for row in result.result_set or []:
+        src, tgt = id_map.get(row[0]), id_map.get(row[1])
+        if src is None or tgt is None:
+            continue
+        props = dict(row[3]) if isinstance(row[3], dict) else {}
+        edges.append({"source": src, "target": tgt, "type": row[2] or "", "props": props})
+    edges.sort(key=lambda e: (e["type"], e["source"], e["target"]))
+
+    return nodes, edges
+
+
+def export_conflict_kg(store: GraphStore, output_path: str | Path) -> dict[str, int | str]:
+    """
+    Export the graph in conflict-kg/v1 format.
+
+    Encoding is chosen by extension: .db/.sqlite/.sqlite3 → SQLite,
+    anything else → canonical JSON.
+
+    Returns:
+        Dict with counts: nodes, edges, and the encoding used.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    nodes, edges = collect_graph(store)
+
+    if output_path.suffix.lower() in _SQLITE_EXTENSIONS:
+        encoding = "sqlite"
+        _write_sqlite(output_path, nodes, edges)
+    else:
+        encoding = "json"
+        payload = {"format": FORMAT, "nodes": nodes, "edges": edges}
+        output_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    logger.info(
+        "Exported %d nodes, %d edges to %s (%s, %s)",
+        len(nodes),
+        len(edges),
+        output_path,
+        FORMAT,
+        encoding,
+    )
+    return {"nodes": len(nodes), "edges": len(edges), "encoding": encoding}
+
+
+def import_conflict_kg(
+    store: GraphStore, input_path: str | Path, clear: bool = True
+) -> dict[str, int]:
+    """
+    Import a conflict-kg/v1 graph (JSON or SQLite encoding) into the store.
+
+    Args:
+        store: Target GraphStore.
+        input_path: Path to a conflict-kg/v1 .json or .db file.
+        clear: If True (default), wipe the graph before importing.
+
+    Returns:
+        Dict with counts: nodes, edges.
+    """
+    input_path = Path(input_path)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Interchange file not found: {input_path}")
+
+    if is_sqlite_file(input_path):
+        nodes, edges = _read_sqlite(input_path)
+    else:
+        payload = json.loads(input_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("format") != FORMAT:
+            raise ValueError(f"Not a {FORMAT} file: {input_path}")
+        nodes, edges = payload.get("nodes", []), payload.get("edges", [])
+
+    if clear:
+        store.clear()
+
+    key_map: dict[str, tuple[str, dict]] = {}
+    for node in nodes:
+        label = node["type"]
+        props = {"name": node.get("name", ""), **node.get("props", {})}
+        store.create_node(label, props)
+        key_map[node["id"]] = (label, _merge_key(label, props))
+
+    edge_count = 0
+    for edge in edges:
+        src, tgt = key_map.get(edge["source"]), key_map.get(edge["target"])
+        if src is None or tgt is None:
+            logger.warning("Skipping edge with unknown endpoint: %s", edge)
+            continue
+        store.create_edge(src[0], src[1], edge["type"], tgt[0], tgt[1], edge.get("props") or None)
+        edge_count += 1
+
+    logger.info("Imported %d nodes, %d edges from %s", len(nodes), edge_count, input_path)
+    return {"nodes": len(nodes), "edges": edge_count}
+
+
+def is_sqlite_file(path: str | Path) -> bool:
+    """True if the file starts with the SQLite magic header."""
+    with Path(path).open("rb") as f:
+        return f.read(16) == b"SQLite format 3\x00"
+
+
+def is_conflict_kg_json(path: str | Path) -> bool:
+    """True if the file is a conflict-kg/v1 JSON document."""
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    return isinstance(payload, dict) and payload.get("format") == FORMAT
+
+
+def _merge_key(label: str, props: dict) -> dict:
+    """Merge-key props for a node, mirroring GraphStore.create_node key selection."""
+    if label in GraphStore._PATH_KEYED_LABELS:
+        return {"path": props.get("path", "")}
+    if props.get("memory_type", "") and props.get("repo", ""):
+        return {"name": props.get("name", ""), "repo": props["repo"]}
+    if props.get("file_path", ""):
+        return {"name": props.get("name", ""), "file_path": props["file_path"]}
+    return {"name": props.get("name", "")}
+
+
+def _write_sqlite(path: Path, nodes: list[dict], edges: list[dict]) -> None:
+    if path.exists():
+        path.unlink()
+    conn = sqlite3.connect(path)
+    try:
+        for stmt in _SQLITE_SCHEMA:
+            conn.execute(stmt)
+        conn.executemany(
+            "INSERT INTO nodes (id, name, type, props) VALUES (?, ?, ?, ?)",
+            [
+                (n["id"], n["name"], n["type"], json.dumps(n["props"], sort_keys=True))
+                for n in nodes
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO edges (source, target, type, props) VALUES (?, ?, ?, ?)",
+            [
+                (e["source"], e["target"], e["type"], json.dumps(e["props"], sort_keys=True))
+                for e in edges
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_sqlite(path: Path) -> tuple[list[dict], list[dict]]:
+    conn = sqlite3.connect(path)
+    try:
+        nodes = [
+            {
+                "id": r[0],
+                "name": r[1] or "",
+                "type": r[2] or "default",
+                "props": json.loads(r[3] or "{}"),
+            }
+            for r in conn.execute("SELECT id, name, type, props FROM nodes")
+        ]
+        edges = [
+            {"source": r[0], "target": r[1], "type": r[2] or "", "props": json.loads(r[3] or "{}")}
+            for r in conn.execute("SELECT source, target, type, props FROM edges")
+        ]
+    finally:
+        conn.close()
+    return nodes, edges

--- a/tests/test_interchange.py
+++ b/tests/test_interchange.py
@@ -1,0 +1,372 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Tests for navegador.graph.interchange — the conflict-kg/v1 canonical format.
+
+These run against real embedded FalkorDB stores (no graph mocks): seed a
+graph, export, re-import, and assert on actual graph state.
+"""
+
+import json
+import socket
+import sqlite3
+import urllib.request
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from navegador.cli.commands import main
+from navegador.explorer import ExplorerServer
+from navegador.graph.interchange import (
+    FORMAT,
+    collect_graph,
+    export_conflict_kg,
+    import_conflict_kg,
+    is_conflict_kg_json,
+    is_sqlite_file,
+)
+from navegador.graph.store import GraphStore
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def source_store(tmp_path_factory):
+    store = GraphStore.sqlite(str(tmp_path_factory.mktemp("kg-src") / "graph.db"))
+    yield store
+    store.close()
+
+
+@pytest.fixture(scope="module")
+def target_store(tmp_path_factory):
+    store = GraphStore.sqlite(str(tmp_path_factory.mktemp("kg-dst") / "graph.db"))
+    yield store
+    store.close()
+
+
+@pytest.fixture(autouse=True)
+def _clean_stores(source_store, target_store):
+    source_store.clear()
+    target_store.clear()
+    yield
+
+
+def _seed(store: GraphStore) -> None:
+    """Small graph: two functions, a concept, a call edge with props, an annotation."""
+    store.create_node("Function", {"name": "foo", "file_path": "app.py", "line": 1})
+    store.create_node("Function", {"name": "bar", "file_path": "app.py", "line": 9})
+    store.create_node("Concept", {"name": "Payments"})
+    store.create_edge(
+        "Function",
+        {"name": "foo", "file_path": "app.py"},
+        "CALLS",
+        "Function",
+        {"name": "bar", "file_path": "app.py"},
+        {"count": 2},
+    )
+    store.create_edge(
+        "Concept",
+        {"name": "Payments"},
+        "ANNOTATES",
+        "Function",
+        {"name": "foo", "file_path": "app.py"},
+    )
+
+
+# ── collect_graph ──────────────────────────────────────────────────────────
+
+
+class TestCollectGraph:
+    def test_canonical_node_shape(self, source_store):
+        _seed(source_store)
+        nodes, _ = collect_graph(source_store)
+        assert len(nodes) == 3
+        for node in nodes:
+            assert set(node) == {"id", "name", "type", "props"}
+
+    def test_type_is_label_and_name_is_top_level(self, source_store):
+        _seed(source_store)
+        nodes, _ = collect_graph(source_store)
+        foo = next(n for n in nodes if n["name"] == "foo")
+        assert foo["type"] == "Function"
+        assert "name" not in foo["props"]
+        assert foo["props"]["line"] == 1
+
+    def test_edges_reference_node_ids(self, source_store):
+        _seed(source_store)
+        nodes, edges = collect_graph(source_store)
+        ids = {n["id"] for n in nodes}
+        assert len(edges) == 2
+        for edge in edges:
+            assert edge["source"] in ids
+            assert edge["target"] in ids
+
+    def test_edge_props_preserved(self, source_store):
+        _seed(source_store)
+        _, edges = collect_graph(source_store)
+        calls = next(e for e in edges if e["type"] == "CALLS")
+        assert calls["props"] == {"count": 2}
+
+    def test_ids_stable_across_exports(self, source_store):
+        _seed(source_store)
+        first, _ = collect_graph(source_store)
+        second, _ = collect_graph(source_store)
+        assert [n["id"] for n in first] == [n["id"] for n in second]
+
+    def test_id_collision_gets_suffix(self, source_store):
+        # Memory nodes are keyed (name, repo): same name in two repos is two
+        # nodes whose content-derived base id collides.
+        source_store.create_node(
+            "Memory", {"name": "note", "memory_type": "fact", "repo": "repo-a"}
+        )
+        source_store.create_node(
+            "Memory", {"name": "note", "memory_type": "fact", "repo": "repo-b"}
+        )
+        nodes, _ = collect_graph(source_store)
+        ids = sorted(n["id"] for n in nodes)
+        assert ids == ["Memory::note", "Memory::note#1"]
+
+
+# ── JSON encoding ──────────────────────────────────────────────────────────
+
+
+class TestJsonExport:
+    def test_writes_format_field(self, source_store, tmp_path):
+        _seed(source_store)
+        out = tmp_path / "kg.json"
+        stats = export_conflict_kg(source_store, out)
+        assert stats == {"nodes": 3, "edges": 2, "encoding": "json"}
+        doc = json.loads(out.read_text())
+        assert doc["format"] == FORMAT
+
+    def test_deterministic_output(self, source_store, tmp_path):
+        _seed(source_store)
+        a, b = tmp_path / "a.json", tmp_path / "b.json"
+        export_conflict_kg(source_store, a)
+        export_conflict_kg(source_store, b)
+        assert a.read_bytes() == b.read_bytes()
+
+    def test_round_trip_restores_graph(self, source_store, target_store, tmp_path):
+        _seed(source_store)
+        out = tmp_path / "kg.json"
+        export_conflict_kg(source_store, out)
+
+        stats = import_conflict_kg(target_store, out)
+        assert stats == {"nodes": 3, "edges": 2}
+        assert target_store.node_count() == 3
+        assert target_store.edge_count() == 2
+
+        result = target_store.query(
+            "MATCH (:Concept {name: 'Payments'})-[r:ANNOTATES]->(f:Function) RETURN f.name"
+        )
+        assert result.result_set == [["foo"]]
+        result = target_store.query("MATCH ()-[r:CALLS]->() RETURN r.count")
+        assert result.result_set == [[2]]
+
+
+# ── SQLite encoding ────────────────────────────────────────────────────────
+
+
+class TestSqliteExport:
+    def test_db_extension_selects_sqlite(self, source_store, tmp_path):
+        _seed(source_store)
+        out = tmp_path / "kg.db"
+        stats = export_conflict_kg(source_store, out)
+        assert stats["encoding"] == "sqlite"
+        assert is_sqlite_file(out)
+
+    def test_schema_matches_contract(self, source_store, tmp_path):
+        _seed(source_store)
+        out = tmp_path / "kg.db"
+        export_conflict_kg(source_store, out)
+        conn = sqlite3.connect(out)
+        try:
+            tables = {
+                r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            }
+            indexes = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx%'"
+                )
+            }
+            node_cols = [r[1] for r in conn.execute("PRAGMA table_info(nodes)")]
+            edge_cols = [r[1] for r in conn.execute("PRAGMA table_info(edges)")]
+        finally:
+            conn.close()
+        assert {"nodes", "edges"} <= tables
+        assert indexes == {"idx_edges_source", "idx_edges_target"}
+        assert node_cols == ["id", "name", "type", "props"]
+        assert edge_cols == ["source", "target", "type", "props"]
+
+    def test_round_trip_restores_graph(self, source_store, target_store, tmp_path):
+        _seed(source_store)
+        out = tmp_path / "kg.db"
+        export_conflict_kg(source_store, out)
+
+        stats = import_conflict_kg(target_store, out)
+        assert stats == {"nodes": 3, "edges": 2}
+        assert target_store.node_count() == 3
+        assert target_store.edge_count() == 2
+
+    def test_overwrites_existing_file(self, source_store, tmp_path):
+        _seed(source_store)
+        out = tmp_path / "kg.db"
+        export_conflict_kg(source_store, out)
+        export_conflict_kg(source_store, out)  # must not fail on existing schema
+        conn = sqlite3.connect(out)
+        try:
+            count = conn.execute("SELECT count(*) FROM nodes").fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 3
+
+
+# ── Import edge cases ──────────────────────────────────────────────────────
+
+
+class TestImportEdgeCases:
+    def test_clear_wipes_target(self, source_store, target_store, tmp_path):
+        _seed(source_store)
+        target_store.create_node("Function", {"name": "stale", "file_path": "old.py"})
+        out = tmp_path / "kg.json"
+        export_conflict_kg(source_store, out)
+        import_conflict_kg(target_store, out, clear=True)
+        result = target_store.query("MATCH (n {name: 'stale'}) RETURN count(n)")
+        assert result.result_set == [[0]]
+
+    def test_no_clear_keeps_existing(self, source_store, target_store, tmp_path):
+        _seed(source_store)
+        target_store.create_node("Function", {"name": "keep", "file_path": "old.py"})
+        out = tmp_path / "kg.json"
+        export_conflict_kg(source_store, out)
+        import_conflict_kg(target_store, out, clear=False)
+        assert target_store.node_count() == 4
+
+    def test_rejects_non_interchange_json(self, target_store, tmp_path):
+        bad = tmp_path / "other.json"
+        bad.write_text(json.dumps({"nodes": [], "edges": []}))
+        with pytest.raises(ValueError, match="conflict-kg/v1"):
+            import_conflict_kg(target_store, bad)
+
+    def test_missing_file_raises(self, target_store, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            import_conflict_kg(target_store, tmp_path / "nope.json")
+
+    def test_edge_with_unknown_endpoint_skipped(self, target_store, tmp_path):
+        doc = {
+            "format": FORMAT,
+            "nodes": [
+                {
+                    "id": "Function:a.py:f",
+                    "name": "f",
+                    "type": "Function",
+                    "props": {"file_path": "a.py"},
+                }
+            ],
+            "edges": [
+                {
+                    "source": "Function:a.py:f",
+                    "target": "Function:a.py:ghost",
+                    "type": "CALLS",
+                    "props": {},
+                }
+            ],
+        }
+        path = tmp_path / "dangling.json"
+        path.write_text(json.dumps(doc))
+        stats = import_conflict_kg(target_store, path)
+        assert stats == {"nodes": 1, "edges": 0}
+
+
+# ── Format detection ───────────────────────────────────────────────────────
+
+
+class TestDetection:
+    def test_is_sqlite_file(self, source_store, tmp_path):
+        _seed(source_store)
+        db = tmp_path / "kg.db"
+        export_conflict_kg(source_store, db)
+        assert is_sqlite_file(db)
+        text = tmp_path / "kg.json"
+        export_conflict_kg(source_store, text)
+        assert not is_sqlite_file(text)
+
+    def test_is_conflict_kg_json(self, source_store, tmp_path):
+        _seed(source_store)
+        kg = tmp_path / "kg.json"
+        export_conflict_kg(source_store, kg)
+        assert is_conflict_kg_json(kg)
+
+    def test_jsonl_is_not_conflict_kg(self, tmp_path):
+        jsonl = tmp_path / "graph.jsonl"
+        jsonl.write_text('{"kind": "node", "label": "Function", "props": {"name": "f"}}\n')
+        assert not is_conflict_kg_json(jsonl)
+
+
+# ── Explorer /api/graph?format=conflict-kg ─────────────────────────────────
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _fetch_json(url: str):
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        return resp.status, json.loads(resp.read().decode())
+
+
+class TestExplorerFormat:
+    def test_conflict_kg_format(self, source_store):
+        _seed(source_store)
+        port = _free_port()
+        with ExplorerServer(source_store, port=port):
+            status, data = _fetch_json(f"http://127.0.0.1:{port}/api/graph?format=conflict-kg")
+        assert status == 200
+        assert data["format"] == FORMAT
+        assert {n["type"] for n in data["nodes"]} == {"Function", "Concept"}
+        ids = {n["id"] for n in data["nodes"]}
+        assert all(e["source"] in ids and e["target"] in ids for e in data["edges"])
+
+    def test_default_shape_unchanged(self, source_store):
+        _seed(source_store)
+        port = _free_port()
+        with ExplorerServer(source_store, port=port):
+            status, data = _fetch_json(f"http://127.0.0.1:{port}/api/graph")
+        assert status == 200
+        assert "format" not in data
+        assert all("label" in n for n in data["nodes"])
+
+
+# ── CLI --format flag and import auto-detect ──────────────────────────────
+
+
+class TestCli:
+    def test_export_conflict_kg_and_reimport(self, source_store, target_store, tmp_path):
+        _seed(source_store)
+        runner = CliRunner()
+        out = tmp_path / "kg.json"
+
+        with patch("navegador.cli.commands._get_store", return_value=source_store):
+            result = runner.invoke(main, ["export", str(out), "--format", "conflict-kg", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["encoding"] == "json"
+        assert is_conflict_kg_json(out)
+
+        with patch("navegador.cli.commands._get_store", return_value=target_store):
+            result = runner.invoke(main, ["import", str(out), "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"nodes": 3, "edges": 2}
+        assert target_store.node_count() == 3
+
+    def test_export_default_stays_jsonl(self, source_store, tmp_path):
+        _seed(source_store)
+        runner = CliRunner()
+        out = tmp_path / "graph.jsonl"
+        with patch("navegador.cli.commands._get_store", return_value=source_store):
+            result = runner.invoke(main, ["export", str(out)])
+        assert result.exit_code == 0, result.output
+        first = json.loads(out.read_text().splitlines()[0])
+        assert first["kind"] == "node"


### PR DESCRIPTION
## Summary
Implements the navegador side of the cross-tool KG harmonization:
- **`navegador/graph/interchange.py`** — canonical `conflict-kg/v1` export/import. JSON and SQLite encodings share field names (`id`/`name`/`type`/`props`, `source`/`target`/`type`/`props`); SQLite schema and edge indexes exactly as specified in the issue. Node ids are content-derived (`type:path:name`, `#n` suffix on collision) so they're stable across re-exports; edges reference node ids — O(1) loads, no prop-dict joins.
- **CLI** — `navegador export OUT --format conflict-kg` (SQLite for `.db`/`.sqlite` outputs, JSON otherwise; default stays `jsonl`). `navegador import` auto-detects SQLite header / `format` field / legacy JSONL.
- **Explorer** — `GET /api/graph?format=conflict-kg` serves the canonical shape (`type`, not `label`); default response unchanged so the built-in viewer keeps working.

## Test plan
- 25 new tests in `tests/test_interchange.py` running against **real embedded FalkorDB stores** (no graph mocks): JSON + SQLite round-trips asserting actual graph state, schema/index contract, edge-id referential integrity, id stability, collision suffixing, clear/no-clear, dangling-edge skip, format detection, explorer param, CLI flag + auto-detect.
- Full suite: 2761 passed, 53 skipped. Lint + format clean on new files.

Closes #107