### PR TITLE
Add federated super-graph aggregator

### DIFF
--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -660,11 +660,11 @@ def wiki_ingest(repo: str, wiki_dir: str, token: str, api: bool, db: str):
 @wiki.command("sync-local")
 @click.option("--repo", required=True, help="GitHub repo (owner/repo).")
 @click.option("--token", default="", envvar="GITHUB_TOKEN", help="GitHub token.")
+@click.option("--dir", "local_dir", required=True, help="Local directory of markdown files.")
 @click.option(
-    "--dir", "local_dir", required=True, help="Local directory of markdown files."
-)
-@click.option(
-    "--cursor", "cursor_path", default="",
+    "--cursor",
+    "cursor_path",
+    default="",
     help="Sync cursor file (default: .navegador/wiki-local-sync.json).",
 )
 def wiki_sync_local(repo: str, token: str, local_dir: str, cursor_path: str):
@@ -679,6 +679,7 @@ def wiki_sync_local(repo: str, token: str, local_dir: str, cursor_path: str):
 
     if not cursor_path:
         from pathlib import Path
+
         cursor_path = str(Path(".navegador") / "wiki-local-sync.json")
 
     engine = WikiSync(GitHubWikiProvider(repo, token=token), LocalMarkdownProvider(local_dir))
@@ -687,14 +688,13 @@ def wiki_sync_local(repo: str, token: str, local_dir: str, cursor_path: str):
     except subprocess.CalledProcessError as exc:
         raise click.ClickException(f"git operation failed: {exc.stderr or exc}") from exc
 
-    a = stats["pushed_to_b"]   # pushed to local dir
-    b = stats["pushed_to_a"]   # pushed to github
+    a = stats["pushed_to_b"]  # pushed to local dir
+    b = stats["pushed_to_a"]  # pushed to github
     skipped = stats["skipped"]
     conflicts = stats["conflicts"]
 
     console.print(
-        f"[green]GitHub wiki ↔ local sync:[/green] "
-        f"{a} → local, {b} → GitHub, {skipped} skipped"
+        f"[green]GitHub wiki ↔ local sync:[/green] " f"{a} → local, {b} → GitHub, {skipped} skipped"
     )
     if conflicts:
         console.print(
@@ -799,7 +799,9 @@ def fossil_pull_wiki(repo: str, token: str, repo_path: str):
 @click.option("--token", default="", envvar="GITHUB_TOKEN", help="GitHub token.")
 @click.option("--path", "repo_path", default=".", help="Path to Fossil checkout.")
 @click.option(
-    "--cursor", "cursor_path", default="",
+    "--cursor",
+    "cursor_path",
+    default="",
     help="Sync cursor file (default: .navegador/fossil-wiki-sync.json).",
 )
 def fossil_sync_wiki(repo: str, token: str, repo_path: str, cursor_path: str):
@@ -829,9 +831,7 @@ def fossil_sync_wiki(repo: str, token: str, repo_path: str, cursor_path: str):
     skipped = stats["skipped"]
     conflicts = stats["conflicts"]
 
-    console.print(
-        f"[green]Wiki sync:[/green] {gh} → GitHub, {fossil} → Fossil, {skipped} skipped"
-    )
+    console.print(f"[green]Wiki sync:[/green] {gh} → GitHub, {fossil} → Fossil, {skipped} skipped")
     if conflicts:
         console.print(
             f"[yellow]Conflicts ({len(conflicts)}) — both sides changed, skipped:[/yellow]"
@@ -846,11 +846,11 @@ def fossil_sync_wiki(repo: str, token: str, repo_path: str, cursor_path: str):
 
 @fossil.command("sync-local")
 @click.option("--path", "repo_path", default=".", help="Path to Fossil checkout.")
+@click.option("--dir", "local_dir", required=True, help="Local directory of markdown files.")
 @click.option(
-    "--dir", "local_dir", required=True, help="Local directory of markdown files."
-)
-@click.option(
-    "--cursor", "cursor_path", default="",
+    "--cursor",
+    "cursor_path",
+    default="",
     help="Sync cursor file (default: .navegador/fossil-local-sync.json).",
 )
 def fossil_sync_local(repo_path: str, local_dir: str, cursor_path: str):
@@ -864,21 +864,18 @@ def fossil_sync_local(repo_path: str, local_dir: str, cursor_path: str):
 
     adapter = FossilAdapter(repo_path)
     if not cursor_path:
-        cursor_path = str(
-            (adapter.repo_path / ".navegador" / "fossil-local-sync.json").resolve()
-        )
+        cursor_path = str((adapter.repo_path / ".navegador" / "fossil-local-sync.json").resolve())
 
     engine = WikiSync(FossilWikiProvider(adapter), LocalMarkdownProvider(local_dir))
     stats = engine.sync(cursor_path=cursor_path)
 
-    a = stats["pushed_to_b"]   # pushed to local dir
-    b = stats["pushed_to_a"]   # pushed to fossil
+    a = stats["pushed_to_b"]  # pushed to local dir
+    b = stats["pushed_to_a"]  # pushed to fossil
     skipped = stats["skipped"]
     conflicts = stats["conflicts"]
 
     console.print(
-        f"[green]Fossil ↔ local sync:[/green] "
-        f"{a} → local, {b} → Fossil, {skipped} skipped"
+        f"[green]Fossil ↔ local sync:[/green] " f"{a} → local, {b} → Fossil, {skipped} skipped"
     )
     if conflicts:
         console.print(
@@ -1058,6 +1055,45 @@ def import_cmd(input_path: str, db: str, no_clear: bool, as_json: bool):
         console.print(
             f"[green]Imported[/green] {stats['nodes']} nodes, {stats['edges']} edges ← {input_path}"
         )
+
+
+@main.command("aggregate")
+@click.argument("repos", nargs=-1, required=True)
+@DB_OPTION
+@click.option("--clear", is_flag=True, help="Wipe the central graph before aggregating.")
+@click.option("--json", "as_json", is_flag=True, help="Output stats as JSON.")
+def aggregate_cmd(repos: tuple[str, ...], db: str, clear: bool, as_json: bool):
+    """
+    Roll repo-local graphs up into a central super-graph.
+
+    Each REPO is a repo root (containing .navegador/graph.db) or a graph
+    file, optionally prefixed NAME= to set the repo namespace (defaults to
+    the directory basename). The --db graph is the central target.
+    """
+    from navegador.federation import SuperGraphAggregator, repo_name_from_path
+
+    sources: dict[str, str] = {}
+    for arg in repos:
+        name, _, path = arg.rpartition("=")
+        if not name:
+            path = arg
+            name = repo_name_from_path(arg)
+        sources[name] = path
+
+    aggregator = SuperGraphAggregator(_get_store(db))
+    summary = aggregator.aggregate(sources, clear=clear)
+
+    if as_json:
+        click.echo(json.dumps(summary, indent=2))
+    else:
+        for name, stats in summary.items():
+            if "error" in stats:
+                console.print(f"[red]{name}[/red]: {stats['error']}")
+            else:
+                console.print(
+                    f"[green]{name}[/green]: {stats['nodes']} nodes, "
+                    f"{stats['edges']} edges ({stats['deduped']} knowledge nodes unified)"
+                )
 
 
 # ── Schema migrations ────────────────────────────────────────────────────────

--- a/navegador/federation.py
+++ b/navegador/federation.py
@@ -1,0 +1,215 @@
+"""
+Federated super-graph aggregation — roll repo-local graphs up into one
+central meta-graph.
+
+Every repo builds its own local Navegador graph; the aggregator merges N of
+them (open stores, repo roots, or graph files) bottom-up into a single
+central FalkorDB super-graph:
+
+- **Namespacing** — non-knowledge nodes get a ``repo`` property and their
+  ``file_path``/``path`` prefixed ``<repo>/`` so merge keys never collide
+  across repos. Name-keyed nodes without a path get the prefix on ``name``
+  (original kept as ``local_name``).
+- **Anchoring** — a synthetic ``Repository`` node per repo, with CONTAINS
+  edges to that repo's File nodes.
+- **Knowledge dedup** — Concept / Person / Domain / Rule merge by name into
+  one un-namespaced node carrying an accumulated ``repos`` property, so
+  IMPLEMENTS / ANNOTATES / knowledge edges from every repo resolve to the
+  same node. Cross-repo linkage is persisted in the central graph, not
+  merged per-query.
+
+Aggregation goes through MERGE semantics end to end, so re-running after a
+repo re-ingest is idempotent.
+
+Usage::
+
+    from navegador.federation import SuperGraphAggregator
+
+    agg = SuperGraphAggregator(central_store)
+    stats = agg.aggregate({
+        "backend": "/path/to/backend",            # repo root or graph file
+        "frontend": frontend_store,               # or an open GraphStore
+    })
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from navegador.graph.interchange import collect_graph
+from navegador.graph.schema import EdgeType, NodeLabel
+from navegador.graph.store import GraphStore
+
+logger = logging.getLogger(__name__)
+
+# Knowledge labels unified across repos instead of namespaced per repo.
+KNOWLEDGE_DEDUP_LABELS = frozenset(
+    {NodeLabel.Concept, NodeLabel.Person, NodeLabel.Domain, NodeLabel.Rule}
+)
+
+_REPOS_SEPARATOR = ","
+
+
+class SuperGraphAggregator:
+    """Merge repo-local graphs bottom-up into a central super-graph."""
+
+    def __init__(self, central: GraphStore) -> None:
+        self.central = central
+
+    def aggregate(
+        self, sources: dict[str, GraphStore | str | Path], clear: bool = False
+    ) -> dict[str, Any]:
+        """
+        Aggregate every source graph into the central store.
+
+        Args:
+            sources: repo name → open GraphStore, repo root directory
+                (resolves ``<root>/.navegador/graph.db``), or graph file path.
+            clear: If True, wipe the central graph first.
+
+        Returns:
+            Dict keyed by repo name → per-repo stats (or ``{"error": ...}``).
+        """
+        if clear:
+            self.central.clear()
+
+        summary: dict[str, Any] = {}
+        for name, source in sources.items():
+            opened: GraphStore | None = None
+            try:
+                if isinstance(source, GraphStore):
+                    store = source
+                else:
+                    opened = GraphStore.sqlite(str(resolve_graph_path(source)))
+                    store = opened
+                summary[name] = self.aggregate_repo(name, store)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Aggregation failed for repo %s: %s", name, exc)
+                summary[name] = {"error": str(exc)}
+            finally:
+                if opened is not None:
+                    opened.close()
+        return summary
+
+    def aggregate_repo(self, repo: str, source: GraphStore) -> dict[str, int]:
+        """
+        Merge one repo-local graph into the central store.
+
+        Returns:
+            Stats dict: nodes, edges, deduped (knowledge nodes unified).
+        """
+        nodes, edges = collect_graph(source)
+
+        # Synthetic per-repo anchor node
+        self.central.create_node(
+            NodeLabel.Repository,
+            {"name": repo, "path": repo, "description": "federated-repo-anchor"},
+        )
+
+        # id (source conflict-kg id) → (label, merge-key props in central)
+        key_map: dict[str, tuple[str, dict]] = {}
+        deduped = 0
+
+        for node in nodes:
+            label, name, props = node["type"], node["name"], dict(node["props"])
+            if label in KNOWLEDGE_DEDUP_LABELS:
+                self._merge_knowledge_node(label, name, props, repo)
+                key_map[node["id"]] = (label, {"name": name})
+                deduped += 1
+                continue
+
+            props["name"] = name
+            props["repo"] = repo
+            if props.get("file_path"):
+                props["file_path"] = f"{repo}/{props['file_path']}"
+            if props.get("path"):
+                props["path"] = f"{repo}/{props['path']}"
+            if not props.get("file_path") and not props.get("path"):
+                props["local_name"] = name
+                props["name"] = f"{repo}/{name}"
+
+            self.central.create_node(label, props)
+            key_map[node["id"]] = (label, _central_merge_key(label, props))
+
+            if label == NodeLabel.File:
+                self.central.create_edge(
+                    NodeLabel.Repository,
+                    {"name": repo, "path": repo},
+                    EdgeType.CONTAINS,
+                    NodeLabel.File,
+                    {"path": props.get("path", "")},
+                )
+
+        edge_count = 0
+        for edge in edges:
+            src, tgt = key_map.get(edge["source"]), key_map.get(edge["target"])
+            if src is None or tgt is None:
+                logger.warning("Skipping edge with unknown endpoint: %s", edge)
+                continue
+            self.central.create_edge(
+                src[0], src[1], edge["type"], tgt[0], tgt[1], edge.get("props") or None
+            )
+            edge_count += 1
+
+        logger.info(
+            "Aggregated repo %s: %d nodes (%d knowledge-deduped), %d edges",
+            repo,
+            len(nodes),
+            deduped,
+            edge_count,
+        )
+        return {"nodes": len(nodes), "edges": edge_count, "deduped": deduped}
+
+    def _merge_knowledge_node(self, label: str, name: str, props: dict, repo: str) -> None:
+        """Upsert a shared knowledge node and add ``repo`` to its repos property."""
+        props.pop("repos", None)
+        self.central.create_node(label, {"name": name, **props})
+
+        result = self.central.query(
+            f"MATCH (n:{label} {{name: $name}}) RETURN n.repos", {"name": name}
+        )
+        current = result.result_set[0][0] if result.result_set else None
+        repos = set(filter(None, (current or "").split(_REPOS_SEPARATOR)))
+        repos.add(repo)
+        self.central.query(
+            f"MATCH (n:{label} {{name: $name}}) SET n.repos = $repos",
+            {"name": name, "repos": _REPOS_SEPARATOR.join(sorted(repos))},
+        )
+
+
+def repo_name_from_path(source: str | Path) -> str:
+    """Default repo namespace for a source path: the repo directory's name."""
+    path = Path(source)
+    if path.name == "graph.db" and path.parent.name == ".navegador":
+        return path.parent.parent.name
+    if path.is_file():
+        return path.stem
+    return path.name
+
+
+def resolve_graph_path(source: str | Path) -> Path:
+    """
+    Resolve a source argument to a graph file.
+
+    A directory resolves to ``<dir>/.navegador/graph.db``; a file is used
+    as-is. Raises FileNotFoundError if no graph file exists there.
+    """
+    path = Path(source)
+    if path.is_dir():
+        path = path / ".navegador" / "graph.db"
+    if not path.exists():
+        raise FileNotFoundError(f"No graph found at {path} — run `navegador ingest` first")
+    return path
+
+
+def _central_merge_key(label: str, props: dict) -> dict:
+    """Merge-key props in the central graph, mirroring GraphStore.create_node."""
+    if label in GraphStore._PATH_KEYED_LABELS:
+        return {"path": props.get("path", "")}
+    if props.get("memory_type", "") and props.get("repo", ""):
+        return {"name": props.get("name", ""), "repo": props["repo"]}
+    if props.get("file_path", ""):
+        return {"name": props.get("name", ""), "file_path": props["file_path"]}
+    return {"name": props.get("name", "")}

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1,0 +1,278 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Tests for navegador.federation — the federated super-graph aggregator.
+
+Real embedded stores throughout: two seeded source repos with colliding
+file paths and shared knowledge nodes roll up into a central graph.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from navegador.cli.commands import main
+from navegador.federation import (
+    SuperGraphAggregator,
+    repo_name_from_path,
+    resolve_graph_path,
+)
+from navegador.graph.store import GraphStore
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def source_a(tmp_path_factory):
+    store = GraphStore.sqlite(str(tmp_path_factory.mktemp("fed-a") / "graph.db"))
+    yield store
+    store.close()
+
+
+@pytest.fixture(scope="module")
+def source_b(tmp_path_factory):
+    store = GraphStore.sqlite(str(tmp_path_factory.mktemp("fed-b") / "graph.db"))
+    yield store
+    store.close()
+
+
+@pytest.fixture(scope="module")
+def central(tmp_path_factory):
+    store = GraphStore.sqlite(str(tmp_path_factory.mktemp("fed-central") / "graph.db"))
+    yield store
+    store.close()
+
+
+@pytest.fixture(autouse=True)
+def _clean(source_a, source_b, central):
+    source_a.clear()
+    source_b.clear()
+    central.clear()
+    yield
+
+
+def _seed_repo(store: GraphStore, impl_fn: str) -> None:
+    """A repo graph: one file, one function, shared Concept + Person, a Decision."""
+    store.create_node("File", {"name": "app.py", "path": "app.py", "language": "python"})
+    store.create_node("Function", {"name": impl_fn, "file_path": "app.py", "line_start": 1})
+    store.create_node("Concept", {"name": "Payments", "description": "money flow"})
+    store.create_node("Person", {"name": "Ada"})
+    store.create_node("Decision", {"name": "use falkordb"})
+    store.create_edge(
+        "File", {"path": "app.py"}, "CONTAINS", "Function", {"name": impl_fn, "file_path": "app.py"}
+    )
+    store.create_edge(
+        "Function",
+        {"name": impl_fn, "file_path": "app.py"},
+        "IMPLEMENTS",
+        "Concept",
+        {"name": "Payments"},
+    )
+    store.create_edge(
+        "Function",
+        {"name": impl_fn, "file_path": "app.py"},
+        "ASSIGNED_TO",
+        "Person",
+        {"name": "Ada"},
+    )
+
+
+def _aggregate_both(central, source_a, source_b):
+    agg = SuperGraphAggregator(central)
+    return agg.aggregate({"repo-a": source_a, "repo-b": source_b})
+
+
+# ── Namespacing ────────────────────────────────────────────────────────────
+
+
+class TestNamespacing:
+    def test_colliding_paths_stay_distinct(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        _aggregate_both(central, source_a, source_b)
+
+        result = central.query("MATCH (f:File) RETURN f.path ORDER BY f.path")
+        paths = [row[0] for row in result.result_set]
+        assert paths == ["repo-a/app.py", "repo-b/app.py"]
+
+    def test_code_nodes_carry_repo_property(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        _aggregate_both(central, source_a, source_b)
+
+        result = central.query(
+            "MATCH (f:Function) RETURN f.name, f.repo, f.file_path ORDER BY f.name"
+        )
+        assert result.result_set == [
+            ["charge", "repo-a", "repo-a/app.py"],
+            ["refund", "repo-b", "repo-b/app.py"],
+        ]
+
+    def test_pathless_name_keyed_nodes_get_prefixed(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        _aggregate_both(central, source_a, source_b)
+
+        result = central.query("MATCH (d:Decision) RETURN d.name, d.local_name ORDER BY d.name")
+        assert result.result_set == [
+            ["repo-a/use falkordb", "use falkordb"],
+            ["repo-b/use falkordb", "use falkordb"],
+        ]
+
+
+# ── Knowledge dedup ────────────────────────────────────────────────────────
+
+
+class TestKnowledgeDedup:
+    def test_shared_concept_is_one_node(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        _aggregate_both(central, source_a, source_b)
+
+        result = central.query("MATCH (c:Concept {name: 'Payments'}) RETURN count(c), c.repos")
+        assert result.result_set == [[1, "repo-a,repo-b"]]
+
+    def test_cross_repo_edges_resolve_on_shared_node(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        _aggregate_both(central, source_a, source_b)
+
+        result = central.query(
+            "MATCH (f:Function)-[:IMPLEMENTS]->(:Concept {name: 'Payments'}) "
+            "RETURN f.repo ORDER BY f.repo"
+        )
+        assert result.result_set == [["repo-a"], ["repo-b"]]
+
+    def test_person_unified(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        _aggregate_both(central, source_a, source_b)
+
+        result = central.query(
+            "MATCH (f:Function)-[:ASSIGNED_TO]->(p:Person {name: 'Ada'}) RETURN count(f)"
+        )
+        assert result.result_set == [[2]]
+        result = central.query("MATCH (p:Person) RETURN count(p)")
+        assert result.result_set == [[1]]
+
+
+# ── Anchoring ──────────────────────────────────────────────────────────────
+
+
+class TestAnchoring:
+    def test_synthetic_repo_nodes_exist(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        _aggregate_both(central, source_a, source_b)
+
+        result = central.query(
+            "MATCH (r:Repository {description: 'federated-repo-anchor'}) "
+            "RETURN r.name ORDER BY r.name"
+        )
+        assert result.result_set == [["repo-a"], ["repo-b"]]
+
+    def test_anchor_contains_repo_files(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        _aggregate_both(central, source_a, source_b)
+
+        result = central.query(
+            "MATCH (:Repository {name: 'repo-a', path: 'repo-a'})-[:CONTAINS]->(f:File) "
+            "RETURN f.path"
+        )
+        assert result.result_set == [["repo-a/app.py"]]
+
+
+# ── Aggregate semantics ────────────────────────────────────────────────────
+
+
+class TestAggregateSemantics:
+    def test_stats(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        stats = SuperGraphAggregator(central).aggregate({"repo-a": source_a})
+        assert stats["repo-a"] == {"nodes": 5, "edges": 3, "deduped": 2}
+
+    def test_idempotent_reaggregation(self, central, source_a, source_b):
+        _seed_repo(source_a, "charge")
+        _seed_repo(source_b, "refund")
+        agg = SuperGraphAggregator(central)
+        agg.aggregate({"repo-a": source_a, "repo-b": source_b})
+        before = (central.node_count(), central.edge_count())
+        agg.aggregate({"repo-a": source_a, "repo-b": source_b})
+        assert (central.node_count(), central.edge_count()) == before
+
+    def test_clear_flag(self, central, source_a, source_b):
+        central.create_node("Concept", {"name": "Stale"})
+        _seed_repo(source_a, "charge")
+        SuperGraphAggregator(central).aggregate({"repo-a": source_a}, clear=True)
+        result = central.query("MATCH (c:Concept {name: 'Stale'}) RETURN count(c)")
+        assert result.result_set == [[0]]
+
+    def test_missing_graph_reports_error(self, central, tmp_path):
+        summary = SuperGraphAggregator(central).aggregate({"ghost": tmp_path / "nope"})
+        assert "error" in summary["ghost"]
+
+    def test_aggregate_from_rdb_file(self, central, tmp_path):
+        db_path = tmp_path / ".navegador" / "graph.db"
+        source = GraphStore.sqlite(str(db_path))
+        _seed_repo(source, "charge")
+        source.close()
+
+        summary = SuperGraphAggregator(central).aggregate({"filerepo": tmp_path})
+        assert summary["filerepo"]["nodes"] == 5
+        result = central.query("MATCH (f:File) RETURN f.path")
+        assert result.result_set == [["filerepo/app.py"]]
+
+
+# ── Path helpers ───────────────────────────────────────────────────────────
+
+
+class TestPathHelpers:
+    def test_resolve_repo_root(self, tmp_path):
+        graph = tmp_path / ".navegador" / "graph.db"
+        graph.parent.mkdir()
+        graph.write_bytes(b"")
+        assert resolve_graph_path(tmp_path) == graph
+
+    def test_resolve_missing_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="navegador ingest"):
+            resolve_graph_path(tmp_path)
+
+    def test_repo_name_from_graph_file(self, tmp_path):
+        repo = tmp_path / "myrepo"
+        graph = repo / ".navegador" / "graph.db"
+        graph.parent.mkdir(parents=True)
+        graph.write_bytes(b"")
+        assert repo_name_from_path(graph) == "myrepo"
+        assert repo_name_from_path(repo) == "myrepo"
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+class TestCli:
+    def test_aggregate_command(self, central, tmp_path):
+        repo_root = tmp_path / "cli-repo"
+        source = GraphStore.sqlite(str(repo_root / ".navegador" / "graph.db"))
+        _seed_repo(source, "charge")
+        source.close()
+
+        runner = CliRunner()
+        with patch("navegador.cli.commands._get_store", return_value=central):
+            result = runner.invoke(main, ["aggregate", str(repo_root), "--json"])
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["cli-repo"] == {"nodes": 5, "edges": 3, "deduped": 2}
+
+    def test_aggregate_named_source(self, central, tmp_path):
+        repo_root = tmp_path / "whatever"
+        source = GraphStore.sqlite(str(repo_root / ".navegador" / "graph.db"))
+        _seed_repo(source, "charge")
+        source.close()
+
+        runner = CliRunner()
+        with patch("navegador.cli.commands._get_store", return_value=central):
+            result = runner.invoke(main, ["aggregate", f"backend={repo_root}", "--json"])
+        assert result.exit_code == 0, result.output
+        assert "backend" in json.loads(result.output)


### PR DESCRIPTION
## Summary
Implements the bottom-up rollup from repo-local graphs into one central meta-graph (builds on the conflict-kg/v1 collection layer from #107):
- **`navegador/federation.py`** — `SuperGraphAggregator.aggregate({name: store|path})`: accepts open stores, repo roots (resolves `.navegador/graph.db`), or graph files; path sources are opened for the merge and closed after.
- **Namespacing** — non-knowledge nodes get `repo=<name>` plus `<name>/`-prefixed `file_path`/`path`; pathless name-keyed nodes (e.g. Decision) get the prefix on `name` with the original kept as `local_name`. Merge keys cannot collide across repos.
- **Anchoring** — synthetic `Repository` node per repo with `CONTAINS` edges to that repo's File nodes.
- **Knowledge dedup** — `Concept`/`Person`/`Domain`/`Rule` unify by name into one node with an accumulated `repos` property; `IMPLEMENTS`/`ASSIGNED_TO`/knowledge edges from every repo resolve on the shared node, persisted in the central graph.
- **Idempotent** — MERGE semantics end to end; re-aggregating after re-ingest doesn't duplicate.
- **CLI** — `navegador aggregate [NAME=]PATH... --db <central> [--clear] [--json]`.

## Test plan
- 18 tests in `tests/test_federation.py` against real embedded stores: colliding file paths stay distinct, repo property + prefixes, shared concept is one node with `repos="repo-a,repo-b"`, cross-repo IMPLEMENTS edges resolve on it, Person unified, anchors + CONTAINS, per-repo stats, idempotent re-run, clear flag, error reporting for missing graphs, aggregation from a closed RDB file, path helpers, CLI positional + NAME= forms.
- Full suite: 2779 passed, 53 skipped. Lint + format clean.

Closes #108