### PR TITLE
Inline traversal depth into variable-length bounds

### DIFF
--- a/navegador/analysis/crossrepo.py
+++ b/navegador/analysis/crossrepo.py
@@ -79,8 +79,9 @@ class CrossRepoImpactResult:
 
     def to_markdown(self) -> str:
         lines = [f"# Cross-Repo Blast Radius — `{self.name}`\n"]
-        lines.append(f"**Source repo:** {self.source_repo or 'unknown'}  "
-                     f"**Depth:** {self.depth}\n")
+        lines.append(
+            f"**Source repo:** {self.source_repo or 'unknown'}  " f"**Depth:** {self.depth}\n"
+        )
 
         if self.affected_repos:
             lines.append(f"\n## Affected Repos ({len(self.affected_repos)})\n")
@@ -97,10 +98,7 @@ class CrossRepoImpactResult:
             for n in self.affected_nodes[:50]:  # cap for readability
                 repo = f" [{n.get('repo', '')}]" if n.get("repo") else ""
                 loc = f":{n['line_start']}" if n.get("line_start") else ""
-                lines.append(
-                    f"- **{n['type']}** `{n['name']}` — "
-                    f"`{n['file_path']}`{loc}{repo}"
-                )
+                lines.append(f"- **{n['type']}** `{n['name']}` — " f"`{n['file_path']}`{loc}{repo}")
             if len(self.affected_nodes) > 50:
                 lines.append(f"  _…and {len(self.affected_nodes) - 50} more_")
 
@@ -142,10 +140,12 @@ class CrossRepoImpactAnalyzer:
             repo:      Source repository name for attribution (optional).
             depth:     Traversal depth.
         """
-        params: dict[str, Any] = {"name": name, "file_path": file_path, "depth": depth}
+        from navegador.graph.queries import inline_depth
+
+        params: dict[str, Any] = {"name": name, "file_path": file_path}
 
         try:
-            result = self.store.query(_CROSS_REPO_BLAST, params)
+            result = self.store.query(inline_depth(_CROSS_REPO_BLAST, depth), params)
             rows = result.result_set or []
         except Exception:
             rows = []
@@ -161,13 +161,15 @@ class CrossRepoImpactAnalyzer:
             line = row[3]
             repo_name = row[4] or ""
 
-            affected_nodes.append({
-                "type": node_type,
-                "name": node_name,
-                "file_path": node_file,
-                "line_start": line,
-                "repo": repo_name,
-            })
+            affected_nodes.append(
+                {
+                    "type": node_type,
+                    "name": node_name,
+                    "file_path": node_file,
+                    "line_start": line,
+                    "repo": repo_name,
+                }
+            )
             if node_file:
                 affected_files.add(node_file)
             if repo_name:
@@ -234,13 +236,15 @@ class CrossRepoImpactAnalyzer:
                 node_name = row[1] or ""
                 node_file = row[2] or ""
                 line = row[3]
-                affected_nodes.append({
-                    "type": node_type,
-                    "name": node_name,
-                    "file_path": node_file,
-                    "line_start": line,
-                    "repo": repo_name,
-                })
+                affected_nodes.append(
+                    {
+                        "type": node_type,
+                        "name": node_name,
+                        "file_path": node_file,
+                        "line_start": line,
+                        "repo": repo_name,
+                    }
+                )
                 if node_file:
                     affected_files.add(node_file)
                 if rows:

--- a/navegador/analysis/impact.py
+++ b/navegador/analysis/impact.py
@@ -109,10 +109,12 @@ class ImpactAnalyzer:
         Returns:
             ImpactResult with affected_nodes, affected_files, affected_knowledge.
         """
-        params: dict[str, Any] = {"name": name, "file_path": file_path, "depth": depth}
+        from navegador.graph.queries import inline_depth
+
+        params: dict[str, Any] = {"name": name, "file_path": file_path}
 
         try:
-            result = self.store.query(_BLAST_RADIUS_SIMPLE, params)
+            result = self.store.query(inline_depth(_BLAST_RADIUS_SIMPLE, depth), params)
             rows = result.result_set or []
         except Exception:
             rows = []

--- a/navegador/context/loader.py
+++ b/navegador/context/loader.py
@@ -134,14 +134,14 @@ class ContextLoader:
         nodes: list[ContextNode] = []
         edges: list[dict[str, str]] = []
 
-        params = {"name": name, "file_path": file_path, "depth": depth}
+        params = {"name": name, "file_path": file_path}
 
-        callees = self.store.query(queries.CALLEES, params)
+        callees = self.store.query(queries.inline_depth(queries.CALLEES, depth), params)
         for row in callees.result_set or []:
             nodes.append(ContextNode(type=row[0], name=row[1], file_path=row[2], line_start=row[3]))
             edges.append({"from": name, "type": "CALLS", "to": row[1]})
 
-        callers = self.store.query(queries.CALLERS, params)
+        callers = self.store.query(queries.inline_depth(queries.CALLERS, depth), params)
         for row in callers.result_set or []:
             nodes.append(ContextNode(type=row[0], name=row[1], file_path=row[2], line_start=row[3]))
             edges.append({"from": row[1], "type": "CALLS", "to": name})

--- a/navegador/graph/queries.py
+++ b/navegador/graph/queries.py
@@ -4,7 +4,23 @@ Cypher query templates for navegador.
 Parameters passed as $name are substituted by FalkorDB at query time.
 Optional file_path filtering: when file_path is "" the WHERE clause is omitted
 so callers/callees/references work across the whole graph by name alone.
+
+Exception: variable-length bounds (``*1..$depth``) cannot be real query
+parameters — FalkorDB rejects them. Templates using $depth must go through
+``inline_depth()`` before execution.
 """
+
+
+def inline_depth(query: str, depth: int) -> str:
+    """
+    Inline a traversal depth into a ``*1..$depth`` bound.
+
+    FalkorDB cannot parameterize variable-length pattern bounds
+    ("Encountered unhandled type in inlined properties"); int() coercion
+    keeps the substitution injection-safe.
+    """
+    return query.replace("$depth", str(int(depth)))
+
 
 # ── Code: file contents ───────────────────────────────────────────────────────
 

--- a/navegador/taskpack.py
+++ b/navegador/taskpack.py
@@ -54,23 +54,20 @@ class TaskPack:
     mode: str = "implement"
 
     # Structured sections
-    code: list[TaskPackNode] = field(default_factory=list)       # direct symbols
+    code: list[TaskPackNode] = field(default_factory=list)  # direct symbols
     callers: list[TaskPackNode] = field(default_factory=list)
     callees: list[TaskPackNode] = field(default_factory=list)
-    rules: list[TaskPackNode] = field(default_factory=list)      # governing rules + memory
-    docs: list[TaskPackNode] = field(default_factory=list)       # wiki + decisions + documents
+    rules: list[TaskPackNode] = field(default_factory=list)  # governing rules + memory
+    docs: list[TaskPackNode] = field(default_factory=list)  # wiki + decisions + documents
     owners: list[TaskPackNode] = field(default_factory=list)
-    tests: list[TaskPackNode] = field(default_factory=list)      # inferred test files/symbols
+    tests: list[TaskPackNode] = field(default_factory=list)  # inferred test files/symbols
     imports: list[TaskPackNode] = field(default_factory=list)
 
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         def _nodes(lst: list[TaskPackNode]) -> list[dict[str, Any]]:
-            return [
-                {k: v for k, v in n.__dict__.items() if v not in (None, "", [])}
-                for n in lst
-            ]
+            return [{k: v for k, v in n.__dict__.items() if v not in (None, "", [])} for n in lst]
 
         return {
             "target": {
@@ -95,9 +92,8 @@ class TaskPack:
 
     def to_markdown(self) -> str:
         lines: list[str] = []
-        target_label = (
-            f"`{self.target_name}`"
-            + (f" in `{self.target_file}`" if self.target_file else "")
+        target_label = f"`{self.target_name}`" + (
+            f" in `{self.target_file}`" if self.target_file else ""
         )
         lines.append(f"# Task Pack — {target_label}\n")
         lines.append(f"**Mode:** {self.mode}  **Type:** {self.target_type}\n")
@@ -217,27 +213,42 @@ class TaskPackBuilder:
             "RETURN labels(n)[0], n.name, n.file_path, n.line_start, "
             "coalesce(n.docstring, n.signature, '') LIMIT 1"
         )
-        rows = (self.store.query(cypher, {"name": name, "file_path": file_path}).result_set or [])
+        rows = self.store.query(cypher, {"name": name, "file_path": file_path}).result_set or []
         for row in rows:
             pack.code.append(
-                TaskPackNode(type=row[0], name=row[1], file_path=row[2] or "",
-                             line_start=row[3], summary=row[4] or "")
+                TaskPackNode(
+                    type=row[0],
+                    name=row[1],
+                    file_path=row[2] or "",
+                    line_start=row[3],
+                    summary=row[4] or "",
+                )
             )
 
-    def _add_callers_callees(
-        self, pack: TaskPack, name: str, file_path: str, depth: int
-    ) -> None:
-        params = {"name": name, "file_path": file_path, "depth": depth}
+    def _add_callers_callees(self, pack: TaskPack, name: str, file_path: str, depth: int) -> None:
+        params = {"name": name, "file_path": file_path}
 
-        for row in (self.store.query(queries.CALLERS, params).result_set or []):
+        callers_q = queries.inline_depth(queries.CALLERS, depth)
+        for row in self.store.query(callers_q, params).result_set or []:
             pack.callers.append(
-                TaskPackNode(type=row[0], name=row[1], file_path=row[2] or "",
-                             line_start=row[3], relation="calls this")
+                TaskPackNode(
+                    type=row[0],
+                    name=row[1],
+                    file_path=row[2] or "",
+                    line_start=row[3],
+                    relation="calls this",
+                )
             )
-        for row in (self.store.query(queries.CALLEES, params).result_set or []):
+        callees_q = queries.inline_depth(queries.CALLEES, depth)
+        for row in self.store.query(callees_q, params).result_set or []:
             pack.callees.append(
-                TaskPackNode(type=row[0], name=row[1], file_path=row[2] or "",
-                             line_start=row[3], relation="called by this")
+                TaskPackNode(
+                    type=row[0],
+                    name=row[1],
+                    file_path=row[2] or "",
+                    line_start=row[3],
+                    relation="called by this",
+                )
             )
 
     def _add_knowledge(self, pack: TaskPack, name: str, file_path: str) -> None:
@@ -249,9 +260,7 @@ class TaskPackBuilder:
             "RETURN labels(k)[0], k.name, coalesce(k.description, k.rationale, '') "
             "LIMIT 20"
         )
-        rows = self.store.query(
-            cypher, {"name": name, "file_path": file_path}
-        ).result_set or []
+        rows = self.store.query(cypher, {"name": name, "file_path": file_path}).result_set or []
         for row in rows:
             label = row[0]
             if label in ("Rule", "Decision", "WikiPage", "Document"):
@@ -268,15 +277,14 @@ class TaskPackBuilder:
             for row in mem_rows:
                 pack.rules.append(
                     TaskPackNode(
-                        type=row[0], name=row[1], summary=row[2] or "",
-                        relation=f"memory:{row[3]}"
+                        type=row[0], name=row[1], summary=row[2] or "", relation=f"memory:{row[3]}"
                     )
                 )
 
     def _add_file_symbols(self, pack: TaskPack, file_path: str) -> None:
         """Add all symbols and imports from a file."""
         result = self.store.query(queries.FILE_CONTENTS, {"path": file_path})
-        for row in (result.result_set or []):
+        for row in result.result_set or []:
             node_type = row[0] or "Unknown"
             node = TaskPackNode(
                 type=node_type,
@@ -299,7 +307,7 @@ class TaskPackBuilder:
             "RETURN DISTINCT labels(k)[0], k.name, "
             "coalesce(k.description, k.rationale, '') LIMIT 30"
         )
-        for row in (self.store.query(cypher, {"path": file_path}).result_set or []):
+        for row in self.store.query(cypher, {"path": file_path}).result_set or []:
             label = row[0]
             node = TaskPackNode(type=label, name=row[1], summary=row[2] or "")
             if label in ("Rule",):
@@ -308,14 +316,11 @@ class TaskPackBuilder:
                 pack.docs.append(node)
 
         # Memory nodes for this file
-        file_mem = (
-            self.store.query(queries.MEMORY_FOR_FILE, {"path": file_path}).result_set or []
-        )
+        file_mem = self.store.query(queries.MEMORY_FOR_FILE, {"path": file_path}).result_set or []
         for row in file_mem:
             pack.rules.append(
                 TaskPackNode(
-                    type=row[0], name=row[1], summary=row[2] or "",
-                    relation=f"memory:{row[3]}"
+                    type=row[0], name=row[1], summary=row[2] or "", relation=f"memory:{row[3]}"
                 )
             )
 
@@ -325,9 +330,7 @@ class TaskPackBuilder:
             "WHERE n.name = $name AND ($file_path = '' OR n.file_path = $file_path) "
             "RETURN p.name, p.role, p.email LIMIT 10"
         )
-        rows = self.store.query(
-            cypher, {"name": name, "file_path": file_path}
-        ).result_set or []
+        rows = self.store.query(cypher, {"name": name, "file_path": file_path}).result_set or []
         for row in rows:
             pack.owners.append(
                 TaskPackNode(type="Person", name=row[0] or "", summary=row[1] or row[2] or "")
@@ -344,11 +347,14 @@ class TaskPackBuilder:
             "     OR t.file_path CONTAINS 'test') "
             "RETURN DISTINCT labels(t)[0], t.name, t.file_path, t.line_start LIMIT 15"
         )
-        rows = self.store.query(
-            cypher, {"name": name, "file_path": file_path}
-        ).result_set or []
+        rows = self.store.query(cypher, {"name": name, "file_path": file_path}).result_set or []
         for row in rows:
             pack.tests.append(
-                TaskPackNode(type=row[0], name=row[1], file_path=row[2] or "",
-                             line_start=row[3], relation="tests this")
+                TaskPackNode(
+                    type=row[0],
+                    name=row[1],
+                    file_path=row[2] or "",
+                    line_start=row[3],
+                    relation="tests this",
+                )
             )

--- a/tests/test_crossrepo.py
+++ b/tests/test_crossrepo.py
@@ -45,7 +45,9 @@ class TestCrossRepoImpactResultMarkdown:
 
     def test_affected_repos_section(self):
         result = CrossRepoImpactResult(
-            name="foo", source_repo="lib", depth=3,
+            name="foo",
+            source_repo="lib",
+            depth=3,
             affected_repos=["api-service", "web-frontend"],
         )
         md = result.to_markdown()
@@ -55,7 +57,9 @@ class TestCrossRepoImpactResultMarkdown:
 
     def test_affected_files_section(self):
         result = CrossRepoImpactResult(
-            name="foo", source_repo="", depth=3,
+            name="foo",
+            source_repo="",
+            depth=3,
             affected_files=["src/handler.py", "src/utils.py"],
         )
         md = result.to_markdown()
@@ -64,10 +68,17 @@ class TestCrossRepoImpactResultMarkdown:
 
     def test_affected_nodes_section(self):
         result = CrossRepoImpactResult(
-            name="foo", source_repo="", depth=3,
+            name="foo",
+            source_repo="",
+            depth=3,
             affected_nodes=[
-                {"type": "Function", "name": "bar", "file_path": "b.py",
-                 "line_start": 10, "repo": "api"},
+                {
+                    "type": "Function",
+                    "name": "bar",
+                    "file_path": "b.py",
+                    "line_start": 10,
+                    "repo": "api",
+                },
             ],
         )
         md = result.to_markdown()
@@ -79,7 +90,9 @@ class TestCrossRepoImpactResultMarkdown:
 
     def test_affected_knowledge_section(self):
         result = CrossRepoImpactResult(
-            name="foo", source_repo="", depth=3,
+            name="foo",
+            source_repo="",
+            depth=3,
             affected_knowledge=[{"type": "Rule", "name": "no_pii"}],
         )
         md = result.to_markdown()
@@ -97,11 +110,13 @@ class TestCrossRepoImpactResultMarkdown:
 
     def test_nodes_capped_at_50_with_overflow_message(self):
         nodes = [
-            {"type": "Function", "name": f"fn_{i}", "file_path": f"f{i}.py"}
-            for i in range(60)
+            {"type": "Function", "name": f"fn_{i}", "file_path": f"f{i}.py"} for i in range(60)
         ]
         result = CrossRepoImpactResult(
-            name="big", source_repo="", depth=3, affected_nodes=nodes,
+            name="big",
+            source_repo="",
+            depth=3,
+            affected_nodes=nodes,
         )
         md = result.to_markdown()
         assert "and 10 more" in md
@@ -113,10 +128,17 @@ class TestCrossRepoImpactResultMarkdown:
 class TestCrossRepoImpactResultJson:
     def test_round_trip(self):
         result = CrossRepoImpactResult(
-            name="UserSchema", source_repo="models", depth=3,
+            name="UserSchema",
+            source_repo="models",
+            depth=3,
             affected_nodes=[
-                {"type": "Class", "name": "UserView", "file_path": "views.py",
-                 "line_start": 5, "repo": "api"},
+                {
+                    "type": "Class",
+                    "name": "UserView",
+                    "file_path": "views.py",
+                    "line_start": 5,
+                    "repo": "api",
+                },
             ],
             affected_files=["views.py"],
             affected_repos=["api"],
@@ -146,9 +168,10 @@ class TestCrossRepoImpactResultJson:
 
     def test_to_dict_counts_match_lists(self):
         result = CrossRepoImpactResult(
-            name="x", source_repo="", depth=1,
-            affected_nodes=[{"type": "Function", "name": "a"},
-                            {"type": "Function", "name": "b"}],
+            name="x",
+            source_repo="",
+            depth=1,
+            affected_nodes=[{"type": "Function", "name": "a"}, {"type": "Function", "name": "b"}],
             affected_files=["a.py", "b.py", "c.py"],
             affected_repos=["repo1"],
         )
@@ -244,11 +267,13 @@ class TestBlastRadius:
         analyzer = CrossRepoImpactAnalyzer(store)
         analyzer.blast_radius("foo", file_path="specific.py", depth=5)
 
-        # Verify the first query got the params including file_path
+        # Verify the first query got the file_path param and the inlined depth
         first_call_args = store.query.call_args_list[0]
+        query_text = first_call_args[0][0]
         params = first_call_args[0][1]
         assert params["file_path"] == "specific.py"
-        assert params["depth"] == 5
+        assert "*1..5" in query_text
+        assert "$depth" not in query_text
 
     def test_none_values_in_rows_handled(self):
         store = _multi_mock_store(
@@ -267,17 +292,24 @@ class TestBlastRadiusFederated:
     @patch("navegador.analysis.crossrepo.CrossRepoImpactAnalyzer")
     def test_queries_each_store(self, _mock_cls):
         """Each store in the federation should be queried."""
-        store_a = _mock_store([
-            ["Function", "handler_a", "a.py", 10],
-        ])
-        store_b = _mock_store([
-            ["Class", "ModelB", "b.py", 1],
-        ])
+        store_a = _mock_store(
+            [
+                ["Function", "handler_a", "a.py", 10],
+            ]
+        )
+        store_b = _mock_store(
+            [
+                ["Class", "ModelB", "b.py", 1],
+            ]
+        )
 
         # Use real analyzer on a primary store
         primary = _mock_store()
-        analyzer = CrossRepoImpactAnalyzer.__wrapped__(primary) if hasattr(
-            CrossRepoImpactAnalyzer, '__wrapped__') else CrossRepoImpactAnalyzer(primary)
+        analyzer = (
+            CrossRepoImpactAnalyzer.__wrapped__(primary)
+            if hasattr(CrossRepoImpactAnalyzer, "__wrapped__")
+            else CrossRepoImpactAnalyzer(primary)
+        )
 
         # Call blast_radius_federated directly — it does not use self.store
         result = analyzer.blast_radius_federated(
@@ -292,13 +324,17 @@ class TestBlastRadiusFederated:
         assert store_b.query.called
 
     def test_merges_results_from_multiple_stores(self):
-        store_a = _mock_store([
-            ["Function", "fn_a", "a.py", 10],
-        ])
-        store_b = _mock_store([
-            ["Class", "ClassB", "b.py", 1],
-            ["Function", "fn_b2", "b2.py", 5],
-        ])
+        store_a = _mock_store(
+            [
+                ["Function", "fn_a", "a.py", 10],
+            ]
+        )
+        store_b = _mock_store(
+            [
+                ["Class", "ClassB", "b.py", 1],
+                ["Function", "fn_b2", "b2.py", 5],
+            ]
+        )
 
         primary = _mock_store()
         analyzer = CrossRepoImpactAnalyzer(primary)
@@ -320,7 +356,8 @@ class TestBlastRadiusFederated:
         primary = _mock_store()
         analyzer = CrossRepoImpactAnalyzer(primary)
         result = analyzer.blast_radius_federated(
-            "X", stores={"has-hits": store_a, "no-hits": store_b},
+            "X",
+            stores={"has-hits": store_a, "no-hits": store_b},
         )
         # Only repos with actual results should be in affected_repos
         assert "has-hits" in result.affected_repos
@@ -332,7 +369,8 @@ class TestBlastRadiusFederated:
         primary = _mock_store()
         analyzer = CrossRepoImpactAnalyzer(primary)
         result = analyzer.blast_radius_federated(
-            "X", stores={"r1": store_a, "r2": store_b},
+            "X",
+            stores={"r1": store_a, "r2": store_b},
         )
         assert result.affected_files == ["a.py", "z.py"]
 
@@ -353,7 +391,8 @@ class TestBlastRadiusFederated:
         primary = _mock_store()
         analyzer = CrossRepoImpactAnalyzer(primary)
         result = analyzer.blast_radius_federated(
-            "X", stores={"bad": bad_store, "good": good_store},
+            "X",
+            stores={"bad": bad_store, "good": good_store},
         )
         # Should still get results from the good store
         assert len(result.affected_nodes) == 1

--- a/tests/test_traversal_depth.py
+++ b/tests/test_traversal_depth.py
@@ -1,0 +1,88 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Regression tests for #118 — FalkorDB rejects parameterized variable-length
+bounds (*1..$depth), so every depth-bounded traversal must inline the depth
+via queries.inline_depth().
+
+These run against a real embedded store: before the fix, each of these
+traversals raised "Encountered unhandled type in inlined properties" and the
+callers silently returned empty results.
+"""
+
+import pytest
+
+from navegador.analysis.crossrepo import CrossRepoImpactAnalyzer
+from navegador.analysis.impact import ImpactAnalyzer
+from navegador.context.loader import ContextLoader
+from navegador.graph.queries import inline_depth
+from navegador.graph.store import GraphStore
+from navegador.taskpack import TaskPackBuilder
+
+
+@pytest.fixture(scope="module")
+def store(tmp_path_factory):
+    """Call chain a -> b -> c in one file, plus a repo containing the file."""
+    store = GraphStore.sqlite(str(tmp_path_factory.mktemp("depth") / "graph.db"))
+    store.create_node("Repository", {"name": "repo", "path": "/repo"})
+    store.create_node("File", {"name": "app.py", "path": "app.py"})
+    for fn, line in (("a", 1), ("b", 5), ("c", 9)):
+        store.create_node("Function", {"name": fn, "file_path": "app.py", "line_start": line})
+    store.create_edge("Repository", {"name": "repo"}, "CONTAINS", "File", {"path": "app.py"})
+    for src, dst in (("a", "b"), ("b", "c")):
+        store.create_edge(
+            "Function",
+            {"name": src, "file_path": "app.py"},
+            "CALLS",
+            "Function",
+            {"name": dst, "file_path": "app.py"},
+        )
+    yield store
+    store.close()
+
+
+class TestInlineDepth:
+    def test_replaces_placeholder(self):
+        assert inline_depth("MATCH (a)-[:CALLS*1..$depth]->(b)", 3) == (
+            "MATCH (a)-[:CALLS*1..3]->(b)"
+        )
+
+    def test_coerces_to_int(self):
+        assert "*1..2" in inline_depth("*1..$depth", 2.9)
+
+    def test_rejects_non_numeric(self):
+        with pytest.raises((TypeError, ValueError)):
+            inline_depth("*1..$depth", "3; MATCH (n) DELETE n")
+
+
+class TestBlastRadiusRealStore:
+    def test_returns_transitive_calls(self, store):
+        result = ImpactAnalyzer(store).blast_radius("a", depth=3)
+        names = {n["name"] for n in result.affected_nodes}
+        assert names == {"b", "c"}
+
+    def test_depth_bounds_traversal(self, store):
+        result = ImpactAnalyzer(store).blast_radius("a", depth=1)
+        names = {n["name"] for n in result.affected_nodes}
+        assert names == {"b"}
+
+
+class TestCallersCalleesRealStore:
+    def test_load_function_finds_callees_and_callers(self, store):
+        bundle = ContextLoader(store).load_function("b", "app.py", depth=2)
+        names = {(e["type"], e["from"], e["to"]) for e in bundle.edges}
+        assert ("CALLS", "b", "c") in names
+        assert ("CALLS", "a", "b") in names
+
+
+class TestCrossRepoRealStore:
+    def test_cross_repo_blast_finds_affected_and_repo(self, store):
+        result = CrossRepoImpactAnalyzer(store).blast_radius("a", depth=3)
+        names = {n["name"] for n in result.affected_nodes}
+        assert names == {"b", "c"}
+
+
+class TestTaskPackRealStore:
+    def test_task_pack_callers_callees(self, store):
+        pack = TaskPackBuilder(store).for_symbol("b", file_path="app.py", depth=2)
+        assert {n.name for n in pack.callees} == {"c"}
+        assert {n.name for n in pack.callers} == {"a"}


### PR DESCRIPTION
## Summary
FalkorDB can't parameterize variable-length pattern bounds — `*1..$depth` raises `Encountered unhandled type in inlined properties`. Every consumer wraps its query in try/except and returns `[]`, so **`blast_radius`, function callers/callees, task-pack context, and cross-repo impact have been silently returning empty results** on the default falkordblite backend. Existing tests mock the store, which is why it never surfaced; found via real-store tests while building #110.

- `queries.inline_depth(query, depth)` — substitutes `str(int(depth))` into the bound; `int()` coercion means no injection surface
- Switched the four live call sites: `ImpactAnalyzer.blast_radius`, `ContextLoader.load_function`, `TaskPackBuilder._add_callers_callees`, `CrossRepoImpactAnalyzer.blast_radius`; `depth` removed from query params
- Left the two unused templates (`NEIGHBORS`, `_BLAST_RADIUS_QUERY`) untouched; module docstring now warns `$depth` templates must go through `inline_depth()`
- One mocked assertion updated (`test_crossrepo`): depth now asserted in the query text, not params

## Test plan
- `tests/test_traversal_depth.py` — regression tests against a real embedded store: transitive blast radius, depth bounding, callers/callees, cross-repo blast, task-pack callers/callees, plus `inline_depth` unit tests (including rejection of non-numeric input). All of these returned empty/raised before the fix.
- Full suite: 2787 passed, 53 skipped. Lint + format clean.

Closes #118