### PR TITLE
Route MCP queries across the federated super-graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ AST + knowledge graph context engine for AI coding agents. Parses codebases into
 - **Python 3.12+**, standalone (no Django dependency)
 - **tree-sitter** for multi-language AST parsing (13 languages)
 - **FalkorDB** graph DB with **falkordblite** (embedded via redislite; graph file is a Redis RDB snapshot, not SQLite) for local use
-- **MCP** (`mcp` Python SDK) for AI agent integration (11 tools)
+- **MCP** (`mcp` Python SDK) for AI agent integration (24 tools)
 - **Click + Rich** for CLI
 - **Pydantic** for data models
 - **Ruff** for linting/formatting
@@ -24,7 +24,7 @@ navegador/
   graph/         — GraphStore + schema + queries + migrations + export
   ingestion/     — RepoIngester + 13 language parsers + optimization
   context/       — ContextLoader + ContextBundle (JSON/markdown)
-  mcp/           — MCP server with 11 tools + security hardening
+  mcp/           — MCP server with 24 tools + security hardening
   enrichment/    — FrameworkEnricher base + 8 framework enrichers
   analysis/      — impact, flow tracing, dead code, cycles, test mapping
   intelligence/  — semantic search, community detection, NLP, doc generation

--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ Available MCP tools:
 | `find_owners` | People assigned to any node |
 | `search_knowledge` | Search concepts, rules, decisions, wiki |
 | `blast_radius` | Impact analysis — what's affected by a change |
+| `list_repos` | Repo namespaces in a federated super-graph |
+
+For a federated workspace, aggregate repo graphs and serve the super-graph:
+
+```bash
+navegador aggregate backend=/path/a frontend=/path/b --db central.db
+navegador mcp --db central.db --read-only
+# or roll up at startup:
+navegador mcp --db central.db --federate backend=/path/a --federate frontend=/path/b
+```
+
+Query/context/search tools accept an optional `repo` argument to scope to one
+namespace; omit it to span all repos (e.g. cross-repo blast radius).
 
 ---
 

--- a/bootstrap.md
+++ b/bootstrap.md
@@ -13,7 +13,7 @@ An agent given this document and a business requirement should be able to genera
 | Graph store | `navegador/graph/` — GraphStore + schema + queries + migrations + export, backed by FalkorDB |
 | Ingestion | `navegador/ingestion/` — RepoIngester + 13 tree-sitter language parsers + optimization |
 | Context | `navegador/context/` — ContextLoader + ContextBundle (JSON/markdown output) |
-| MCP server | `navegador/mcp/` — 11 tools + security hardening, via the `mcp` Python SDK |
+| MCP server | `navegador/mcp/` — 24 tools + security hardening, via the `mcp` Python SDK |
 | CLI | `navegador/cli/` — Click + Rich, 50+ subcommands, entry point `navegador` |
 | Enrichment | `navegador/enrichment/` — FrameworkEnricher base + 8 framework enrichers, auto-discovered via `pkgutil` |
 | Analysis | `navegador/analysis/` — impact, flow tracing, dead code, cycles, test mapping |

--- a/docs/guide/mcp-integration.md
+++ b/docs/guide/mcp-integration.md
@@ -92,7 +92,7 @@ The server speaks MCP over stdio. It does not bind a port.
 
 ## Available MCP tools
 
-All tools accept and return JSON. There are 11 tools in total.
+All tools accept and return JSON. There are 24 tools in total.
 
 | Tool | Equivalent CLI | Description |
 |---|---|---|
@@ -107,6 +107,22 @@ All tools accept and return JSON. There are 11 tools in total.
 | `find_owners` | `navegador codeowners` | People and domains that own a node |
 | `search_knowledge` | `navegador search --knowledge` | Search knowledge layer only |
 | `blast_radius` | `navegador impact` | Transitive impact set for a node |
+| `list_repos` | — | Repo namespaces in a federated super-graph |
+
+### Federated workspaces
+
+Bind the server to a central super-graph built with `navegador aggregate`, or
+roll repo graphs up at startup:
+
+```bash
+navegador mcp --db central.db --federate backend=/path/a --federate frontend=/path/b
+```
+
+Query/context/search tools take an optional `repo` argument to scope to one
+namespace (`list_repos` returns the available names); omit it to span every
+repo — `query_graph` and `blast_radius` then answer workspace-wide questions
+like "who implements Concept X across all repos". Read-only hardening applies
+to the federated graph exactly as to a single-repo graph.
 
 ### Tool input schemas
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,7 @@ print(bundle.to_markdown())
     }
     ```
 
-    11 tools available. See [MCP Integration](guide/mcp-integration.md) for the full tool list and per-agent config snippets. Use `--read-only` mode to restrict agents to query-only access.
+    24 tools available. See [MCP Integration](guide/mcp-integration.md) for the full tool list and per-agent config snippets. Use `--read-only` mode to restrict agents to query-only access.
 
 === "Bootstrap"
 

--- a/navegador/analysis/impact.py
+++ b/navegador/analysis/impact.py
@@ -31,9 +31,11 @@ RETURN DISTINCT
 """
 
 # Simpler fallback without CALL subquery (FalkorDB compatibility)
+# $repo scopes the root to one federated namespace ('' = any repo)
 _BLAST_RADIUS_SIMPLE = """
 MATCH (root)-[:CALLS|REFERENCES|INHERITS|IMPLEMENTS|ANNOTATES*1..$depth]->(affected)
 WHERE root.name = $name AND ($file_path = '' OR root.file_path = $file_path)
+  AND ($repo = '' OR root.repo = $repo)
 RETURN DISTINCT
     labels(affected)[0] AS node_type,
     affected.name AS node_name,
@@ -45,6 +47,7 @@ RETURN DISTINCT
 _AFFECTED_KNOWLEDGE_QUERY = """
 MATCH (root)-[:ANNOTATES|IMPLEMENTS|GOVERNS*1..2]->(kn)
 WHERE root.name = $name AND ($file_path = '' OR root.file_path = $file_path)
+  AND ($repo = '' OR root.repo = $repo)
   AND (kn:Concept OR kn:Rule OR kn:Decision OR kn:WikiPage)
 RETURN DISTINCT labels(kn)[0] AS type, kn.name AS name
 """
@@ -94,6 +97,7 @@ class ImpactAnalyzer:
         name: str,
         file_path: str = "",
         depth: int = 3,
+        repo: str = "",
     ) -> ImpactResult:
         """
         Compute the blast radius of changing a named node.
@@ -105,11 +109,17 @@ class ImpactAnalyzer:
             name:      Symbol name (function, class, etc.)
             file_path: Narrow to a specific file (optional).
             depth:     Maximum traversal depth.
+            repo:      Scope the root to one federated repo namespace (optional).
 
         Returns:
             ImpactResult with affected_nodes, affected_files, affected_knowledge.
         """
-        params: dict[str, Any] = {"name": name, "file_path": file_path, "depth": depth}
+        params: dict[str, Any] = {
+            "name": name,
+            "file_path": file_path,
+            "depth": depth,
+            "repo": repo,
+        }
 
         try:
             result = self.store.query(_BLAST_RADIUS_SIMPLE, params)
@@ -145,7 +155,7 @@ class ImpactAnalyzer:
         affected_knowledge: list[dict[str, str]] = []
         try:
             k_result = self.store.query(
-                _AFFECTED_KNOWLEDGE_QUERY, {"name": name, "file_path": file_path}
+                _AFFECTED_KNOWLEDGE_QUERY, {"name": name, "file_path": file_path, "repo": repo}
             )
             for row in k_result.result_set or []:
                 affected_knowledge.append({"type": row[0] or "", "name": row[1] or ""})

--- a/navegador/analysis/impact.py
+++ b/navegador/analysis/impact.py
@@ -114,15 +114,12 @@ class ImpactAnalyzer:
         Returns:
             ImpactResult with affected_nodes, affected_files, affected_knowledge.
         """
-        params: dict[str, Any] = {
-            "name": name,
-            "file_path": file_path,
-            "depth": depth,
-            "repo": repo,
-        }
+        from navegador.graph.queries import inline_depth
+
+        params: dict[str, Any] = {"name": name, "file_path": file_path, "repo": repo}
 
         try:
-            result = self.store.query(_BLAST_RADIUS_SIMPLE, params)
+            result = self.store.query(inline_depth(_BLAST_RADIUS_SIMPLE, depth), params)
             rows = result.result_set or []
         except Exception:
             rows = []

--- a/navegador/analysis/release.py
+++ b/navegador/analysis/release.py
@@ -233,9 +233,7 @@ class ReleaseChecker:
         except Exception:
             pass
 
-    def _check_knowledge_links(
-        self, report: ReleaseReport, symbol: str, file_path: str
-    ) -> None:
+    def _check_knowledge_links(self, report: ReleaseReport, symbol: str, file_path: str) -> None:
         """Warn when a changed symbol has linked knowledge nodes that may be stale."""
         try:
             result = self.store.query(

--- a/navegador/api_schema.py
+++ b/navegador/api_schema.py
@@ -142,8 +142,7 @@ class APISchemaIngester:
         # ── Type definitions ──────────────────────────────────────────────────
         # Matches: type Foo { ... }  /  input Bar { ... }  /  interface X { ... }
         type_pattern = re.compile(
-            r"(?:^|\n)\s*(?:type|input|interface|enum|union)\s+(\w+)"
-            r"(?:[^{]*)?\{([^}]*)\}",
+            r"(?:^|\n)\s*(?:type|input|interface|enum|union)\s+(\w+)" r"(?:[^{]*)?\{([^}]*)\}",
             re.MULTILINE | re.DOTALL,
         )
 

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -1057,6 +1057,20 @@ def import_cmd(input_path: str, db: str, no_clear: bool, as_json: bool):
         )
 
 
+def _parse_repo_sources(args: tuple[str, ...]) -> dict[str, str]:
+    """Parse [NAME=]PATH source arguments into {repo name: path}."""
+    from navegador.federation import repo_name_from_path
+
+    sources: dict[str, str] = {}
+    for arg in args:
+        name, _, path = arg.rpartition("=")
+        if not name:
+            path = arg
+            name = repo_name_from_path(arg)
+        sources[name] = path
+    return sources
+
+
 @main.command("aggregate")
 @click.argument("repos", nargs=-1, required=True)
 @DB_OPTION
@@ -1070,16 +1084,9 @@ def aggregate_cmd(repos: tuple[str, ...], db: str, clear: bool, as_json: bool):
     file, optionally prefixed NAME= to set the repo namespace (defaults to
     the directory basename). The --db graph is the central target.
     """
-    from navegador.federation import SuperGraphAggregator, repo_name_from_path
+    from navegador.federation import SuperGraphAggregator
 
-    sources: dict[str, str] = {}
-    for arg in repos:
-        name, _, path = arg.rpartition("=")
-        if not name:
-            path = arg
-            name = repo_name_from_path(arg)
-        sources[name] = path
-
+    sources = _parse_repo_sources(repos)
     aggregator = SuperGraphAggregator(_get_store(db))
     summary = aggregator.aggregate(sources, clear=clear)
 
@@ -1670,15 +1677,34 @@ def churn(
         "Start in read-only mode: disables ingest_repo and blocks write operations in query_graph."
     ),
 )
-def mcp(db: str, read_only: bool):
+@click.option(
+    "--federate",
+    "federate",
+    multiple=True,
+    metavar="[NAME=]PATH",
+    help=(
+        "Roll up a repo graph ([NAME=]PATH, repeatable) into the bound graph at "
+        "startup and serve the federated super-graph."
+    ),
+)
+def mcp(db: str, read_only: bool, federate: tuple[str, ...]):
     """Start the MCP server for AI agent integration (stdio)."""
     from mcp.server.stdio import stdio_server  # type: ignore[import]
 
     from navegador.mcp import create_mcp_server
 
-    server = create_mcp_server(lambda: _get_store(db), read_only=read_only)
+    def _store_factory():
+        store = _get_store(db)
+        if federate:
+            from navegador.federation import SuperGraphAggregator
+
+            SuperGraphAggregator(store).aggregate(_parse_repo_sources(federate))
+        return store
+
+    server = create_mcp_server(_store_factory, read_only=read_only)
     mode = "read-only" if read_only else "read-write"
-    console.print(f"[green]Navegador MCP server running[/green] (stdio, {mode})")
+    federated = f", federated over {len(federate)} repos" if federate else ""
+    console.print(f"[green]Navegador MCP server running[/green] (stdio, {mode}{federated})")
 
     async def _run():
         async with stdio_server() as (read_stream, write_stream):

--- a/navegador/context/loader.py
+++ b/navegador/context/loader.py
@@ -270,9 +270,11 @@ class ContextLoader:
 
     # ── Search ────────────────────────────────────────────────────────────────
 
-    def search(self, query: str, limit: int = 20) -> list[ContextNode]:
-        """Search code symbols by name."""
-        result = self.store.query(queries.SYMBOL_SEARCH, {"query": query, "limit": limit})
+    def search(self, query: str, limit: int = 20, repo: str = "") -> list[ContextNode]:
+        """Search code symbols by name; repo scopes to one federated namespace."""
+        result = self.store.query(
+            queries.SYMBOL_SEARCH, {"query": query, "limit": limit, "repo": repo}
+        )
         return [
             ContextNode(
                 type=row[0], name=row[1], file_path=row[2], line_start=row[3], docstring=row[4]
@@ -355,9 +357,11 @@ class ContextLoader:
 
     # ── Knowledge: search ────────────────────────────────────────────────────
 
-    def search_knowledge(self, query: str, limit: int = 20) -> list[ContextNode]:
-        """Search concepts, rules, decisions, and wiki pages."""
-        result = self.store.query(queries.KNOWLEDGE_SEARCH, {"query": query, "limit": limit})
+    def search_knowledge(self, query: str, limit: int = 20, repo: str = "") -> list[ContextNode]:
+        """Search concepts, rules, decisions, and wiki pages; repo scopes to one namespace."""
+        result = self.store.query(
+            queries.KNOWLEDGE_SEARCH, {"query": query, "limit": limit, "repo": repo}
+        )
         return [
             ContextNode(
                 type=row[0],

--- a/navegador/explorer/server.py
+++ b/navegador/explorer/server.py
@@ -152,9 +152,7 @@ def _get_node_detail(store: "GraphStore", name: str, file_path: str = "") -> dic
         key = f"{nb_name}|{nb_file}|{rel}"
         if key not in seen:
             seen.add(key)
-            neighbors.append(
-                {"label": nb_label, "name": nb_name, "file_path": nb_file, "rel": rel}
-            )
+            neighbors.append({"label": nb_label, "name": nb_name, "file_path": nb_file, "rel": rel})
 
     return {"name": name, "label": label, "props": props, "neighbors": neighbors}
 

--- a/navegador/graph/queries.py
+++ b/navegador/graph/queries.py
@@ -103,10 +103,12 @@ RETURN DISTINCT
 
 # ── Universal: search ─────────────────────────────────────────────────────────
 
-# Search code symbols by name substring
+# Search code symbols by name substring.
+# $repo scopes to one federated namespace ('' = span all repos).
 SYMBOL_SEARCH = """
 MATCH (n)
 WHERE (n:Function OR n:Class OR n:Method) AND n.name CONTAINS $query
+  AND ($repo = '' OR n.repo = $repo)
 RETURN labels(n)[0] AS type, n.name AS name, n.file_path AS file_path,
        n.line_start AS line, n.docstring AS docstring
 LIMIT $limit
@@ -123,13 +125,18 @@ RETURN labels(n)[0] AS type, n.name AS name, n.file_path AS file_path,
 LIMIT $limit
 """
 
-# Search knowledge layer (concepts, rules, decisions, wiki) by name or description
+# Search knowledge layer (concepts, rules, decisions, wiki) by name or description.
+# $repo scopes to one federated namespace ('' = span all repos): deduped knowledge
+# nodes carry a comma-joined `repos` membership, namespaced nodes carry `repo`.
 KNOWLEDGE_SEARCH = """
 MATCH (n)
 WHERE (n:Concept OR n:Rule OR n:Decision OR n:WikiPage OR n:Document)
   AND (toLower(n.name) CONTAINS toLower($query)
        OR (n.description IS NOT NULL AND toLower(n.description) CONTAINS toLower($query))
        OR (n.content IS NOT NULL AND toLower(n.content) CONTAINS toLower($query)))
+  AND ($repo = ''
+       OR n.repo = $repo
+       OR (',' + coalesce(n.repos, '') + ',') CONTAINS (',' + $repo + ','))
 RETURN labels(n)[0] AS type, n.name AS name, n.description AS description,
        n.domain AS domain, n.status AS status
 LIMIT $limit

--- a/navegador/graph/schema.py
+++ b/navegador/graph/schema.py
@@ -153,17 +153,17 @@ NODE_PROPS = {
         "symbol_count",
     ],
     NodeLabel.Ticket: [
-        "ticket_id",   # Fossil UUID / short hash
+        "ticket_id",  # Fossil UUID / short hash
         "title",
-        "status",      # open|closed|fixed|invalid|…
-        "type",        # bug|feature|task|…
+        "status",  # open|closed|fixed|invalid|…
+        "type",  # bug|feature|task|…
         "priority",
         "severity",
         "assignee",
         "resolution",
-        "content",     # description / latest comment
-        "repo",        # repo name (for multi-repo graphs)
-        "source",      # "fossil" | "github" | …
+        "content",  # description / latest comment
+        "repo",  # repo name (for multi-repo graphs)
+        "source",  # "fossil" | "github" | …
         "updated_at",
     ],
 }

--- a/navegador/graph/store.py
+++ b/navegador/graph/store.py
@@ -117,9 +117,7 @@ class GraphStore:
         elif props.get("file_path", ""):
             # Code symbol with a known file — disambiguate by (name, file_path)
             props.setdefault("name", "")
-            cypher = (
-                f"MERGE (n:{label} {{name: $name, file_path: $file_path}}) SET {prop_str}"
-            )
+            cypher = f"MERGE (n:{label} {{name: $name, file_path: $file_path}}) SET {prop_str}"
         else:
             # Knowledge node or symbol without a file — key by name only
             props.setdefault("name", "")

--- a/navegador/history.py
+++ b/navegador/history.py
@@ -56,7 +56,7 @@ class SnapshotEntry:
 
     ref: str
     name: str
-    label: str        # Function | Class | Method
+    label: str  # Function | Class | Method
     file_path: str
     line_start: int | None = None
     line_end: int | None = None
@@ -67,7 +67,7 @@ class HistoryEvent:
     """One event in a symbol's history across snapshot refs."""
 
     ref: str
-    event: str        # "first_seen" | "moved" | "renamed" | "changed" | "removed" | "seen"
+    event: str  # "first_seen" | "moved" | "renamed" | "changed" | "removed" | "seen"
     name: str
     file_path: str
     detail: str = ""
@@ -87,7 +87,7 @@ class LineageStep:
     name: str
     file_path: str
     label: str
-    event: str        # "created" | "moved" | "renamed" | "continued" | "removed"
+    event: str  # "created" | "moved" | "renamed" | "continued" | "removed"
     detail: str = ""
 
 
@@ -135,10 +135,7 @@ class LineageReport:
         for step in self.chain:
             tag = f"**{step.event}**" if step.event != "continued" else step.event
             detail = f" — {step.detail}" if step.detail else ""
-            lines.append(
-                f"- `{step.ref}` {tag} `{step.name}` "
-                f"`{step.file_path}`{detail}"
-            )
+            lines.append(f"- `{step.ref}` {tag} `{step.name}` " f"`{step.file_path}`{detail}")
         return "\n".join(lines)
 
     def to_json(self) -> str:
@@ -149,6 +146,7 @@ class LineageReport:
 
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
+
 
 def _bigrams(s: str) -> set[str]:
     s = s.lower()
@@ -230,6 +228,7 @@ _SNAPSHOTS_FOR_SYMBOL = (
 
 # ── Main class ────────────────────────────────────────────────────────────────
 
+
 class HistoryStore:
     """
     Manages graph snapshots for historical symbol lineage queries.
@@ -309,9 +308,12 @@ class HistoryStore:
 
         Events: first_seen, seen, moved, removed.
         """
-        rows = self.store.query(
-            _SNAPSHOTS_FOR_SYMBOL, {"name": name, "file_path": file_path}
-        ).result_set or []
+        rows = (
+            self.store.query(
+                _SNAPSHOTS_FOR_SYMBOL, {"name": name, "file_path": file_path}
+            ).result_set
+            or []
+        )
 
         events: list[HistoryEvent] = []
         prev_file: str | None = None
@@ -330,13 +332,15 @@ class HistoryStore:
                 event = "seen"
                 detail = f"in `{cur_file}`"
 
-            events.append(HistoryEvent(
-                ref=ref,
-                event=event,
-                name=name,
-                file_path=cur_file,
-                detail=detail,
-            ))
+            events.append(
+                HistoryEvent(
+                    ref=ref,
+                    event=event,
+                    name=name,
+                    file_path=cur_file,
+                    detail=detail,
+                )
+            )
             prev_file = cur_file
 
         # Detect removal: symbol in penultimate snapshot but not latest
@@ -345,13 +349,15 @@ class HistoryStore:
             latest_ref = snapshots[-1].ref
             latest_refs = {r[0] for r in rows}
             if latest_ref not in latest_refs:
-                events.append(HistoryEvent(
-                    ref=latest_ref,
-                    event="removed",
-                    name=name,
-                    file_path=prev_file or "",
-                    detail="not present in latest snapshot",
-                ))
+                events.append(
+                    HistoryEvent(
+                        ref=latest_ref,
+                        event="removed",
+                        name=name,
+                        file_path=prev_file or "",
+                        detail="not present in latest snapshot",
+                    )
+                )
 
         return HistoryReport(symbol=name, file_path=file_path, events=events)
 
@@ -381,10 +387,15 @@ class HistoryStore:
             if key in sym_map:
                 s = sym_map[key]
                 event = "created" if not chain else "continued"
-                chain.append(LineageStep(
-                    ref=snap.ref, name=s.name, file_path=s.file_path,
-                    label=s.label, event=event,
-                ))
+                chain.append(
+                    LineageStep(
+                        ref=snap.ref,
+                        name=s.name,
+                        file_path=s.file_path,
+                        label=s.label,
+                        event=event,
+                    )
+                )
                 continue
 
             # 2. Same name, different file (move)
@@ -392,14 +403,17 @@ class HistoryStore:
             if name_matches:
                 s = name_matches[0]
                 event = "created" if not chain else "moved"
-                detail = (
-                    f"moved from `{current_file}` to `{s.file_path}`"
-                    if chain else ""
+                detail = f"moved from `{current_file}` to `{s.file_path}`" if chain else ""
+                chain.append(
+                    LineageStep(
+                        ref=snap.ref,
+                        name=s.name,
+                        file_path=s.file_path,
+                        label=s.label,
+                        event=event,
+                        detail=detail,
+                    )
                 )
-                chain.append(LineageStep(
-                    ref=snap.ref, name=s.name, file_path=s.file_path,
-                    label=s.label, event=event, detail=detail,
-                ))
                 current_file = s.file_path
                 continue
 
@@ -414,31 +428,39 @@ class HistoryStore:
                         best_score = score
                         best = s
                 if best and best_score >= self.RENAME_THRESHOLD:
-                    chain.append(LineageStep(
-                        ref=snap.ref, name=best.name, file_path=best.file_path,
-                        label=best.label, event="renamed",
-                        detail=(
-                            f"`{current_name}` → `{best.name}` "
-                            f"(similarity={best_score:.2f})"
-                        ),
-                    ))
+                    chain.append(
+                        LineageStep(
+                            ref=snap.ref,
+                            name=best.name,
+                            file_path=best.file_path,
+                            label=best.label,
+                            event="renamed",
+                            detail=(
+                                f"`{current_name}` → `{best.name}` "
+                                f"(similarity={best_score:.2f})"
+                            ),
+                        )
+                    )
                     current_name = best.name
                     continue
 
             # 4. Not found — removed
             if chain:
-                chain.append(LineageStep(
-                    ref=snap.ref, name=current_name, file_path=current_file,
-                    label="", event="removed",
-                    detail="not found in this snapshot",
-                ))
+                chain.append(
+                    LineageStep(
+                        ref=snap.ref,
+                        name=current_name,
+                        file_path=current_file,
+                        label="",
+                        event="removed",
+                        detail="not found in this snapshot",
+                    )
+                )
                 break
 
         return LineageReport(symbol=name, chain=chain)
 
-    def diff_snapshots(
-        self, base_ref: str, head_ref: str
-    ) -> dict[str, Any]:
+    def diff_snapshots(self, base_ref: str, head_ref: str) -> dict[str, Any]:
         """
         Compare two snapshots: what symbols were added, removed, or moved?
 

--- a/navegador/ingestion/kotlin.py
+++ b/navegador/ingestion/kotlin.py
@@ -208,7 +208,8 @@ class KotlinParser(LanguageParser):
                         (
                             c
                             for c in node.children
-                            if c.type in (
+                            if c.type
+                            in (
                                 "simple_identifier",
                                 "identifier",
                                 "navigation_expression",

--- a/navegador/ingestion/memory.py
+++ b/navegador/ingestion/memory.py
@@ -70,7 +70,7 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
             key, _, value = line.partition(":")
             meta[key.strip()] = value.strip()
 
-    body = text[m.end():]
+    body = text[m.end() :]
     return meta, body
 
 
@@ -183,7 +183,7 @@ class MemoryIngester:
                 if idx_name:
                     name = idx_name
                 else:
-                    slug = md_file.stem[len(mem_type) + 1:]  # strip "type_" prefix
+                    slug = md_file.stem[len(mem_type) + 1 :]  # strip "type_" prefix
                     name = slug.replace("_", " ").replace("-", " ")
                 # Description: prefer MEMORY.md entry, fall back to first content line
                 description = idx_desc or _first_line(body)
@@ -337,9 +337,7 @@ class MemoryIngester:
     def _clear_memory_nodes(self, repo_name: str) -> None:
         """Remove all memory-typed nodes for a given repo."""
         cypher = (
-            "MATCH (n) "
-            "WHERE n.memory_type IS NOT NULL AND n.repo = $repo "
-            "DETACH DELETE n"
+            "MATCH (n) " "WHERE n.memory_type IS NOT NULL AND n.repo = $repo " "DETACH DELETE n"
         )
         self.store.query(cypher, {"repo": repo_name})
         logger.info("Cleared memory nodes for repo=%s", repo_name)

--- a/navegador/intelligence/doclink.py
+++ b/navegador/intelligence/doclink.py
@@ -69,9 +69,11 @@ def _fuzzy_score(a: str, b: str) -> float:
         return 1.0
     if a in b or b in a:
         return min(len(a), len(b)) / max(len(a), len(b))
+
     # character bigram overlap
     def bigrams(s: str) -> set[str]:
-        return {s[i:i+2] for i in range(len(s) - 1)}
+        return {s[i : i + 2] for i in range(len(s) - 1)}
+
     bg_a, bg_b = bigrams(a), bigrams(b)
     if not bg_a or not bg_b:
         return 0.0
@@ -80,14 +82,14 @@ def _fuzzy_score(a: str, b: str) -> float:
 
 @dataclass
 class LinkCandidate:
-    source_label: str        # Document / WikiPage / Rule / Decision
+    source_label: str  # Document / WikiPage / Rule / Decision
     source_name: str
-    target_label: str        # Function / Class / Concept / Rule …
+    target_label: str  # Function / Class / Concept / Rule …
     target_name: str
     target_file: str = ""
-    edge_type: str = "DOCUMENTS"   # proposed edge type
+    edge_type: str = "DOCUMENTS"  # proposed edge type
     confidence: float = 0.0
-    strategy: str = ""       # EXACT_NAME | ALIAS | FUZZY | SEMANTIC
+    strategy: str = ""  # EXACT_NAME | ALIAS | FUZZY | SEMANTIC
     rationale: str = ""
 
 
@@ -142,16 +144,18 @@ class DocLinker:
                     key = (doc["name"], target["name"])
                     if key in existing:
                         continue
-                    candidates.append(LinkCandidate(
-                        source_label=doc["label"],
-                        source_name=doc["name"],
-                        target_label=target["label"],
-                        target_name=target["name"],
-                        target_file=target.get("file_path", ""),
-                        confidence=self.EXACT_CONFIDENCE,
-                        strategy="EXACT_NAME",
-                        rationale=f"term '{term}' exactly matches {target['label']} name",
-                    ))
+                    candidates.append(
+                        LinkCandidate(
+                            source_label=doc["label"],
+                            source_name=doc["name"],
+                            target_label=target["label"],
+                            target_name=target["name"],
+                            target_file=target.get("file_path", ""),
+                            confidence=self.EXACT_CONFIDENCE,
+                            strategy="EXACT_NAME",
+                            rationale=f"term '{term}' exactly matches {target['label']} name",
+                        )
+                    )
                     continue
 
                 # 2. Fuzzy match
@@ -161,17 +165,19 @@ class DocLinker:
                         continue
                     score = _fuzzy_score(term, target["name"])
                     if score >= self.FUZZY_THRESHOLD:
-                        candidates.append(LinkCandidate(
-                            source_label=doc["label"],
-                            source_name=doc["name"],
-                            target_label=target["label"],
-                            target_name=target["name"],
-                            target_file=target.get("file_path", ""),
-                            confidence=round(score * self.ALIAS_CONFIDENCE, 3),
-                            strategy="FUZZY",
-                            rationale=f"term '{term}' fuzzy-matches '{target['name']}' "
-                                      f"(score={score:.2f})",
-                        ))
+                        candidates.append(
+                            LinkCandidate(
+                                source_label=doc["label"],
+                                source_name=doc["name"],
+                                target_label=target["label"],
+                                target_name=target["name"],
+                                target_file=target.get("file_path", ""),
+                                confidence=round(score * self.ALIAS_CONFIDENCE, 3),
+                                strategy="FUZZY",
+                                rationale=f"term '{term}' fuzzy-matches '{target['name']}' "
+                                f"(score={score:.2f})",
+                            )
+                        )
 
         # 3. Semantic matching (requires provider)
         if self._provider:
@@ -228,15 +234,11 @@ class DocLinker:
         )
         rows = self.store.query(cypher).result_set or []
         return [
-            {"label": r[0], "name": r[1], "file_path": r[2], "text": r[3]}
-            for r in rows if r[1]
+            {"label": r[0], "name": r[1], "file_path": r[2], "text": r[3]} for r in rows if r[1]
         ]
 
     def _existing_links(self) -> set[tuple[str, str]]:
-        cypher = (
-            "MATCH (a)-[:DOCUMENTS|ANNOTATES|GOVERNS]->(b) "
-            "RETURN a.name, b.name LIMIT 5000"
-        )
+        cypher = "MATCH (a)-[:DOCUMENTS|ANNOTATES|GOVERNS]->(b) " "RETURN a.name, b.name LIMIT 5000"
         rows = self.store.query(cypher).result_set or []
         return {(r[0], r[1]) for r in rows if r[0] and r[1]}
 
@@ -281,15 +283,17 @@ class DocLinker:
                     continue
                 score = _cos(doc_vec, code_vec)
                 if score >= self.SEMANTIC_THRESHOLD:
-                    candidates.append(LinkCandidate(
-                        source_label=doc["label"],
-                        source_name=doc["name"],
-                        target_label=target["label"],
-                        target_name=target["name"],
-                        target_file=target.get("file_path", ""),
-                        confidence=round(score, 3),
-                        strategy="SEMANTIC",
-                        rationale=f"semantic similarity={score:.2f}",
-                    ))
+                    candidates.append(
+                        LinkCandidate(
+                            source_label=doc["label"],
+                            source_name=doc["name"],
+                            target_label=target["label"],
+                            target_name=target["name"],
+                            target_file=target.get("file_path", ""),
+                            confidence=round(score, 3),
+                            strategy="SEMANTIC",
+                            rationale=f"semantic similarity={score:.2f}",
+                        )
+                    )
 
         return candidates

--- a/navegador/lenses.py
+++ b/navegador/lenses.py
@@ -207,9 +207,7 @@ class LensEngine:
             label, name, file_path, owner = row[0] or "", row[1] or "", row[2] or "", row[3] or ""
             nk = (name, file_path)
             if name and nk not in seen_nodes:
-                seen_nodes[nk] = LensNode(
-                    label=label, name=name, file_path=file_path, owner=owner
-                )
+                seen_nodes[nk] = LensNode(label=label, name=name, file_path=file_path, owner=owner)
             ok = (owner, "")
             if owner and ok not in seen_nodes:
                 seen_nodes[ok] = LensNode(label="Person", name=owner)
@@ -300,10 +298,22 @@ class LensEngine:
 
     # Common framework component suffixes produced by framework enrichers
     _FRAMEWORK_SUFFIXES = (
-        "Controller", "Service", "Repository", "Model",
-        "Middleware", "Serializer", "View", "Handler",
-        "Router", "Provider", "Resolver", "Gateway",
-        "Component", "Module", "Guard", "Interceptor",
+        "Controller",
+        "Service",
+        "Repository",
+        "Model",
+        "Middleware",
+        "Serializer",
+        "View",
+        "Handler",
+        "Router",
+        "Provider",
+        "Resolver",
+        "Gateway",
+        "Component",
+        "Module",
+        "Guard",
+        "Interceptor",
     )
 
     def _lens_framework_components(self, label: str = "", **_kw: Any) -> LensResult:

--- a/navegador/mcp/server.py
+++ b/navegador/mcp/server.py
@@ -71,6 +71,13 @@ def create_mcp_server(store_factory, read_only: bool = False):
                             "type": "string",
                             "description": "Relative file path within the ingested repo.",
                         },
+                        "repo": {
+                            "type": "string",
+                            "default": "",
+                            "description": (
+                                "Federated repo namespace; scopes file_path to that repo."
+                            ),
+                        },
                         "format": {
                             "type": "string",
                             "enum": ["json", "markdown"],
@@ -88,6 +95,13 @@ def create_mcp_server(store_factory, read_only: bool = False):
                     "properties": {
                         "name": {"type": "string", "description": "Function name."},
                         "file_path": {"type": "string", "description": "Relative file path."},
+                        "repo": {
+                            "type": "string",
+                            "default": "",
+                            "description": (
+                                "Federated repo namespace; scopes file_path to that repo."
+                            ),
+                        },
                         "depth": {"type": "integer", "default": 2},
                         "format": {
                             "type": "string",
@@ -106,6 +120,13 @@ def create_mcp_server(store_factory, read_only: bool = False):
                     "properties": {
                         "name": {"type": "string", "description": "Class name."},
                         "file_path": {"type": "string", "description": "Relative file path."},
+                        "repo": {
+                            "type": "string",
+                            "default": "",
+                            "description": (
+                                "Federated repo namespace; scopes file_path to that repo."
+                            ),
+                        },
                         "format": {
                             "type": "string",
                             "enum": ["json", "markdown"],
@@ -123,13 +144,25 @@ def create_mcp_server(store_factory, read_only: bool = False):
                     "properties": {
                         "query": {"type": "string", "description": "Partial name to search."},
                         "limit": {"type": "integer", "default": 20},
+                        "repo": {
+                            "type": "string",
+                            "default": "",
+                            "description": (
+                                "Federated repo namespace to scope to (see list_repos). "
+                                "Omit to span all repos in a super-graph."
+                            ),
+                        },
                     },
                     "required": ["query"],
                 },
             ),
             Tool(
                 name="query_graph",
-                description="Execute a raw Cypher query against the navegador graph.",
+                description=(
+                    "Execute a raw Cypher query against the navegador graph. "
+                    "On a federated super-graph the query spans all repos; nodes carry a "
+                    "`repo` property (knowledge nodes a comma-joined `repos`) for filtering."
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -141,6 +174,25 @@ def create_mcp_server(store_factory, read_only: bool = False):
             Tool(
                 name="graph_stats",
                 description="Return node and edge counts for the current graph.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "repo": {
+                            "type": "string",
+                            "default": "",
+                            "description": (
+                                "Count only nodes/edges of one federated repo namespace."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="list_repos",
+                description=(
+                    "List the repo namespaces available in a federated super-graph "
+                    "(falls back to all Repository nodes on a single-repo graph)."
+                ),
                 inputSchema={"type": "object", "properties": {}},
             ),
             Tool(
@@ -183,6 +235,14 @@ def create_mcp_server(store_factory, read_only: bool = False):
                     "properties": {
                         "query": {"type": "string", "description": "Search query."},
                         "limit": {"type": "integer", "default": 20},
+                        "repo": {
+                            "type": "string",
+                            "default": "",
+                            "description": (
+                                "Federated repo namespace to scope to. Matches shared "
+                                "knowledge nodes contributed by that repo. Omit to span all."
+                            ),
+                        },
                     },
                     "required": ["query"],
                 },
@@ -206,6 +266,14 @@ def create_mcp_server(store_factory, read_only: bool = False):
                             "type": "integer",
                             "description": "Maximum traversal depth.",
                             "default": 3,
+                        },
+                        "repo": {
+                            "type": "string",
+                            "default": "",
+                            "description": (
+                                "Federated repo namespace; scopes file_path to that repo. "
+                                "Omit to span the whole workspace."
+                            ),
                         },
                     },
                     "required": ["name"],
@@ -562,6 +630,14 @@ def create_mcp_server(store_factory, read_only: bool = False):
             ),
         ]
 
+    def _scoped_path(arguments: dict) -> str:
+        """file_path, prefixed with the federated repo namespace when given."""
+        file_path = arguments.get("file_path", "")
+        repo = arguments.get("repo", "")
+        if repo and file_path and not file_path.startswith(f"{repo}/"):
+            return f"{repo}/{file_path}"
+        return file_path
+
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         loader = _get_loader()
@@ -581,7 +657,7 @@ def create_mcp_server(store_factory, read_only: bool = False):
             return [TextContent(type="text", text=json.dumps(stats, indent=2))]
 
         elif name == "load_file_context":
-            bundle = loader.load_file(arguments["file_path"])
+            bundle = loader.load_file(_scoped_path(arguments))
             fmt = arguments.get("format", "markdown")
             text = bundle.to_markdown() if fmt == "markdown" else bundle.to_json()
             return [TextContent(type="text", text=text)]
@@ -589,7 +665,7 @@ def create_mcp_server(store_factory, read_only: bool = False):
         elif name == "load_function_context":
             bundle = loader.load_function(
                 arguments["name"],
-                arguments["file_path"],
+                _scoped_path(arguments),
                 depth=arguments.get("depth", 2),
             )
             fmt = arguments.get("format", "markdown")
@@ -597,13 +673,17 @@ def create_mcp_server(store_factory, read_only: bool = False):
             return [TextContent(type="text", text=text)]
 
         elif name == "load_class_context":
-            bundle = loader.load_class(arguments["name"], arguments["file_path"])
+            bundle = loader.load_class(arguments["name"], _scoped_path(arguments))
             fmt = arguments.get("format", "markdown")
             text = bundle.to_markdown() if fmt == "markdown" else bundle.to_json()
             return [TextContent(type="text", text=text)]
 
         elif name == "search_symbols":
-            results = loader.search(arguments["query"], limit=arguments.get("limit", 20))
+            results = loader.search(
+                arguments["query"],
+                limit=arguments.get("limit", 20),
+                repo=arguments.get("repo", ""),
+            )
             lines = [f"- **{r.type}** `{r.name}` — `{r.file_path}`:{r.line_start}" for r in results]
             return [TextContent(type="text", text="\n".join(lines) or "No results.")]
 
@@ -624,11 +704,38 @@ def create_mcp_server(store_factory, read_only: bool = False):
             return [TextContent(type="text", text=text)]
 
         elif name == "graph_stats":
-            stats = {
-                "nodes": loader.store.node_count(),
-                "edges": loader.store.edge_count(),
-            }
+            repo = arguments.get("repo", "")
+            if repo:
+                nodes = loader.store.query(
+                    "MATCH (n {repo: $repo}) RETURN count(n)", {"repo": repo}
+                )
+                edges = loader.store.query(
+                    "MATCH (a {repo: $repo})-[r]->(b {repo: $repo}) RETURN count(r)",
+                    {"repo": repo},
+                )
+                stats = {
+                    "repo": repo,
+                    "nodes": (nodes.result_set or [[0]])[0][0],
+                    "edges": (edges.result_set or [[0]])[0][0],
+                }
+            else:
+                stats = {
+                    "nodes": loader.store.node_count(),
+                    "edges": loader.store.edge_count(),
+                }
             return [TextContent(type="text", text=json.dumps(stats, indent=2))]
+
+        elif name == "list_repos":
+            result = loader.store.query(
+                "MATCH (r:Repository {description: 'federated-repo-anchor'}) "
+                "RETURN r.name ORDER BY r.name"
+            )
+            rows = result.result_set or []
+            if not rows:
+                result = loader.store.query("MATCH (r:Repository) RETURN r.name ORDER BY r.name")
+                rows = result.result_set or []
+            repos = [row[0] for row in rows]
+            return [TextContent(type="text", text=json.dumps(repos, indent=2))]
 
         elif name == "get_rationale":
             bundle = loader.load_decision(arguments["name"])
@@ -646,7 +753,11 @@ def create_mcp_server(store_factory, read_only: bool = False):
             return [TextContent(type="text", text="\n".join(lines))]
 
         elif name == "search_knowledge":
-            results = loader.search_knowledge(arguments["query"], limit=arguments.get("limit", 20))
+            results = loader.search_knowledge(
+                arguments["query"],
+                limit=arguments.get("limit", 20),
+                repo=arguments.get("repo", ""),
+            )
             if not results:
                 return [TextContent(type="text", text="No results.")]
             lines = [f"- **{r.type}** `{r.name}` — {r.description or ''}" for r in results]
@@ -657,8 +768,9 @@ def create_mcp_server(store_factory, read_only: bool = False):
 
             result = ImpactAnalyzer(loader.store).blast_radius(
                 arguments["name"],
-                file_path=arguments.get("file_path", ""),
+                file_path=_scoped_path(arguments),
                 depth=arguments.get("depth", 3),
+                repo=arguments.get("repo", ""),
             )
             return [TextContent(type="text", text=json.dumps(result.to_dict(), indent=2))]
 

--- a/navegador/mcp/server.py
+++ b/navegador/mcp/server.py
@@ -814,17 +814,21 @@ def create_mcp_server(store_factory, read_only: bool = False):
             # return an error instead of an arbitrary match.
             if len(rows) > 1 and not arguments.get("repo", ""):
                 repos = sorted({row[4] for row in rows if row[4]})
-                return [TextContent(
-                    type="text",
-                    text=json.dumps({
-                        "error": "ambiguous",
-                        "message": (
-                            f"Memory name {arguments['name']!r} exists in multiple repos. "
-                            "Pass repo= to disambiguate."
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "error": "ambiguous",
+                                "message": (
+                                    f"Memory name {arguments['name']!r} exists in multiple repos. "
+                                    "Pass repo= to disambiguate."
+                                ),
+                                "repos": repos,
+                            }
                         ),
-                        "repos": repos,
-                    }),
-                )]
+                    )
+                ]
             row = rows[0]
             item = {
                 "label": row[0],

--- a/tests/test_mcp_federation.py
+++ b/tests/test_mcp_federation.py
@@ -89,9 +89,10 @@ def _seed_repo(store: GraphStore, suffix: str) -> None:
         "Function", {"name": f"helper_{suffix}", "file_path": "app.py", "line_start": 9}
     )
     store.create_node("Concept", {"name": "Payments"})
-    store.create_edge(
-        "File", {"path": "app.py"}, "CONTAINS", "Function", {"name": "process", "file_path": "app.py"}
-    )
+    for fn in ("process", f"helper_{suffix}"):
+        store.create_edge(
+            "File", {"path": "app.py"}, "CONTAINS", "Function", {"name": fn, "file_path": "app.py"}
+        )
     store.create_edge(
         "Function",
         {"name": "process", "file_path": "app.py"},
@@ -186,7 +187,7 @@ class TestQueryGraph:
             {
                 "cypher": (
                     "MATCH (f:Function)-[:IMPLEMENTS]->(:Concept {name: 'Payments'}) "
-                    "RETURN f.repo ORDER BY f.repo"
+                    "RETURN f.repo ORDER BY f.repo LIMIT 10"
                 )
             },
         )

--- a/tests/test_mcp_federation.py
+++ b/tests/test_mcp_federation.py
@@ -1,0 +1,256 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Tests for MCP multi-graph routing over a federated super-graph.
+
+Two seeded repo graphs are rolled up with SuperGraphAggregator into a real
+central store; MCP tools are exercised through the captured call_tool handler
+against that store — no graph mocks.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from navegador.cli.commands import _parse_repo_sources
+from navegador.federation import SuperGraphAggregator
+from navegador.graph.store import GraphStore
+
+# ── Server harness (mocked mcp SDK, real store + loader) ───────────────────
+
+
+class _ServerFixture:
+    """Capture list_tools/call_tool from create_mcp_server bound to a real store."""
+
+    def __init__(self, store: GraphStore, read_only: bool = False):
+        self.store = store
+        self.call_tool_fn = None
+        self.list_tools_fn = None
+        self._build(read_only)
+
+    def _build(self, read_only: bool):
+        list_holder: dict = {}
+        call_holder: dict = {}
+
+        def list_tools_decorator():
+            def decorator(fn):
+                list_holder["fn"] = fn
+                return fn
+
+            return decorator
+
+        def call_tool_decorator():
+            def decorator(fn):
+                call_holder["fn"] = fn
+                return fn
+
+            return decorator
+
+        mock_server = MagicMock()
+        mock_server.list_tools = list_tools_decorator
+        mock_server.call_tool = call_tool_decorator
+
+        mock_mcp_server = MagicMock()
+        mock_mcp_server.Server.return_value = mock_server
+        mock_mcp_types = MagicMock()
+        mock_mcp_types.Tool = dict
+        mock_mcp_types.TextContent = dict
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "mcp": MagicMock(),
+                "mcp.server": mock_mcp_server,
+                "mcp.types": mock_mcp_types,
+            },
+        ):
+            from importlib import reload
+
+            import navegador.mcp.server as srv
+
+            reload(srv)
+            srv.create_mcp_server(lambda: self.store, read_only=read_only)
+
+        self.list_tools_fn = list_holder["fn"]
+        self.call_tool_fn = call_holder["fn"]
+
+
+def _text(result) -> str:
+    return result[0]["text"]
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+def _seed_repo(store: GraphStore, suffix: str) -> None:
+    store.create_node("File", {"name": "app.py", "path": "app.py", "language": "python"})
+    store.create_node("Function", {"name": "process", "file_path": "app.py", "line_start": 1})
+    store.create_node(
+        "Function", {"name": f"helper_{suffix}", "file_path": "app.py", "line_start": 9}
+    )
+    store.create_node("Concept", {"name": "Payments"})
+    store.create_edge(
+        "File", {"path": "app.py"}, "CONTAINS", "Function", {"name": "process", "file_path": "app.py"}
+    )
+    store.create_edge(
+        "Function",
+        {"name": "process", "file_path": "app.py"},
+        "CALLS",
+        "Function",
+        {"name": f"helper_{suffix}", "file_path": "app.py"},
+    )
+    store.create_edge(
+        "Function",
+        {"name": "process", "file_path": "app.py"},
+        "IMPLEMENTS",
+        "Concept",
+        {"name": "Payments"},
+    )
+
+
+@pytest.fixture(scope="module")
+def central(tmp_path_factory):
+    """A real federated super-graph: repo-a and repo-b rolled up centrally."""
+    central = GraphStore.sqlite(str(tmp_path_factory.mktemp("mcp-central") / "graph.db"))
+    for repo in ("repo-a", "repo-b"):
+        source = GraphStore.sqlite(str(tmp_path_factory.mktemp(f"mcp-{repo}") / "graph.db"))
+        _seed_repo(source, repo.replace("repo-", ""))
+        SuperGraphAggregator(central).aggregate({repo: source})
+        source.close()
+    yield central
+    central.close()
+
+
+@pytest.fixture(scope="module")
+def call_tool(central):
+    return _ServerFixture(central).call_tool_fn
+
+
+@pytest.fixture(scope="module")
+def call_tool_readonly(central):
+    return _ServerFixture(central, read_only=True).call_tool_fn
+
+
+# ── list_repos ─────────────────────────────────────────────────────────────
+
+
+class TestListRepos:
+    @pytest.mark.asyncio
+    async def test_lists_federated_namespaces(self, call_tool):
+        result = await call_tool("list_repos", {})
+        assert json.loads(_text(result)) == ["repo-a", "repo-b"]
+
+
+# ── search_symbols ─────────────────────────────────────────────────────────
+
+
+class TestSearchSymbols:
+    @pytest.mark.asyncio
+    async def test_spans_all_repos_by_default(self, call_tool):
+        result = await call_tool("search_symbols", {"query": "helper"})
+        text = _text(result)
+        assert "helper_a" in text
+        assert "helper_b" in text
+
+    @pytest.mark.asyncio
+    async def test_repo_arg_scopes(self, call_tool):
+        result = await call_tool("search_symbols", {"query": "helper", "repo": "repo-a"})
+        text = _text(result)
+        assert "helper_a" in text
+        assert "helper_b" not in text
+
+
+# ── search_knowledge ───────────────────────────────────────────────────────
+
+
+class TestSearchKnowledge:
+    @pytest.mark.asyncio
+    async def test_shared_concept_matches_contributing_repo(self, call_tool):
+        result = await call_tool("search_knowledge", {"query": "Payments", "repo": "repo-a"})
+        assert "Payments" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_unknown_repo_matches_nothing(self, call_tool):
+        result = await call_tool("search_knowledge", {"query": "Payments", "repo": "repo-c"})
+        assert _text(result) == "No results."
+
+
+# ── query_graph across the federation ──────────────────────────────────────
+
+
+class TestQueryGraph:
+    @pytest.mark.asyncio
+    async def test_who_implements_concept_across_repos(self, call_tool):
+        result = await call_tool(
+            "query_graph",
+            {
+                "cypher": (
+                    "MATCH (f:Function)-[:IMPLEMENTS]->(:Concept {name: 'Payments'}) "
+                    "RETURN f.repo ORDER BY f.repo"
+                )
+            },
+        )
+        assert json.loads(_text(result)) == [["repo-a"], ["repo-b"]]
+
+    @pytest.mark.asyncio
+    async def test_read_only_blocks_writes_on_supergraph(self, call_tool_readonly):
+        result = await call_tool_readonly(
+            "query_graph", {"cypher": "CREATE (n:Function {name: 'evil'})"}
+        )
+        assert _text(result).startswith("Error:")
+
+
+# ── blast_radius ───────────────────────────────────────────────────────────
+
+
+class TestBlastRadius:
+    @pytest.mark.asyncio
+    async def test_spans_workspace_without_repo(self, call_tool):
+        result = await call_tool("blast_radius", {"name": "process"})
+        affected = {n["name"] for n in json.loads(_text(result))["affected_nodes"]}
+        assert {"helper_a", "helper_b"} <= affected
+
+    @pytest.mark.asyncio
+    async def test_repo_arg_scopes_root(self, call_tool):
+        result = await call_tool("blast_radius", {"name": "process", "repo": "repo-b"})
+        affected = {n["name"] for n in json.loads(_text(result))["affected_nodes"]}
+        assert "helper_b" in affected
+        assert "helper_a" not in affected
+
+
+# ── graph_stats ────────────────────────────────────────────────────────────
+
+
+class TestGraphStats:
+    @pytest.mark.asyncio
+    async def test_repo_scoped_counts(self, call_tool):
+        total = json.loads(_text(await call_tool("graph_stats", {})))
+        scoped = json.loads(_text(await call_tool("graph_stats", {"repo": "repo-a"})))
+        assert scoped["repo"] == "repo-a"
+        assert 0 < scoped["nodes"] < total["nodes"]
+
+
+# ── context tools ──────────────────────────────────────────────────────────
+
+
+class TestContextScoping:
+    @pytest.mark.asyncio
+    async def test_load_file_context_with_repo(self, call_tool):
+        result = await call_tool(
+            "load_file_context", {"file_path": "app.py", "repo": "repo-a", "format": "json"}
+        )
+        payload = json.loads(_text(result))
+        names = json.dumps(payload)
+        assert "helper_a" in names
+        assert "helper_b" not in names
+
+
+# ── CLI source parsing (used by mcp --federate and aggregate) ──────────────
+
+
+class TestParseRepoSources:
+    def test_named_and_positional(self, tmp_path):
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        sources = _parse_repo_sources((f"backend={repo}", str(repo)))
+        assert sources == {"backend": str(repo), "myrepo": str(repo)}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -334,12 +334,12 @@ class TestCallToolSearchSymbols:
     @pytest.mark.asyncio
     async def test_passes_limit(self):
         await self.fx.call_tool_fn("search_symbols", {"query": "foo", "limit": 5})
-        self.fx.loader.search.assert_called_once_with("foo", limit=5)
+        self.fx.loader.search.assert_called_once_with("foo", limit=5, repo="")
 
     @pytest.mark.asyncio
     async def test_limit_defaults_to_twenty(self):
         await self.fx.call_tool_fn("search_symbols", {"query": "foo"})
-        self.fx.loader.search.assert_called_once_with("foo", limit=20)
+        self.fx.loader.search.assert_called_once_with("foo", limit=20, repo="")
 
 
 # ── call_tool — query_graph ───────────────────────────────────────────────────
@@ -458,12 +458,12 @@ class TestCallToolSearchKnowledge:
     @pytest.mark.asyncio
     async def test_passes_limit(self):
         await self.fx.call_tool_fn("search_knowledge", {"query": "auth", "limit": 5})
-        self.fx.loader.search_knowledge.assert_called_once_with("auth", limit=5)
+        self.fx.loader.search_knowledge.assert_called_once_with("auth", limit=5, repo="")
 
     @pytest.mark.asyncio
     async def test_limit_defaults_to_twenty(self):
         await self.fx.call_tool_fn("search_knowledge", {"query": "auth"})
-        self.fx.loader.search_knowledge.assert_called_once_with("auth", limit=20)
+        self.fx.loader.search_knowledge.assert_called_once_with("auth", limit=20, repo="")
 
 
 # ── call_tool — unknown tool ──────────────────────────────────────────────────
@@ -510,7 +510,7 @@ class TestCallToolBlastRadius:
             )
 
         mock_analyzer.blast_radius.assert_called_once_with(
-            "foo", file_path="bar.py", depth=2
+            "foo", file_path="bar.py", depth=2, repo=""
         )
         data = json.loads(result[0]["text"])
         assert data["name"] == "foo"
@@ -528,7 +528,7 @@ class TestCallToolBlastRadius:
         with patch("navegador.analysis.impact.ImpactAnalyzer", return_value=mock_analyzer):
             await self.fx.call_tool_fn("blast_radius", {"name": "x"})
 
-        mock_analyzer.blast_radius.assert_called_once_with("x", file_path="", depth=3)
+        mock_analyzer.blast_radius.assert_called_once_with("x", file_path="", depth=3, repo="")
 
 
 class TestCallToolMemoryList:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -127,9 +127,9 @@ class TestListTools:
         self.fx = _ServerFixture()
 
     @pytest.mark.asyncio
-    async def test_returns_twenty_three_tools(self):
+    async def test_returns_twenty_four_tools(self):
         tools = await self.fx.list_tools_fn()
-        assert len(tools) == 23
+        assert len(tools) == 24
 
     @pytest.mark.asyncio
     async def test_tool_names(self):
@@ -143,6 +143,7 @@ class TestListTools:
             "search_symbols",
             "query_graph",
             "graph_stats",
+            "list_repos",
             "get_rationale",
             "find_owners",
             "search_knowledge",


### PR DESCRIPTION
## Summary
The MCP server can now serve a federated workspace (built on #108's super-graph shape and #118's traversal fix):
- **Attach shards**: `navegador mcp --db <central>` binds an aggregated super-graph; new `--federate [NAME=]PATH` (repeatable) rolls repo graphs up into the bound store at startup via `SuperGraphAggregator`.
- **`repo` arg** on `load_file_context` / `load_function_context` / `load_class_context` (prefixes `file_path` with the namespace), `search_symbols` (filters `n.repo` in Cypher), `search_knowledge` (matches deduped nodes' `repos` membership), `blast_radius` (root scoping in `ImpactAnalyzer`), and `graph_stats` (per-namespace counts). Omit `repo` to span all repos.
- **`list_repos`** tool (24 tools now) so agents can discover namespaces before scoping; falls back to Repository nodes on single-repo graphs.
- **`query_graph`** spans the federation by nature; description documents the `repo`/`repos` properties. Read-only hardening (validate_cypher + complexity) untouched.
- Docs: README + MCP guide federation sections; stale "11 tools" counts corrected to 24.

## Test plan
- `tests/test_mcp_federation.py` — 12 tests, real embedded stores: two repos aggregated centrally, exercised through the MCP call_tool path. `list_repos`, span-vs-scope for search_symbols, knowledge scoping incl. unknown repo, "who implements Concept X across all repos" via query_graph, workspace-spanning + repo-scoped blast radius, per-repo graph_stats, context scoping, read-only blocking writes on the super-graph, `--federate` source parsing.
- 6 mocked assertions updated for the new `repo` kwarg; tool-count test 23 → 24.
- Full suite: 2799 passed, 53 skipped. Lint + format clean.

Closes #110