### PR TITLE
Add LRU shard load/unload with memory ceiling

### DIFF
--- a/navegador/cluster/shards.py
+++ b/navegador/cluster/shards.py
@@ -1,0 +1,173 @@
+"""
+Brain-scale shard load/unload — bounded resident memory for federated graphs.
+
+At company scale the meta-graph doesn't fit in memory as one resident set.
+ShardManager pages repo/namespace shards in and out: a shard's embedded
+store loads on first access, sits in an LRU order while resident, and is
+evicted (closed) when a configurable ceiling is exceeded. Closing a
+redislite-backed store persists its RDB, so eviction never loses state —
+the next access transparently reloads it.
+
+Ceilings (either or both):
+- ``max_resident`` — number of simultaneously loaded shards
+- ``max_memory_mb`` — summed ``INFO memory used_memory`` of resident shards
+
+Configured via ``.navegador/config.toml``::
+
+    [cluster]
+    max_resident_shards = 4
+    max_shard_memory_mb = 512
+
+Usage::
+
+    from navegador.cluster.shards import ShardManager
+
+    with ShardManager({"backend": "/path/a", "frontend": "/path/b"},
+                      max_resident=2) as shards:
+        result = shards.query("backend", "MATCH (n) RETURN count(n)")
+"""
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+from navegador.graph.store import GraphStore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_RESIDENT = 4
+
+
+class ShardManager:
+    """LRU-managed loader for a fleet of repo-local graph shards."""
+
+    def __init__(
+        self,
+        sources: dict[str, str | Path],
+        max_resident: int = DEFAULT_MAX_RESIDENT,
+        max_memory_mb: float | None = None,
+    ) -> None:
+        if max_resident < 1:
+            raise ValueError("max_resident must be at least 1")
+        self.sources = dict(sources)
+        self.max_resident = max_resident
+        self.max_memory_mb = max_memory_mb
+        # repo → GraphStore, in least-recently-used-first order
+        self._resident: OrderedDict[str, GraphStore] = OrderedDict()
+
+    @classmethod
+    def from_config(
+        cls, sources: dict[str, str | Path], project_dir: str | Path = "."
+    ) -> "ShardManager":
+        """
+        Build a manager with ceilings from ``.navegador/config.toml [cluster]``.
+
+        Missing file or keys fall back to defaults (max_resident_shards=4,
+        no memory ceiling).
+        """
+        max_resident = DEFAULT_MAX_RESIDENT
+        max_memory_mb = None
+        config_path = Path(project_dir) / ".navegador" / "config.toml"
+        if config_path.exists():
+            cluster = tomllib.loads(config_path.read_text(encoding="utf-8")).get("cluster", {})
+            max_resident = int(cluster.get("max_resident_shards", DEFAULT_MAX_RESIDENT))
+            if "max_shard_memory_mb" in cluster:
+                max_memory_mb = float(cluster["max_shard_memory_mb"])
+        return cls(sources, max_resident=max_resident, max_memory_mb=max_memory_mb)
+
+    # ── Access ────────────────────────────────────────────────────────────
+
+    def get(self, repo: str) -> GraphStore:
+        """
+        Return the shard's store, loading it on demand.
+
+        Touches the LRU order and enforces the resident ceilings (evicting
+        least-recently-used shards, never the one just requested).
+        """
+        if repo in self._resident:
+            self._resident.move_to_end(repo)
+            return self._resident[repo]
+
+        if repo not in self.sources:
+            raise KeyError(f"Unknown shard: {repo!r} (known: {sorted(self.sources)})")
+
+        path = self._graph_path(self.sources[repo])
+        store = GraphStore.sqlite(str(path))
+        self._resident[repo] = store
+        logger.info("Shard %s loaded from %s", repo, path)
+        self._enforce(keep=repo)
+        return store
+
+    def query(self, repo: str, cypher: str, params: dict[str, Any] | None = None) -> Any:
+        """Run a query against a shard, loading it if cold."""
+        return self.get(repo).query(cypher, params)
+
+    # ── Introspection ─────────────────────────────────────────────────────
+
+    def resident(self) -> list[str]:
+        """Resident shard names, least-recently-used first."""
+        return list(self._resident)
+
+    def memory_usage(self) -> dict[str, int]:
+        """Bytes of redis ``used_memory`` per resident shard."""
+        return {repo: self._used_memory(store) for repo, store in self._resident.items()}
+
+    # ── Eviction ──────────────────────────────────────────────────────────
+
+    def evict(self, repo: str) -> None:
+        """Close a shard's store (persists its RDB); no-op when not resident."""
+        store = self._resident.pop(repo, None)
+        if store is not None:
+            store.close()
+            logger.info("Shard %s evicted", repo)
+
+    def close_all(self) -> None:
+        """Evict every resident shard."""
+        for repo in list(self._resident):
+            self.evict(repo)
+
+    def __enter__(self) -> "ShardManager":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close_all()
+
+    # ── Internals ─────────────────────────────────────────────────────────
+
+    def _enforce(self, keep: str) -> None:
+        """Evict LRU shards until both ceilings hold (keep stays resident)."""
+        while len(self._resident) > self.max_resident:
+            self._evict_lru(keep)
+
+        if self.max_memory_mb is not None:
+            ceiling = self.max_memory_mb * 1024 * 1024
+            while len(self._resident) > 1 and self._total_memory() > ceiling:
+                self._evict_lru(keep)
+
+    def _evict_lru(self, keep: str) -> None:
+        for repo in self._resident:
+            if repo != keep:
+                self.evict(repo)
+                return
+
+    def _total_memory(self) -> int:
+        return sum(self._used_memory(store) for store in self._resident.values())
+
+    @staticmethod
+    def _used_memory(store: GraphStore) -> int:
+        try:
+            info = store._client.execute_command("INFO", "memory")
+            return int(info.get("used_memory", 0))
+        except Exception:
+            return 0
+
+    @staticmethod
+    def _graph_path(source: str | Path) -> Path:
+        path = Path(source)
+        if path.is_dir():
+            path = path / ".navegador" / "graph.db"
+        return path

--- a/navegador/config.py
+++ b/navegador/config.py
@@ -123,6 +123,9 @@ def init_project(
         "",
         "[cluster]",
         f"enabled = {'true' if cluster else 'false'}",
+        "# Shard eviction (federated workspaces) — ceilings for resident repo shards:",
+        "# max_resident_shards = 4",
+        "# max_shard_memory_mb = 512",
     ]
     config_path.write_text("\n".join(config_lines) + "\n", encoding="utf-8")
 

--- a/tests/test_shards.py
+++ b/tests/test_shards.py
@@ -1,0 +1,143 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Tests for navegador.cluster.shards — LRU shard load/unload under ceilings.
+
+Real embedded stores: three seeded shard RDB files are paged in and out by
+a ShardManager and the data is re-queried after eviction to prove persisted
+state survives the unload/reload cycle.
+"""
+
+import pytest
+
+from navegador.cluster.shards import ShardManager
+from navegador.graph.store import GraphStore
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def shard_sources(tmp_path_factory):
+    """Three repo roots, each with a seeded .navegador/graph.db RDB."""
+    sources = {}
+    for name in ("alpha", "beta", "gamma"):
+        root = tmp_path_factory.mktemp(f"shard-{name}")
+        store = GraphStore.sqlite(str(root / ".navegador" / "graph.db"))
+        store.create_node("Function", {"name": f"fn_{name}", "file_path": "app.py"})
+        store.close()
+        sources[name] = root
+    return sources
+
+
+def _fn_name(store: GraphStore) -> str:
+    result = store.query("MATCH (f:Function) RETURN f.name")
+    return result.result_set[0][0]
+
+
+# ── Load on demand + LRU eviction ──────────────────────────────────────────
+
+
+class TestLoadAndEvict:
+    def test_loads_on_demand_and_evicts_lru(self, shard_sources):
+        with ShardManager(shard_sources, max_resident=2) as shards:
+            assert shards.resident() == []
+
+            assert _fn_name(shards.get("alpha")) == "fn_alpha"
+            assert _fn_name(shards.get("beta")) == "fn_beta"
+            assert shards.resident() == ["alpha", "beta"]
+
+            # Third load exceeds the ceiling → alpha (LRU) is evicted
+            assert _fn_name(shards.get("gamma")) == "fn_gamma"
+            assert shards.resident() == ["beta", "gamma"]
+
+    def test_access_touches_lru_order(self, shard_sources):
+        with ShardManager(shard_sources, max_resident=2) as shards:
+            shards.get("alpha")
+            shards.get("beta")
+            shards.get("alpha")  # touch → beta is now least recently used
+            shards.get("gamma")
+            assert shards.resident() == ["alpha", "gamma"]
+
+    def test_evicted_shard_reloads_with_data_intact(self, shard_sources):
+        with ShardManager(shard_sources, max_resident=1) as shards:
+            shards.get("alpha")
+            shards.get("beta")  # evicts alpha
+            assert shards.resident() == ["beta"]
+            # Transparent reload — persisted state survived the eviction
+            assert _fn_name(shards.get("alpha")) == "fn_alpha"
+            assert shards.resident() == ["alpha"]
+
+    def test_query_routes_through_manager(self, shard_sources):
+        with ShardManager(shard_sources, max_resident=2) as shards:
+            result = shards.query("beta", "MATCH (f:Function) RETURN f.name")
+            assert result.result_set == [["fn_beta"]]
+
+    def test_unknown_shard_raises(self, shard_sources):
+        with ShardManager(shard_sources) as shards:
+            with pytest.raises(KeyError, match="delta"):
+                shards.get("delta")
+
+    def test_close_all(self, shard_sources):
+        shards = ShardManager(shard_sources, max_resident=3)
+        shards.get("alpha")
+        shards.get("beta")
+        shards.close_all()
+        assert shards.resident() == []
+
+    def test_max_resident_must_be_positive(self, shard_sources):
+        with pytest.raises(ValueError):
+            ShardManager(shard_sources, max_resident=0)
+
+
+# ── Memory ceiling ─────────────────────────────────────────────────────────
+
+
+class TestMemoryCeiling:
+    def test_memory_usage_reports_resident_shards(self, shard_sources):
+        with ShardManager(shard_sources, max_resident=2) as shards:
+            shards.get("alpha")
+            usage = shards.memory_usage()
+            assert set(usage) == {"alpha"}
+            assert usage["alpha"] > 0
+
+    def test_memory_ceiling_evicts_down(self, shard_sources):
+        # An empty redislite instance uses ~3MB — a 1MB ceiling forces
+        # eviction down to the minimum of one resident shard.
+        with ShardManager(shard_sources, max_resident=3, max_memory_mb=1) as shards:
+            shards.get("alpha")
+            shards.get("beta")
+            assert shards.resident() == ["beta"]
+
+    def test_no_ceiling_keeps_all_resident(self, shard_sources):
+        with ShardManager(shard_sources, max_resident=3) as shards:
+            for name in ("alpha", "beta", "gamma"):
+                shards.get(name)
+            assert len(shards.resident()) == 3
+
+
+# ── Config loading ─────────────────────────────────────────────────────────
+
+
+class TestFromConfig:
+    def test_reads_cluster_ceilings(self, tmp_path):
+        nav = tmp_path / ".navegador"
+        nav.mkdir()
+        (nav / "config.toml").write_text(
+            "[cluster]\nenabled = false\nmax_resident_shards = 2\nmax_shard_memory_mb = 64\n"
+        )
+        shards = ShardManager.from_config({}, project_dir=tmp_path)
+        assert shards.max_resident == 2
+        assert shards.max_memory_mb == 64.0
+
+    def test_defaults_without_config(self, tmp_path):
+        shards = ShardManager.from_config({}, project_dir=tmp_path)
+        assert shards.max_resident == 4
+        assert shards.max_memory_mb is None
+
+    def test_generated_config_parses(self, tmp_path):
+        import tomllib
+
+        from navegador.config import init_project
+
+        nav_dir = init_project(tmp_path)
+        config = tomllib.loads((nav_dir / "config.toml").read_text())
+        assert "cluster" in config  # commented shard keys must not break parsing


### PR DESCRIPTION
## Summary
Brain-scale load/unload for federated workspaces — the resident set no longer has to be the whole graph:
- **`navegador/cluster/shards.py`** — `ShardManager({repo: root_or_graph_path}, max_resident=4, max_memory_mb=None)`. `get(repo)` loads a shard's embedded store on demand and touches LRU order; `query(repo, cypher)` routes through it.
- **Eviction** — after each load, least-recently-used shards are closed while over the count ceiling or while the summed redis `INFO memory used_memory` of resident shards exceeds the memory ceiling (never evicting the shard just requested, minimum one resident). Closing a redislite store persists its RDB, so eviction loses nothing; the next `get()` transparently reloads.
- **Config** — `ShardManager.from_config(sources, project_dir)` reads `[cluster] max_resident_shards` / `max_shard_memory_mb` from `.navegador/config.toml`; `navegador init` now writes those keys (commented) with defaults.
- Introspection: `resident()` (LRU order), `memory_usage()` (bytes per shard), `evict()`, `close_all()`, context manager.

## Test plan
- 13 tests in `tests/test_shards.py` against real embedded stores: on-demand load, LRU eviction at the count ceiling, access-touches-order semantics, **eviction → transparent reload with data intact**, memory-ceiling eviction (1MB ceiling vs ~3MB/instance), memory_usage reporting, query routing, unknown-shard KeyError, close_all, config.toml ceilings + defaults, and generated config stays parseable.
- Full suite: 2800 passed, 53 skipped. Lint + format clean.

Closes #109