### PR TITLE
Update agent docs for federation, interchange, and shard modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,15 @@ AST + knowledge graph context engine for AI coding agents. Parses codebases into
 ```
 navegador/
   cli/           — Click commands (50+ subcommands)
-  graph/         — GraphStore + schema + queries + migrations + export
+  graph/         — GraphStore + schema + queries + migrations + export + conflict-kg/v1 interchange
   ingestion/     — RepoIngester + 13 language parsers + optimization
   context/       — ContextLoader + ContextBundle (JSON/markdown)
   mcp/           — MCP server with 24 tools + security hardening
   enrichment/    — FrameworkEnricher base + 8 framework enrichers
   analysis/      — impact, flow tracing, dead code, cycles, test mapping
   intelligence/  — semantic search, community detection, NLP, doc generation
-  cluster/       — Redis pub/sub, task queue, locking, sessions, messaging
+  cluster/       — Redis pub/sub, task queue, locking, sessions, messaging, shard load/unload
+  federation.py  — SuperGraphAggregator (repo graphs → central super-graph)
   sdk.py         — Python SDK (Navegador class)
   llm.py         — LLM provider abstraction (Anthropic, OpenAI, Ollama)
   vcs.py         — VCS abstraction (Git, Fossil)

--- a/bootstrap.md
+++ b/bootstrap.md
@@ -10,7 +10,8 @@ An agent given this document and a business requirement should be able to genera
 
 | Layer | What's there |
 |-------|-------------|
-| Graph store | `navegador/graph/` — GraphStore + schema + queries + migrations + export, backed by FalkorDB |
+| Graph store | `navegador/graph/` — GraphStore + schema + queries + migrations + export + conflict-kg/v1 interchange, backed by FalkorDB |
+| Federation | `navegador/federation.py` — SuperGraphAggregator: roll repo-local graphs into a central super-graph (namespacing, knowledge dedup) |
 | Ingestion | `navegador/ingestion/` — RepoIngester + 13 tree-sitter language parsers + optimization |
 | Context | `navegador/context/` — ContextLoader + ContextBundle (JSON/markdown output) |
 | MCP server | `navegador/mcp/` — 24 tools + security hardening, via the `mcp` Python SDK |
@@ -18,7 +19,7 @@ An agent given this document and a business requirement should be able to genera
 | Enrichment | `navegador/enrichment/` — FrameworkEnricher base + 8 framework enrichers, auto-discovered via `pkgutil` |
 | Analysis | `navegador/analysis/` — impact, flow tracing, dead code, cycles, test mapping |
 | Intelligence | `navegador/intelligence/` — semantic search, community detection, NLP, doc generation |
-| Cluster | `navegador/cluster/` — Redis pub/sub, task queue, locking, sessions, messaging |
+| Cluster | `navegador/cluster/` — Redis pub/sub, task queue, locking, sessions, messaging, LRU shard load/unload (`shards.py`) |
 | SDK | `navegador/sdk.py` — Python SDK (`Navegador` class) |
 | LLM | `navegador/llm.py` — provider abstraction (Anthropic, OpenAI, Ollama) |
 | VCS | `navegador/vcs.py` — Git + Fossil abstraction; `diff.py` (diff → graph impact), `churn.py` (behavioural coupling) |


### PR DESCRIPTION
## Summary
bootstrap.md is the canonical conventions doc and was missing the modules added this cycle:
- Graph store row/line now mentions the conflict-kg/v1 interchange (#107)
- New Federation row for `navegador/federation.py` (#108)
- Cluster row/line now mentions LRU shard load/unload (#109)
- CLAUDE.md package layout gains `federation.py` and matching notes

## Test plan
Docs-only; no runtime surface.