### PR TITLE
Skip missing tree-sitter grammars during ingest instead of aborting

### DIFF
--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -242,6 +242,13 @@ def ingest(
         for k, v in stats.items():
             table.add_row(k.capitalize(), str(v))
         console.print(table)
+        if ingester.unavailable_grammars:
+            console.print(
+                f"[yellow]Skipped {stats.get('grammar_skipped', 0)} file(s) — "
+                f"missing grammars: {', '.join(sorted(ingester.unavailable_grammars))}. "
+                "Install with pip install 'navegador\\[languages,iac]' or the "
+                "specific tree-sitter-<language> package.[/yellow]"
+            )
 
 
 # ── CODE: context / function / class ─────────────────────────────────────────

--- a/navegador/ingestion/optimization.py
+++ b/navegador/ingestion/optimization.py
@@ -381,12 +381,19 @@ class ParallelIngester:
             "classes": 0,
             "edges": 0,
             "skipped": 0,
+            "grammar_skipped": 0,
             "errors": 0,
         }
         lock = threading.Lock()
 
         def _process_file(source_file: Path) -> None:
             language = LANGUAGE_MAP[source_file.suffix]
+            with lock:
+                parser = self._ingester._get_parser(language)
+            if parser is None:
+                with lock:
+                    aggregated["grammar_skipped"] += 1
+                return
             rel_path = str(source_file.relative_to(repo_path))
             content_hash = _file_hash(source_file)
 
@@ -400,7 +407,6 @@ class ParallelIngester:
 
             parse_path, effective_root = self._ingester._maybe_redact_to_tmp(source_file, repo_path)
             try:
-                parser = self._ingester._get_parser(language)
                 file_stats = parser.parse_file(parse_path, effective_root, self._store)
                 self._ingester._store_file_hash(rel_path, content_hash)
                 with lock:

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -87,7 +87,9 @@ class RepoIngester:
     def __init__(self, store: GraphStore, redact: bool = False) -> None:
         self.store = store
         self.redact = redact
-        self._parsers: dict[str, "LanguageParser"] = {}
+        self._parsers: dict[str, "LanguageParser | None"] = {}
+        # language → install hint, populated when an optional grammar is missing
+        self.unavailable_grammars: dict[str, str] = {}
         if redact:
             from navegador.security import SensitiveContentDetector
 
@@ -135,11 +137,17 @@ class RepoIngester:
             "classes": 0,
             "edges": 0,
             "skipped": 0,
+            "grammar_skipped": 0,
         }
 
         for source_file in self._iter_source_files(repo_path):
             language = LANGUAGE_MAP.get(source_file.suffix)
             if not language:
+                continue
+
+            parser = self._get_parser(language)
+            if parser is None:
+                stats["grammar_skipped"] += 1
                 continue
 
             rel_path = str(source_file.relative_to(repo_path))
@@ -154,7 +162,6 @@ class RepoIngester:
 
             parse_path, effective_root = self._maybe_redact_to_tmp(source_file, repo_path)
             try:
-                parser = self._get_parser(language)
                 file_stats = parser.parse_file(parse_path, effective_root, self.store)
                 stats["files"] += 1
                 stats["functions"] += file_stats.get("functions", 0)
@@ -177,6 +184,14 @@ class RepoIngester:
         # Fossil mirror pass — if the repo is also a Fossil checkout (e.g. a
         # Git repo mirrored to/from Fossil), ingest wiki pages and tickets.
         self._ingest_fossil_mirror(repo_path, stats)
+
+        if self.unavailable_grammars:
+            logger.warning(
+                "Skipped %d file(s) with missing optional grammars: %s "
+                "(pip install 'navegador[languages,iac]' to parse everything)",
+                stats["grammar_skipped"],
+                ", ".join(sorted(self.unavailable_grammars)),
+            )
 
         logger.info(
             "Ingested %s: %d files, %d functions, %d classes, %d skipped",
@@ -402,75 +417,88 @@ class RepoIngester:
         stats["tickets"] = ticket_stats["tickets"]
         stats["edges"] += wiki_stats["edges"] + ticket_stats["edges"]
 
-    def _get_parser(self, language: str) -> "LanguageParser":
+    def _get_parser(self, language: str) -> "LanguageParser | None":
+        """
+        Return the parser for *language*, or None when its optional
+        tree-sitter grammar is not installed. A missing grammar is recorded
+        in ``unavailable_grammars`` and warned about once — never raised, so
+        one absent grammar cannot abort a whole ingest.
+        """
         if language not in self._parsers:
-            if language == "python":
-                from navegador.ingestion.python import PythonParser
-
-                self._parsers[language] = PythonParser()
-            elif language in ("typescript", "javascript"):
-                from navegador.ingestion.typescript import TypeScriptParser
-
-                self._parsers[language] = TypeScriptParser(language)
-            elif language == "go":
-                from navegador.ingestion.go import GoParser
-
-                self._parsers[language] = GoParser()
-            elif language == "rust":
-                from navegador.ingestion.rust import RustParser
-
-                self._parsers[language] = RustParser()
-            elif language == "java":
-                from navegador.ingestion.java import JavaParser
-
-                self._parsers[language] = JavaParser()
-            elif language == "kotlin":
-                from navegador.ingestion.kotlin import KotlinParser
-
-                self._parsers[language] = KotlinParser()
-            elif language == "csharp":
-                from navegador.ingestion.csharp import CSharpParser
-
-                self._parsers[language] = CSharpParser()
-            elif language == "php":
-                from navegador.ingestion.php import PHPParser
-
-                self._parsers[language] = PHPParser()
-            elif language == "ruby":
-                from navegador.ingestion.ruby import RubyParser
-
-                self._parsers[language] = RubyParser()
-            elif language == "swift":
-                from navegador.ingestion.swift import SwiftParser
-
-                self._parsers[language] = SwiftParser()
-            elif language == "c":
-                from navegador.ingestion.c import CParser
-
-                self._parsers[language] = CParser()
-            elif language == "cpp":
-                from navegador.ingestion.cpp import CppParser
-
-                self._parsers[language] = CppParser()
-            elif language == "hcl":
-                from navegador.ingestion.hcl import HCLParser
-
-                self._parsers[language] = HCLParser()
-            elif language == "puppet":
-                from navegador.ingestion.puppet import PuppetParser
-
-                self._parsers[language] = PuppetParser()
-            elif language == "bash":
-                from navegador.ingestion.bash import BashParser
-
-                self._parsers[language] = BashParser()
-            elif language == "markdown":
-                from navegador.ingestion.markdown import MarkdownParser
-
-                self._parsers[language] = MarkdownParser()
-            else:
-                raise ValueError(f"Unsupported language: {language}")
+            try:
+                self._parsers[language] = self._build_parser(language)
+            except ImportError as e:
+                self._parsers[language] = None
+                self.unavailable_grammars[language] = str(e)
+                logger.warning("Skipping %s files — %s", language, e)
         return self._parsers[language]
+
+    def _build_parser(self, language: str) -> "LanguageParser":
+        if language == "python":
+            from navegador.ingestion.python import PythonParser
+
+            return PythonParser()
+        elif language in ("typescript", "javascript"):
+            from navegador.ingestion.typescript import TypeScriptParser
+
+            return TypeScriptParser(language)
+        elif language == "go":
+            from navegador.ingestion.go import GoParser
+
+            return GoParser()
+        elif language == "rust":
+            from navegador.ingestion.rust import RustParser
+
+            return RustParser()
+        elif language == "java":
+            from navegador.ingestion.java import JavaParser
+
+            return JavaParser()
+        elif language == "kotlin":
+            from navegador.ingestion.kotlin import KotlinParser
+
+            return KotlinParser()
+        elif language == "csharp":
+            from navegador.ingestion.csharp import CSharpParser
+
+            return CSharpParser()
+        elif language == "php":
+            from navegador.ingestion.php import PHPParser
+
+            return PHPParser()
+        elif language == "ruby":
+            from navegador.ingestion.ruby import RubyParser
+
+            return RubyParser()
+        elif language == "swift":
+            from navegador.ingestion.swift import SwiftParser
+
+            return SwiftParser()
+        elif language == "c":
+            from navegador.ingestion.c import CParser
+
+            return CParser()
+        elif language == "cpp":
+            from navegador.ingestion.cpp import CppParser
+
+            return CppParser()
+        elif language == "hcl":
+            from navegador.ingestion.hcl import HCLParser
+
+            return HCLParser()
+        elif language == "puppet":
+            from navegador.ingestion.puppet import PuppetParser
+
+            return PuppetParser()
+        elif language == "bash":
+            from navegador.ingestion.bash import BashParser
+
+            return BashParser()
+        elif language == "markdown":
+            from navegador.ingestion.markdown import MarkdownParser
+
+            return MarkdownParser()
+        raise ValueError(f"Unsupported language: {language}")
 
 
 def _file_hash(path: Path) -> str:

--- a/tests/test_grammar_skip.py
+++ b/tests/test_grammar_skip.py
@@ -1,0 +1,80 @@
+"""Regression tests for #127 — a missing optional tree-sitter grammar must
+skip that language's files with a warning, never abort the ingest."""
+
+import logging
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from navegador.ingestion.optimization import ParallelIngester
+from navegador.ingestion.parser import RepoIngester
+
+_MISSING = ImportError("Install tree-sitter-bash: pip install tree-sitter-bash")
+
+
+def _repo(tmpdir: str) -> Path:
+    root = Path(tmpdir)
+    (root / "script.sh").write_text("echo hi\n", encoding="utf-8")
+    (root / "other.sh").write_text("echo bye\n", encoding="utf-8")
+    (root / "app.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
+    return root
+
+
+def _store():
+    store = MagicMock()
+    store.query.return_value = MagicMock(result_set=[])
+    return store
+
+
+class TestMissingGrammarSkips:
+    def test_ingest_completes_and_counts_skipped_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _repo(tmpdir)
+            ingester = RepoIngester(_store())
+            with patch("navegador.ingestion.bash.BashParser", side_effect=_MISSING):
+                stats = ingester.ingest(root)
+
+        assert stats["grammar_skipped"] == 2
+        assert stats["files"] == 1  # app.py still parsed
+        assert "bash" in ingester.unavailable_grammars
+        assert "tree-sitter-bash" in ingester.unavailable_grammars["bash"]
+
+    def test_warning_logged_once_per_language(self, caplog):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _repo(tmpdir)
+            ingester = RepoIngester(_store())
+            with (
+                patch("navegador.ingestion.bash.BashParser", side_effect=_MISSING),
+                caplog.at_level(logging.WARNING, logger="navegador.ingestion.parser"),
+            ):
+                ingester.ingest(root)
+
+        skip_warnings = [r for r in caplog.records if "Skipping bash files" in r.message]
+        assert len(skip_warnings) == 1
+
+    def test_get_parser_does_not_retry_missing_grammar(self):
+        ingester = RepoIngester(_store())
+        with patch("navegador.ingestion.bash.BashParser", side_effect=_MISSING) as ctor:
+            assert ingester._get_parser("bash") is None
+            assert ingester._get_parser("bash") is None
+            assert ctor.call_count == 1
+
+    def test_parallel_ingest_completes_and_counts_skipped_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _repo(tmpdir)
+            parallel = ParallelIngester(_store())
+            with patch("navegador.ingestion.bash.BashParser", side_effect=_MISSING):
+                stats = parallel.ingest_parallel(root, max_workers=2)
+
+        assert stats["grammar_skipped"] == 2
+        assert stats["errors"] == 0
+        assert stats["files"] == 1
+
+    def test_unsupported_language_still_raises(self):
+        ingester = RepoIngester(_store())
+        try:
+            ingester._get_parser("cobol")
+        except ValueError as e:
+            assert "Unsupported language" in str(e)
+        else:  # pragma: no cover
+            raise AssertionError("expected ValueError for unsupported language")


### PR DESCRIPTION
## Summary
- A missing optional tree-sitter grammar no longer aborts an ingest: `RepoIngester._get_parser` catches the `ImportError`, records the language in `unavailable_grammars` (with the install hint), warns once, and returns `None`.
- Both ingest loops (`RepoIngester.ingest` and `ParallelIngester.ingest_parallel`) fetch the parser before any per-file work and count skipped files under a new `grammar_skipped` stat.
- End-of-run one-line warning lists skipped languages; `navegador ingest` prints the same summary with the `pip install 'navegador[languages,iac]'` hint.
- Behavior is now uniform for all 15 tree-sitter-backed languages (bash previously aborted while hcl degraded gracefully).

## Test plan
- New `tests/test_grammar_skip.py`: forced `ImportError` on the bash grammar → ingest completes, `.py` still parsed, both `.sh` files counted as `grammar_skipped`, warning logged exactly once, constructor not retried per file; same for `ParallelIngester`; unsupported language still raises `ValueError`.
- Full suite: 2870 passed locally.

Fixes #127