### PR TITLE
Page export past the 10k resultset cap; export named central graphs

### DIFF
--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -1007,10 +1007,21 @@ def planopticon_ingest(path: str, input_type: str, source: str, as_json: bool, d
     help="Export format: jsonl (legacy) or conflict-kg (canonical conflict-kg/v1; "
     "writes SQLite for .db/.sqlite outputs, JSON otherwise).",
 )
+@click.option(
+    "--graph",
+    "graph_name",
+    default="",
+    metavar="NAME",
+    help="Named graph within the connected FalkorDB to export "
+    "(e.g. navegador_myrepo from a federated workspace ingest). "
+    "Defaults to the main 'navegador' graph.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Output stats as JSON.")
-def export_cmd(output: str, db: str, fmt: str, as_json: bool):
+def export_cmd(output: str, db: str, fmt: str, graph_name: str, as_json: bool):
     """Export the graph to a text-based JSONL file (git-friendly)."""
     store = _get_store(db)
+    if graph_name:
+        store = store.with_graph(graph_name)
     if fmt == "conflict-kg":
         from navegador.graph.interchange import export_conflict_kg
 

--- a/navegador/graph/export.py
+++ b/navegador/graph/export.py
@@ -14,7 +14,7 @@ import json
 import logging
 from pathlib import Path
 
-from navegador.graph.store import GraphStore
+from navegador.graph.store import GraphStore, paged_query
 
 logger = logging.getLogger(__name__)
 
@@ -94,9 +94,11 @@ def import_graph(store: GraphStore, input_path: str | Path, clear: bool = True) 
 
 def _export_nodes(store: GraphStore) -> list[dict]:
     """Export all nodes with their labels and properties."""
-    result = store.query("MATCH (n) RETURN labels(n)[0] AS label, properties(n) AS props")
+    rows = paged_query(
+        store, "MATCH (n) RETURN labels(n)[0] AS label, properties(n) AS props ORDER BY id(n)"
+    )
     nodes = []
-    for row in result.result_set or []:
+    for row in rows:
         label = row[0]
         props = row[1] if isinstance(row[1], dict) else {}
         nodes.append({"kind": "node", "label": label, "props": props})
@@ -105,15 +107,17 @@ def _export_nodes(store: GraphStore) -> list[dict]:
 
 def _export_edges(store: GraphStore) -> list[dict]:
     """Export all edges with type and endpoint identifiers."""
-    result = store.query(
+    rows = paged_query(
+        store,
         "MATCH (a)-[r]->(b) "
         "RETURN type(r) AS type, labels(a)[0] AS from_label, "
         "a.name AS from_name, coalesce(a.file_path, a.path, '') AS from_path, "
         "labels(b)[0] AS to_label, b.name AS to_name, "
-        "coalesce(b.file_path, b.path, '') AS to_path"
+        "coalesce(b.file_path, b.path, '') AS to_path "
+        "ORDER BY id(r)",
     )
     edges = []
-    for row in result.result_set or []:
+    for row in rows:
         edges.append(
             {
                 "kind": "edge",

--- a/navegador/graph/interchange.py
+++ b/navegador/graph/interchange.py
@@ -24,7 +24,7 @@ import logging
 import sqlite3
 from pathlib import Path
 
-from navegador.graph.store import GraphStore
+from navegador.graph.store import GraphStore, paged_query
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +47,11 @@ def collect_graph(store: GraphStore) -> tuple[list[dict], list[dict]]:
     Returns:
         (nodes, edges) — deterministically ordered, edges referencing node ids.
     """
-    result = store.query("MATCH (n) RETURN id(n) AS iid, labels(n)[0] AS label, properties(n)")
+    rows = paged_query(
+        store, "MATCH (n) RETURN id(n) AS iid, labels(n)[0] AS label, properties(n) ORDER BY iid"
+    )
     raw_nodes = []
-    for row in result.result_set or []:
+    for row in rows:
         iid, label = row[0], row[1] or "default"
         props = dict(row[2]) if isinstance(row[2], dict) else {}
         name = str(props.pop("name", "") or "")
@@ -70,11 +72,13 @@ def collect_graph(store: GraphStore) -> tuple[list[dict], list[dict]]:
         id_map[iid] = node_id
         nodes.append({"id": node_id, "name": name, "type": label, "props": props})
 
-    result = store.query(
-        "MATCH (a)-[r]->(b) RETURN id(a) AS src, id(b) AS tgt, type(r) AS type, properties(r)"
+    rows = paged_query(
+        store,
+        "MATCH (a)-[r]->(b) RETURN id(a) AS src, id(b) AS tgt, type(r) AS type, properties(r) "
+        "ORDER BY id(r)",
     )
     edges = []
-    for row in result.result_set or []:
+    for row in rows:
         src, tgt = id_map.get(row[0]), id_map.get(row[1])
         if src is None or tgt is None:
             continue

--- a/navegador/graph/store.py
+++ b/navegador/graph/store.py
@@ -20,14 +20,18 @@ class GraphStore:
     """
     Wraps a FalkorDB graph, providing helpers for navegador node/edge operations.
 
-    The underlying graph is named "navegador" within the database.
+    The underlying graph is named "navegador" within the database by default;
+    pass ``graph_name`` (or use :meth:`with_graph`) to target another named
+    graph in the same database — e.g. the per-repo ``navegador_<name>`` graphs
+    written by federated workspace ingest.
     """
 
     GRAPH_NAME = "navegador"
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, graph_name: str | None = None) -> None:
         self._client = client
-        self._graph = client.select_graph(self.GRAPH_NAME)
+        self.graph_name = graph_name or self.GRAPH_NAME
+        self._graph = client.select_graph(self.graph_name)
 
     # ── Constructors ──────────────────────────────────────────────────────────
 
@@ -75,6 +79,24 @@ class GraphStore:
     def query(self, cypher: str, params: dict[str, Any] | None = None) -> Any:
         """Execute a raw Cypher query and return the result."""
         return self._graph.query(cypher, params or {})
+
+    def with_graph(self, graph_name: str) -> "GraphStore":
+        """
+        Return a GraphStore for another named graph in the same database.
+
+        Shares the underlying client — closing either store closes both.
+        """
+        return GraphStore(self._client, graph_name)
+
+    def list_graphs(self) -> list[str]:
+        """Names of all graphs resident in the connected database."""
+        lister = getattr(self._client, "list_graphs", None)
+        if callable(lister):
+            return [str(g) for g in lister()]
+        conn = getattr(self._client, "connection", None)
+        if conn is not None:
+            return [str(g) for g in conn.execute_command("GRAPH.LIST")]
+        return []
 
     def close(self) -> None:
         """Close the underlying client if it exposes a close method."""
@@ -164,3 +186,27 @@ class GraphStore:
     def edge_count(self) -> int:
         result = self.query("MATCH ()-[r]->() RETURN count(r) AS c")
         return result.result_set[0][0] if result.result_set else 0
+
+
+# FalkorDB's default RESULTSET_SIZE silently caps a single query at 10,000
+# rows; readers that need the full graph must page below that ceiling.
+_DEFAULT_PAGE_SIZE = 5000
+
+
+def paged_query(store: GraphStore, cypher: str, page_size: int | None = None) -> list:
+    """
+    Run *cypher* in SKIP/LIMIT pages and return all rows.
+
+    The query must have a deterministic order (ORDER BY) so pages don't
+    overlap or miss rows.
+    """
+    size = page_size or _DEFAULT_PAGE_SIZE
+    rows: list = []
+    offset = 0
+    while True:
+        result = store.query(f"{cypher} SKIP {offset} LIMIT {size}")
+        page = result.result_set or []
+        rows.extend(page)
+        if len(page) < size:
+            return rows
+        offset += size

--- a/tests/test_export_pagination.py
+++ b/tests/test_export_pagination.py
@@ -1,0 +1,129 @@
+"""Regression tests for #129 — export must page past FalkorDB's default
+RESULTSET_SIZE (10k rows/query) and be able to target a named central graph.
+
+Run against real embedded FalkorDB stores (no graph mocks)."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from navegador.cli.commands import main
+from navegador.graph.export import export_graph
+from navegador.graph.interchange import collect_graph
+from navegador.graph.store import GraphStore, paged_query
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("export-pg") / "graph.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture(autouse=True)
+def _clean(store):
+    store.clear()
+
+
+def _seed(store, count: int) -> None:
+    for i in range(count):
+        store.create_node("Function", {"name": f"fn_{i:03d}", "file_path": "app.py"})
+    for i in range(count - 1):
+        store.create_edge(
+            "Function",
+            {"name": f"fn_{i:03d}", "file_path": "app.py"},
+            "CALLS",
+            "Function",
+            {"name": f"fn_{i + 1:03d}", "file_path": "app.py"},
+        )
+
+
+# ── paged_query ────────────────────────────────────────────────────────────
+
+
+class TestPagedQuery:
+    def test_collects_all_rows_across_pages(self, store):
+        _seed(store, 7)
+        rows = paged_query(store, "MATCH (n:Function) RETURN n.name ORDER BY n.name", page_size=3)
+        assert [r[0] for r in rows] == [f"fn_{i:03d}" for i in range(7)]
+
+    def test_exact_page_boundary(self, store):
+        _seed(store, 6)
+        rows = paged_query(store, "MATCH (n:Function) RETURN n.name ORDER BY n.name", page_size=3)
+        assert len(rows) == 6
+
+    def test_empty_graph(self, store):
+        assert paged_query(store, "MATCH (n) RETURN n.name ORDER BY n.name") == []
+
+
+# ── Exporters page below the resultset ceiling ────────────────────────────
+
+
+class TestExportPagination:
+    def test_collect_graph_beyond_page_size(self, store, monkeypatch):
+        monkeypatch.setattr("navegador.graph.store._DEFAULT_PAGE_SIZE", 3)
+        _seed(store, 8)
+        nodes, edges = collect_graph(store)
+        names = {n["name"] for n in nodes if n["type"] == "Function"}
+        assert names == {f"fn_{i:03d}" for i in range(8)}
+        assert len(edges) == 7
+
+    def test_export_graph_beyond_page_size(self, store, monkeypatch, tmp_path):
+        monkeypatch.setattr("navegador.graph.store._DEFAULT_PAGE_SIZE", 3)
+        _seed(store, 8)
+        stats = export_graph(store, tmp_path / "out.jsonl")
+        assert stats["nodes"] == 8
+        assert stats["edges"] == 7
+
+
+# ── Named central graphs ───────────────────────────────────────────────────
+
+
+class TestNamedGraph:
+    def test_with_graph_isolates_named_graph(self, store):
+        _seed(store, 2)
+        named = store.with_graph("navegador_sidecar")
+        named.clear()
+        named.create_node("Function", {"name": "only_here", "file_path": "x.py"})
+
+        assert named.graph_name == "navegador_sidecar"
+        assert named.node_count() == 1
+        main_names = paged_query(store, "MATCH (n:Function) RETURN n.name ORDER BY n.name")
+        assert ["only_here"] not in main_names
+
+    def test_list_graphs_sees_named_graph(self, store):
+        named = store.with_graph("navegador_listed")
+        named.create_node("Concept", {"name": "marker"})
+        assert "navegador_listed" in store.list_graphs()
+
+    def test_export_cli_targets_named_graph(self, store, tmp_path):
+        _seed(store, 3)  # main graph: 3 nodes — must NOT be exported
+        named = store.with_graph("navegador_cli")
+        named.clear()
+        named.create_node("Function", {"name": "central_fn", "file_path": "y.py"})
+
+        out = tmp_path / "named.json"
+        runner = CliRunner()
+        with patch("navegador.cli.commands._get_store", return_value=store):
+            result = runner.invoke(
+                main,
+                [
+                    "export",
+                    str(out),
+                    "--format",
+                    "conflict-kg",
+                    "--graph",
+                    "navegador_cli",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        stats = json.loads(result.output)
+        assert stats["nodes"] == 1
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["nodes"][0]["name"] == "central_fn"


### PR DESCRIPTION
## Summary
- The 10k truncation was FalkorDB's default `RESULTSET_SIZE` (10,000 rows per query) silently clipping the export `MATCH` queries — the exporter itself had no cap. Both exporters (`collect_graph` for conflict-kg and the legacy JSONL `export_graph`) now page with `ORDER BY id(...) SKIP/LIMIT` batches through a shared `paged_query` helper, so graphs of any size export fully. No `--limit` knob was added: a truncation option invites exactly the silently-partial exports this issue is about.
- `GraphStore` gains a `graph_name` constructor param, `with_graph(name)` (same client, different named graph), and `list_graphs()`.
- `navegador export --graph navegador_client-cove` targets a named graph resident in the connected Redis/FalkorDB, unblocking per-repo central-graph exports for `aggregate-brains.py --code-kg`.

## Test plan
- New `tests/test_export_pagination.py` against real embedded stores: paged_query across pages incl. exact page boundary and empty graph; both exporters with page size forced to 3 over an 8-node graph return everything; `with_graph` isolation; `list_graphs`; CLI `--graph` exports only the named graph's content.
- Full suite: 2873 passed locally.

Fixes #129
Sibling of #124 (aggregate roll-up will reuse `with_graph`).