### PR TITLE
Prune nested git repos and skip dirs before descending in ingest walks

### DIFF
--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -26,6 +26,7 @@ Infrastructure-as-Code:
 
 import hashlib
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -169,6 +170,10 @@ class RepoIngester:
                 stats["edges"] += file_stats.get("edges", 0)
 
                 self._store_file_hash(rel_path, content_hash)
+                if stats["files"] % 1000 == 0:
+                    logger.info(
+                        "Ingest progress %s: %d files parsed", repo_path.name, stats["files"]
+                    )
             except Exception:
                 logger.exception("Failed to parse %s", source_file)
             finally:
@@ -304,8 +309,9 @@ class RepoIngester:
         tmp_file.write_text(redacted, encoding="utf-8")
         return tmp_file, tmp_root
 
-    def _iter_source_files(self, repo_path: Path):
-        skip_dirs = {
+    # Directories never entered during the repo walk.
+    _SKIP_DIRS = frozenset(
+        {
             ".git",
             ".venv",
             "venv",
@@ -318,10 +324,38 @@ class RepoIngester:
             "vendor",  # Go modules cache
             ".gradle",  # Gradle cache
         }
-        for path in repo_path.rglob("*"):
-            if path.is_file() and path.suffix in LANGUAGE_MAP:
-                if not any(part in skip_dirs for part in path.parts):
+    )
+
+    def _walk_files(self, repo_path: Path):
+        """
+        Walk *repo_path* yielding files, pruning skipped directories BEFORE
+        descending into them (rglob enumerated everything first, which made
+        metarepo roots with huge vendored trees appear to hang — #128).
+
+        A subdirectory containing ``.git`` (directory, or file for worktrees
+        and submodule pointers) is another repository: it is a boundary and
+        is never entered.
+        """
+        for dirpath, dirnames, filenames in os.walk(repo_path):
+            current = Path(dirpath)
+            kept = []
+            for d in dirnames:
+                if d in self._SKIP_DIRS:
+                    continue
+                if (current / d / ".git").exists():
+                    logger.info("Skipping nested git repository: %s", current / d)
+                    continue
+                kept.append(d)
+            dirnames[:] = kept
+            for fname in filenames:
+                path = current / fname
+                if path.is_file():  # excludes broken symlinks, FIFOs, sockets
                     yield path
+
+    def _iter_source_files(self, repo_path: Path):
+        for path in self._walk_files(repo_path):
+            if path.suffix in LANGUAGE_MAP:
+                yield path
 
     def _ingest_ansible(self, repo_path: Path, stats: dict[str, int], incremental: bool) -> None:
         """Detect and parse Ansible YAML files (playbooks, roles, tasks)."""
@@ -331,41 +365,8 @@ class RepoIngester:
 
         ansible_parser: AnsibleParser | None = None
 
-        for path in repo_path.rglob("*.yml"):
-            if not path.is_file():
-                continue
-            if any(part in (".git", ".venv", "venv", "node_modules") for part in path.parts):
-                continue
-            if not is_ansible_file(path, repo_path):
-                continue
-
-            rel_path = str(path.relative_to(repo_path))
-            content_hash = _file_hash(path)
-
-            if incremental and self._file_unchanged(rel_path, content_hash):
-                stats["skipped"] += 1
-                continue
-
-            if incremental:
-                self._clear_file_subgraph(rel_path)
-
-            if ansible_parser is None:
-                ansible_parser = AnsibleParser()
-            try:
-                file_stats = ansible_parser.parse_file(path, repo_path, self.store)
-                stats["files"] += 1
-                stats["functions"] += file_stats.get("functions", 0)
-                stats["classes"] += file_stats.get("classes", 0)
-                stats["edges"] += file_stats.get("edges", 0)
-                self._store_file_hash(rel_path, content_hash)
-            except Exception:
-                logger.exception("Failed to parse Ansible file %s", path)
-
-        # Also check .yaml extension
-        for path in repo_path.rglob("*.yaml"):
-            if not path.is_file():
-                continue
-            if any(part in (".git", ".venv", "venv", "node_modules") for part in path.parts):
+        for path in self._walk_files(repo_path):
+            if path.suffix not in (".yml", ".yaml"):
                 continue
             if not is_ansible_file(path, repo_path):
                 continue

--- a/tests/test_nested_repo_walk.py
+++ b/tests/test_nested_repo_walk.py
@@ -1,0 +1,98 @@
+"""Regression tests for #128 — the ingest file walk must treat nested git
+repositories as boundaries (never descend into them) and prune skip dirs
+before entering, so metarepo roots cannot hang workspace ingest."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from navegador.ingestion.parser import RepoIngester
+
+
+def _store():
+    store = MagicMock()
+    store.query.return_value = MagicMock(result_set=[])
+    return store
+
+
+def _metarepo(tmpdir: str) -> Path:
+    """A repo root containing its own code plus a nested git clone."""
+    root = Path(tmpdir)
+    (root / ".git").mkdir()
+    (root / "own.py").write_text("def mine():\n    return 1\n", encoding="utf-8")
+
+    nested = root / "vendored-clone"
+    (nested / ".git").mkdir(parents=True)
+    (nested / "theirs.py").write_text("def theirs():\n    return 2\n", encoding="utf-8")
+    (nested / "deep").mkdir()
+    (nested / "deep" / "more.py").write_text("def more():\n    return 3\n", encoding="utf-8")
+    return root
+
+
+class TestNestedRepoBoundary:
+    def test_nested_git_dir_is_not_descended(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _metarepo(tmpdir)
+            files = {p.name for p in RepoIngester(_store())._iter_source_files(root)}
+        assert files == {"own.py"}
+
+    def test_nested_git_file_is_boundary_too(self):
+        """.git can be a file (worktrees, submodule pointers) — still a boundary."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "own.py").write_text("x = 1\n", encoding="utf-8")
+            worktree = root / "linked-worktree"
+            worktree.mkdir()
+            (worktree / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+            (worktree / "wt.py").write_text("y = 2\n", encoding="utf-8")
+
+            files = {p.name for p in RepoIngester(_store())._iter_source_files(root)}
+        assert files == {"own.py"}
+
+    def test_ingest_root_with_its_own_git_is_still_ingested(self):
+        """Only *nested* repos are boundaries — the ingest root itself has .git."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _metarepo(tmpdir)
+            stats = RepoIngester(_store()).ingest(root)
+        assert stats["files"] == 1
+
+    def test_skip_dirs_are_pruned(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "app.py").write_text("a = 1\n", encoding="utf-8")
+            for skip in ("node_modules", "dist", ".venv", "vendor"):
+                d = root / skip / "sub"
+                d.mkdir(parents=True)
+                (d / "junk.py").write_text("j = 1\n", encoding="utf-8")
+
+            files = {p.name for p in RepoIngester(_store())._iter_source_files(root)}
+        assert files == {"app.py"}
+
+    def test_skip_dir_name_in_ancestors_of_root_does_not_hide_repo(self):
+        """A repo living under a directory *named* like a skip dir (e.g.
+        /home/x/build/myrepo) must still be ingested — only dirs below the
+        ingest root are pruned. The old parts-based filter got this wrong."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir) / "build" / "myrepo"
+            repo.mkdir(parents=True)
+            (repo / "app.py").write_text("a = 1\n", encoding="utf-8")
+
+            files = {p.name for p in RepoIngester(_store())._iter_source_files(repo)}
+        assert files == {"app.py"}
+
+    def test_ansible_pass_respects_nested_repo_boundary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "playbook.yml").write_text(
+                "---\n- hosts: all\n  tasks:\n    - name: ping\n      ping:\n", encoding="utf-8"
+            )
+            nested = root / "clone"
+            (nested / ".git").mkdir(parents=True)
+            (nested / "playbook.yml").write_text(
+                "---\n- hosts: all\n  tasks:\n    - name: pong\n      ping:\n", encoding="utf-8"
+            )
+
+            ingester = RepoIngester(_store())
+            stats = {"files": 0, "functions": 0, "classes": 0, "edges": 0, "skipped": 0}
+            ingester._ingest_ansible(root, stats, incremental=False)
+        assert stats["files"] == 1


### PR DESCRIPTION
## Summary
- `RepoIngester._iter_source_files` used `Path.rglob("*")` and filtered *after* enumeration — it physically descended into `.git`, `node_modules`, and any nested clone (e.g. the 14GB vendored vscode tree) before the skip-dir check discarded entries. On a metarepo root that's millions of directory entries at near-zero CPU: the observed hang.
- The walk is now `os.walk` with **in-place pruning**: skip dirs are never entered, and any subdirectory containing `.git` (dir, or file for worktrees/submodule pointers) is treated as a repository boundary and never entered. The ingest root itself having `.git` is of course still ingested.
- The Ansible YAML pass now shares the same pruned walk (it previously re-globbed the whole tree twice with a smaller skip set).
- Progress: INFO log every 1000 parsed files so long ingests are diagnosable.
- Bonus latent bug fixed: the old parts-based filter matched skip-dir names in the ingest root's *ancestors*, so a repo at e.g. `~/build/myrepo` was silently skipped entirely.

Deliberately including vendored clones (authored/full modes) is #130; here nested repos are always boundary-stopped, restoring bounded completion for `workspace ingest`.

## Test plan
- New `tests/test_nested_repo_walk.py`: nested `.git` dir and `.git` file forms are boundaries; ingest root with its own `.git` still ingested; skip dirs pruned; ancestor-named-like-skip-dir repo still ingested; Ansible pass respects the boundary.
- Full suite: 2876 passed locally.

Fixes #128