### PR TITLE
aggregate: roll up central-resident named graphs; --graph super-graph target

### DIFF
--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -1092,20 +1092,35 @@ def _parse_repo_sources(args: tuple[str, ...]) -> dict[str, str]:
 @main.command("aggregate")
 @click.argument("repos", nargs=-1, required=True)
 @DB_OPTION
+@click.option(
+    "--graph",
+    "graph_name",
+    default="",
+    metavar="NAME",
+    help="Target super-graph name within the connected FalkorDB "
+    "(e.g. navegador_supergraph), so per-repo shards and the rollup "
+    "coexist. Defaults to the main 'navegador' graph.",
+)
 @click.option("--clear", is_flag=True, help="Wipe the central graph before aggregating.")
 @click.option("--json", "as_json", is_flag=True, help="Output stats as JSON.")
-def aggregate_cmd(repos: tuple[str, ...], db: str, clear: bool, as_json: bool):
+def aggregate_cmd(repos: tuple[str, ...], db: str, graph_name: str, clear: bool, as_json: bool):
     """
     Roll repo-local graphs up into a central super-graph.
 
-    Each REPO is a repo root (containing .navegador/graph.db) or a graph
-    file, optionally prefixed NAME= to set the repo namespace (defaults to
-    the directory basename). The --db graph is the central target.
+    Each REPO is a repo root (containing .navegador/graph.db), a graph
+    file, or the name of a graph already resident in the connected
+    FalkorDB (<name> or navegador_<name>, as written by
+    `workspace ingest --mode federated`), optionally prefixed NAME= to set
+    the repo namespace (defaults to the directory basename). The --db (or
+    --graph) graph is the central target.
     """
     from navegador.federation import SuperGraphAggregator
 
     sources = _parse_repo_sources(repos)
-    aggregator = SuperGraphAggregator(_get_store(db))
+    store = _get_store(db)
+    if graph_name:
+        store = store.with_graph(graph_name)
+    aggregator = SuperGraphAggregator(store)
     summary = aggregator.aggregate(sources, clear=clear)
 
     if as_json:

--- a/navegador/federation.py
+++ b/navegador/federation.py
@@ -66,7 +66,10 @@ class SuperGraphAggregator:
 
         Args:
             sources: repo name → open GraphStore, repo root directory
-                (resolves ``<root>/.navegador/graph.db``), or graph file path.
+                (resolves ``<root>/.navegador/graph.db``), a graph file path,
+                or the name of a graph already resident in the central
+                database (``<name>`` or ``navegador_<name>``, as written by
+                ``workspace ingest --mode federated``).
             clear: If True, wipe the central graph first.
 
         Returns:
@@ -82,8 +85,22 @@ class SuperGraphAggregator:
                 if isinstance(source, GraphStore):
                     store = source
                 else:
-                    opened = GraphStore.sqlite(str(resolve_graph_path(source)))
-                    store = opened
+                    try:
+                        opened = GraphStore.sqlite(str(resolve_graph_path(source)))
+                        store = opened
+                    except FileNotFoundError:
+                        # Not a local graph — try graphs resident in the
+                        # central database. Shares the central client, so it
+                        # must not be closed here.
+                        resident = self._resolve_central_graph(str(source))
+                        if resident is None:
+                            raise FileNotFoundError(
+                                f"No graph found at {source} — run `navegador ingest` "
+                                f"first, or pass the name of a graph resident in the "
+                                f"connected database (no '{source}' or "
+                                f"'navegador_{source}' graph found there)"
+                            ) from None
+                        store = resident
                 summary[name] = self.aggregate_repo(name, store)
             except Exception as exc:  # noqa: BLE001
                 logger.error("Aggregation failed for repo %s: %s", name, exc)
@@ -92,6 +109,24 @@ class SuperGraphAggregator:
                 if opened is not None:
                     opened.close()
         return summary
+
+    def _resolve_central_graph(self, name: str) -> GraphStore | None:
+        """
+        Resolve *name* to a graph resident in the central database.
+
+        Tries the exact name first, then the ``navegador_<name>`` convention
+        used by federated workspace ingest. Returns None when neither exists.
+        """
+        resident = set(self.central.list_graphs())
+        for candidate in (name, f"navegador_{name}"):
+            if candidate in resident:
+                if candidate == self.central.graph_name:
+                    raise ValueError(
+                        f"Source graph {candidate!r} is the aggregation target itself — "
+                        f"aggregate into a different graph (e.g. --graph navegador_supergraph)"
+                    )
+                return self.central.with_graph(candidate)
+        return None
 
     def aggregate_repo(self, repo: str, source: GraphStore) -> dict[str, int]:
         """

--- a/tests/test_federation_central.py
+++ b/tests/test_federation_central.py
@@ -1,0 +1,122 @@
+"""Regression tests for #124 — aggregate must roll up per-repo graphs that
+live as named graphs in the connected (central) FalkorDB, matching the
+navegador_<name> convention of `workspace ingest --mode federated`.
+
+Run against a real embedded FalkorDB with multiple named graphs."""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from navegador.cli.commands import main
+from navegador.federation import SuperGraphAggregator
+from navegador.graph.store import GraphStore
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def central(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("central") / "graph.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture(autouse=True)
+def _clean(central):
+    central.clear()
+    for shard in ("navegador_repoa", "navegador_repob"):
+        central.with_graph(shard).clear()
+
+
+def _seed_shard(central, graph_name: str, fn_name: str) -> None:
+    shard = central.with_graph(graph_name)
+    shard.create_node("File", {"name": "app.py", "path": "app.py", "language": "python"})
+    shard.create_node("Function", {"name": fn_name, "file_path": "app.py"})
+    shard.create_node("Concept", {"name": "SharedConcept", "description": "x"})
+    shard.create_edge(
+        "File", {"path": "app.py"}, "CONTAINS", "Function", {"name": fn_name, "file_path": "app.py"}
+    )
+
+
+def _central_function_repos(central) -> dict[str, str]:
+    result = central.query("MATCH (f:Function) RETURN f.name, f.repo ORDER BY f.name")
+    return {row[0]: row[1] for row in result.result_set or []}
+
+
+# ── Name resolution ────────────────────────────────────────────────────────
+
+
+class TestCentralResidentSources:
+    def test_bare_name_resolves_navegador_prefixed_graph(self, central):
+        _seed_shard(central, "navegador_repoa", "alpha_fn")
+        summary = SuperGraphAggregator(central).aggregate({"repoa": "repoa"})
+
+        assert "error" not in summary["repoa"]
+        assert summary["repoa"]["nodes"] == 3
+        assert _central_function_repos(central) == {"alpha_fn": "repoa"}
+
+    def test_exact_graph_name_also_resolves(self, central):
+        _seed_shard(central, "navegador_repoa", "alpha_fn")
+        summary = SuperGraphAggregator(central).aggregate({"repoa": "navegador_repoa"})
+        assert "error" not in summary["repoa"]
+
+    def test_multiple_shards_roll_up_with_knowledge_dedup(self, central):
+        _seed_shard(central, "navegador_repoa", "alpha_fn")
+        _seed_shard(central, "navegador_repob", "beta_fn")
+        summary = SuperGraphAggregator(central).aggregate({"repoa": "repoa", "repob": "repob"})
+
+        assert summary["repoa"]["deduped"] == 1
+        assert summary["repob"]["deduped"] == 1
+        assert _central_function_repos(central) == {"alpha_fn": "repoa", "beta_fn": "repob"}
+        result = central.query("MATCH (c:Concept {name: 'SharedConcept'}) RETURN c.repos, count(c)")
+        repos, count = result.result_set[0]
+        assert count == 1
+        assert repos == "repoa,repob"
+
+    def test_missing_source_reports_both_lookups(self, central):
+        summary = SuperGraphAggregator(central).aggregate({"ghost": "ghost"})
+        err = summary["ghost"]["error"]
+        assert "ghost" in err and "navegador_ghost" in err
+
+    def test_source_equal_to_target_graph_is_rejected(self, central):
+        supergraph = central.with_graph("navegador_repoa")
+        _seed_shard(central, "navegador_repoa", "alpha_fn")
+        summary = SuperGraphAggregator(supergraph).aggregate({"repoa": "repoa"})
+        assert "aggregation target" in summary["repoa"]["error"]
+
+    def test_local_path_still_takes_precedence(self, central, tmp_path):
+        local = GraphStore.sqlite(str(tmp_path / ".navegador" / "graph.db"))
+        local.create_node("Function", {"name": "local_fn", "file_path": "l.py"})
+        local.close()
+
+        summary = SuperGraphAggregator(central).aggregate({"localrepo": str(tmp_path)})
+        assert "error" not in summary["localrepo"]
+        assert _central_function_repos(central) == {"local_fn": "localrepo"}
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+class TestAggregateCli:
+    def test_aggregate_into_named_supergraph(self, central):
+        _seed_shard(central, "navegador_repoa", "alpha_fn")
+        _seed_shard(central, "navegador_repob", "beta_fn")
+
+        runner = CliRunner()
+        with patch("navegador.cli.commands._get_store", return_value=central):
+            result = runner.invoke(
+                main, ["aggregate", "repoa", "repob", "--graph", "navegador_supergraph"]
+            )
+
+        assert result.exit_code == 0, result.output
+        super_store = central.with_graph("navegador_supergraph")
+        assert _central_function_repos(super_store) == {
+            "alpha_fn": "repoa",
+            "beta_fn": "repob",
+        }
+        # per-repo shards are untouched and the default graph stays empty
+        assert central.with_graph("navegador_repoa").node_count() == 3
+        assert central.node_count() == 0
+        super_store.clear()


### PR DESCRIPTION
## Summary
- `SuperGraphAggregator.aggregate` source resolution now falls back to graphs **resident in the connected database** when no local graph file exists: `aggregate clientcove` tries `clientcove` then `navegador_clientcove` (the `workspace ingest --mode federated` naming convention) via `GRAPH.LIST`. Local repo roots / graph files keep precedence; a missing source's error names both lookups.
- `navegador aggregate --graph navegador_supergraph` targets a distinct named super-graph in the same instance so per-repo shards and the rollup coexist. A source that resolves to the aggregation target itself is rejected instead of self-merging.
- Central-resident source stores share the central client and are not closed; locally-opened stores still are.
- Built on #129's `with_graph`/`list_graphs` + paged `collect_graph`, so >10k-node shards aggregate fully.

## Test plan
- New `tests/test_federation_central.py` against a real embedded FalkorDB with multiple named graphs: bare-name → `navegador_<name>` resolution, exact-name resolution, multi-shard rollup with cross-repo knowledge dedup (`repos` accumulation on shared Concept), missing-source error naming both lookups, self-target guard, local-path precedence, and CLI end-to-end into `navegador_supergraph` with shards untouched and the default graph left empty.
- Full suite: 2885 passed locally.

Fixes #124