### PR TITLE
Native exclusion + metarepo authored/full workspace ingest modes

### DIFF
--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -9,6 +9,7 @@ Navegador CLI — the single interface to your project's knowledge graph.
 import asyncio
 import json
 import logging
+from pathlib import Path
 
 import click
 from rich.console import Console
@@ -177,6 +178,14 @@ def init(
     is_flag=True,
     help="Detect and ingest as a monorepo workspace (Turborepo, Nx, Yarn, pnpm, Cargo, Go).",
 )
+@click.option(
+    "--exclude",
+    "excludes",
+    multiple=True,
+    metavar="GLOB",
+    help="Exclude paths matching GLOB (repeatable). Matches repo-relative "
+    "paths or single path components; a repo-root .navignore is honored too.",
+)
 def ingest(
     repo_path: str,
     db: str,
@@ -187,6 +196,7 @@ def ingest(
     as_json: bool,
     redact: bool,
     monorepo: bool,
+    excludes: tuple[str, ...],
 ):
     """Ingest a repository's code into the graph (AST + call graph)."""
     if monorepo:
@@ -212,7 +222,7 @@ def ingest(
     from navegador.ingestion import RepoIngester
 
     store = _get_store(db)
-    ingester = RepoIngester(store, redact=redact)
+    ingester = RepoIngester(store, redact=redact, exclude=list(excludes))
 
     if watch:
         console.print(f"[bold]Watching[/bold] {repo_path} (interval={interval}s, Ctrl-C to stop)")
@@ -2591,40 +2601,79 @@ def workspace():
 
 
 @workspace.command("ingest")
-@click.argument("repos", nargs=-1, metavar="NAME=PATH ...")
+@click.argument("repos", nargs=-1, metavar="[NAME=]PATH ...")
 @click.option(
     "--mode",
-    type=click.Choice(["unified", "federated"]),
+    type=click.Choice(["unified", "federated", "authored", "full"]),
     default="unified",
     show_default=True,
-    help="Graph mode: unified (shared graph) or federated (per-repo graphs).",
+    help="unified (shared graph), federated (per-repo graphs), or the "
+    "metarepo modes (imply --recursive + federated): authored skips each "
+    "repo's vendored nested clones, full indexes them too.",
+)
+@click.option(
+    "--recursive",
+    is_flag=True,
+    help="Discover nested git clones under each PATH and ingest each as its own repo.",
+)
+@click.option(
+    "--exclude",
+    "excludes",
+    multiple=True,
+    metavar="GLOB",
+    help="Exclude paths matching GLOB in every repo (repeatable; "
+    "per-repo .navignore files are honored too).",
 )
 @DB_OPTION
 @click.option("--clear", is_flag=True)
 @click.option("--json", "as_json", is_flag=True)
-def workspace_ingest(repos: tuple, mode: str, db: str, clear: bool, as_json: bool):
+def workspace_ingest(
+    repos: tuple,
+    mode: str,
+    recursive: bool,
+    excludes: tuple[str, ...],
+    db: str,
+    clear: bool,
+    as_json: bool,
+):
     """Ingest multiple repositories as a workspace.
 
     \b
-    REPOS is a list of NAME=PATH pairs, e.g.:
+    REPOS is a list of [NAME=]PATH entries (NAME defaults to the directory
+    basename), e.g.:
       navegador workspace ingest backend=/path/to/backend frontend=/path/to/frontend
 
     \b
     Examples:
       navegador workspace ingest backend=. frontend=../frontend --mode unified
       navegador workspace ingest api=./api worker=./worker --mode federated
+      navegador workspace ingest /path/to/metarepo --recursive --mode authored
     """
-    from navegador.multirepo import WorkspaceManager, WorkspaceMode
+    from navegador.multirepo import WorkspaceManager, WorkspaceMode, discover_nested_repos
 
     if not repos:
-        raise click.UsageError("Provide at least one NAME=PATH repo.")
+        raise click.UsageError("Provide at least one [NAME=]PATH repo.")
 
-    wm = WorkspaceManager(_get_store(db), mode=WorkspaceMode(mode))
+    metarepo = mode in ("authored", "full")
+    recursive = recursive or metarepo
+    storage_mode = WorkspaceMode.FEDERATED if metarepo else WorkspaceMode(mode)
+
+    wm = WorkspaceManager(
+        _get_store(db),
+        mode=storage_mode,
+        exclude=list(excludes),
+        include_nested_repos=(mode == "full"),
+    )
     for repo_spec in repos:
-        if "=" not in repo_spec:
-            raise click.UsageError(f"Invalid repo spec {repo_spec!r}. Expected NAME=PATH format.")
-        name, path = repo_spec.split("=", 1)
-        wm.add_repo(name.strip(), path.strip())
+        name, sep, path = repo_spec.partition("=")
+        if not sep:
+            path = repo_spec
+            name = Path(path).resolve().name
+        name, path = name.strip(), path.strip()
+        wm.add_repo(name, path)
+        if recursive:
+            for nested_name, nested_path in discover_nested_repos(path):
+                wm.add_repo(f"{name}-{nested_name}", nested_path)
 
     stats = wm.ingest_all(clear=clear)
 

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -24,6 +24,7 @@ Infrastructure-as-Code:
   Ansible     .yml .yaml      (detected heuristically, not via extension)
 """
 
+import fnmatch
 import hashlib
 import logging
 import os
@@ -85,9 +86,21 @@ class RepoIngester:
                 with ``[REDACTED]`` before the content is stored in graph nodes.
     """
 
-    def __init__(self, store: GraphStore, redact: bool = False) -> None:
+    def __init__(
+        self,
+        store: GraphStore,
+        redact: bool = False,
+        exclude: list[str] | None = None,
+        include_nested_repos: bool = False,
+    ) -> None:
         self.store = store
         self.redact = redact
+        # Glob patterns excluded from the walk, merged with the repo's
+        # .navignore. Matching directories are pruned before descent.
+        self.exclude = list(exclude or [])
+        # When True, nested git clones are walked instead of boundary-stopped
+        # (metarepo "full" mode — index vendored cores too).
+        self.include_nested_repos = include_nested_repos
         self._parsers: dict[str, "LanguageParser | None"] = {}
         # language → install hint, populated when an optional grammar is missing
         self.unavailable_grammars: dict[str, str] = {}
@@ -334,23 +347,67 @@ class RepoIngester:
 
         A subdirectory containing ``.git`` (directory, or file for worktrees
         and submodule pointers) is another repository: it is a boundary and
-        is never entered.
+        is never entered — unless ``include_nested_repos`` is set. Exclusion
+        patterns (``exclude`` + the repo's ``.navignore``) prune matching
+        directories the same way (#130).
         """
+        patterns = self._exclusion_patterns(repo_path)
         for dirpath, dirnames, filenames in os.walk(repo_path):
             current = Path(dirpath)
             kept = []
             for d in dirnames:
                 if d in self._SKIP_DIRS:
                     continue
-                if (current / d / ".git").exists():
-                    logger.info("Skipping nested git repository: %s", current / d)
+                child = current / d
+                if patterns and self._matches_exclusion(
+                    child.relative_to(repo_path).as_posix(), patterns
+                ):
+                    logger.info("Excluding %s (exclusion pattern)", child)
+                    continue
+                if not self.include_nested_repos and (child / ".git").exists():
+                    logger.info("Skipping nested git repository: %s", child)
                     continue
                 kept.append(d)
             dirnames[:] = kept
             for fname in filenames:
                 path = current / fname
+                if patterns and self._matches_exclusion(
+                    path.relative_to(repo_path).as_posix(), patterns
+                ):
+                    continue
                 if path.is_file():  # excludes broken symlinks, FIFOs, sockets
                     yield path
+
+    def _exclusion_patterns(self, repo_path: Path) -> list[str]:
+        """Explicit exclude patterns plus the repo's .navignore entries."""
+        patterns = list(self.exclude)
+        navignore = repo_path / ".navignore"
+        if navignore.is_file():
+            for line in navignore.read_text(encoding="utf-8", errors="replace").splitlines():
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    patterns.append(line)
+        return patterns
+
+    @staticmethod
+    def _matches_exclusion(rel_posix: str, patterns: list[str]) -> bool:
+        """
+        True when the repo-relative POSIX path matches any pattern.
+
+        A pattern matches the whole relative path (``docs/generated/*``) or,
+        gitignore-style, any single path component (``*.gen.py``, ``vscode``).
+        Trailing slashes (directory markers) are ignored.
+        """
+        parts = rel_posix.split("/")
+        for pattern in patterns:
+            pattern = pattern.rstrip("/")
+            if not pattern:
+                continue
+            if fnmatch.fnmatch(rel_posix, pattern) or any(
+                fnmatch.fnmatch(part, pattern) for part in parts
+            ):
+                return True
+        return False
 
     def _iter_source_files(self, repo_path: Path):
         for path in self._walk_files(repo_path):

--- a/navegador/multirepo.py
+++ b/navegador/multirepo.py
@@ -30,6 +30,7 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -79,9 +80,18 @@ class WorkspaceManager:
     fan out across all per-repo graphs and merge the result lists.
     """
 
-    def __init__(self, store: GraphStore, mode: WorkspaceMode = WorkspaceMode.UNIFIED) -> None:
+    def __init__(
+        self,
+        store: GraphStore,
+        mode: WorkspaceMode = WorkspaceMode.UNIFIED,
+        exclude: list[str] | None = None,
+        include_nested_repos: bool = False,
+    ) -> None:
         self.store = store
         self.mode = mode
+        # Passed through to each repo's RepoIngester (#130).
+        self.exclude = list(exclude or [])
+        self.include_nested_repos = include_nested_repos
         # repo name → {"path": str, "graph_name": str}
         self._repos: dict[str, dict[str, str]] = {}
 
@@ -148,7 +158,11 @@ class WorkspaceManager:
                 target_store = self.store
 
             try:
-                ingester = RepoIngester(target_store)
+                ingester = RepoIngester(
+                    target_store,
+                    exclude=self.exclude,
+                    include_nested_repos=self.include_nested_repos,
+                )
                 stats = ingester.ingest(path, clear=False)
                 summary[name] = stats
             except Exception as exc:  # noqa: BLE001
@@ -224,6 +238,37 @@ class WorkspaceManager:
             {"label": row[0] or "", "name": row[1] or "", "file_path": row[2] or "", "repo": ""}
             for row in rows
         ]
+
+
+def discover_nested_repos(root: str | Path) -> list[tuple[str, Path]]:
+    """
+    Find nested git clones under *root* (independent clones, not submodules).
+
+    Walks the tree pruning the standard skip dirs and hidden directories;
+    a directory containing ``.git`` (dir or file) is recorded as a repo and
+    not descended into for further discovery, so a clone's own vendored
+    clones stay inside its boundary. Returns ``(name, path)`` pairs sorted
+    by path, where *name* is the root-relative path with ``/`` → ``-``
+    (e.g. ``core-calliope-vscode``).
+    """
+    from navegador.ingestion.parser import RepoIngester
+
+    root = Path(root).resolve()
+    found: list[tuple[str, Path]] = []
+    for dirpath, dirnames, _filenames in os.walk(root):
+        current = Path(dirpath)
+        kept = []
+        for d in sorted(dirnames):
+            if d in RepoIngester._SKIP_DIRS or d.startswith("."):
+                continue
+            child = current / d
+            if (child / ".git").exists():
+                name = child.relative_to(root).as_posix().replace("/", "-")
+                found.append((name, child))
+            else:
+                kept.append(d)
+        dirnames[:] = kept
+    return sorted(found, key=lambda item: item[1])
 
 
 class MultiRepoManager:

--- a/tests/test_cli_new_commands.py
+++ b/tests/test_cli_new_commands.py
@@ -45,10 +45,14 @@ class TestMemoryIngest:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("repo").mkdir()
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.ingestion.MemoryIngester") as MockMI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.ingestion.MemoryIngester") as MockMI,
+            ):
                 MockMI.return_value.ingest_recursive.return_value = {
-                    "ingested": 12, "skipped": 2, "repos": ["svc-a", "svc-b"],
+                    "ingested": 12,
+                    "skipped": 2,
+                    "repos": ["svc-a", "svc-b"],
                 }
                 result = runner.invoke(main, ["memory", "ingest", "repo", "--recursive"])
                 assert result.exit_code == 0
@@ -61,10 +65,14 @@ class TestMemoryIngest:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("ws").mkdir()
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.ingestion.MemoryIngester") as MockMI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.ingestion.MemoryIngester") as MockMI,
+            ):
                 MockMI.return_value.ingest_workspace.return_value = {
-                    "ingested": 8, "skipped": 1, "repos": ["root", "sub1"],
+                    "ingested": 8,
+                    "skipped": 1,
+                    "repos": ["root", "sub1"],
                 }
                 result = runner.invoke(main, ["memory", "ingest", "ws", "--workspace"])
                 assert result.exit_code == 0
@@ -76,10 +84,13 @@ class TestMemoryIngest:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("mem").mkdir()
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.ingestion.MemoryIngester") as MockMI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.ingestion.MemoryIngester") as MockMI,
+            ):
                 MockMI.return_value.ingest.return_value = {
-                    "ingested": 5, "repo": "my-repo",
+                    "ingested": 5,
+                    "repo": "my-repo",
                     "by_type": {"Concept": 3, "Rule": 2},
                 }
                 result = runner.invoke(main, ["memory", "ingest", "mem", "--repo", "my-repo"])
@@ -95,8 +106,10 @@ class TestMemoryIngest:
 class TestImpactKnowledge:
     def test_impact_shows_knowledge_nodes(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.analysis.impact.ImpactAnalyzer") as MockIA:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.analysis.impact.ImpactAnalyzer") as MockIA,
+        ):
             mock_result = MagicMock()
             mock_result.affected_nodes = [
                 {"type": "Function", "name": "helper", "file_path": "a.py", "line_start": 10},
@@ -120,8 +133,10 @@ class TestImpactKnowledge:
 class TestDriftCommand:
     def test_drift_markdown(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.analysis.drift.DriftChecker") as MockDC:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.analysis.drift.DriftChecker") as MockDC,
+        ):
             mock_report = MagicMock()
             mock_report.to_markdown.return_value = "# Drift Report\nAll good"
             mock_report.has_violations = False
@@ -132,8 +147,10 @@ class TestDriftCommand:
 
     def test_drift_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.analysis.drift.DriftChecker") as MockDC:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.analysis.drift.DriftChecker") as MockDC,
+        ):
             mock_report = MagicMock()
             mock_report.to_json.return_value = '{"violations": []}'
             mock_report.has_violations = False
@@ -145,8 +162,10 @@ class TestDriftCommand:
 
     def test_drift_fail_on_violations(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.analysis.drift.DriftChecker") as MockDC:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.analysis.drift.DriftChecker") as MockDC,
+        ):
             mock_report = MagicMock()
             mock_report.to_markdown.return_value = "# Violations found"
             mock_report.has_violations = True
@@ -162,8 +181,10 @@ class TestDiffGraphCommand:
     def test_diff_working_tree_default(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA,
+            ):
                 mock_report = MagicMock()
                 mock_report.to_markdown.return_value = "# Diff Report"
                 MockDGA.return_value.diff_working_tree.return_value = mock_report
@@ -175,38 +196,62 @@ class TestDiffGraphCommand:
     def test_diff_refs(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA,
+            ):
                 mock_report = MagicMock()
                 mock_report.to_json.return_value = '{"changes": []}'
                 MockDGA.return_value.diff_refs.return_value = mock_report
-                result = runner.invoke(main, [
-                    "diff-graph", "--base", "main", "--head", "HEAD",
-                    "--json", "--repo-path", ".",
-                ])
+                result = runner.invoke(
+                    main,
+                    [
+                        "diff-graph",
+                        "--base",
+                        "main",
+                        "--head",
+                        "HEAD",
+                        "--json",
+                        "--repo-path",
+                        ".",
+                    ],
+                )
                 assert result.exit_code == 0
                 data = json.loads(result.output)
                 assert "changes" in data
                 MockDGA.return_value.diff_refs.assert_called_once_with(
-                    base="main", head="HEAD",
+                    base="main",
+                    head="HEAD",
                 )
 
     def test_diff_snapshots(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA,
+            ):
                 mock_report = MagicMock()
                 mock_report.to_markdown.return_value = "# Snapshot Diff"
                 MockDGA.return_value.diff_snapshots.return_value = mock_report
-                result = runner.invoke(main, [
-                    "diff-graph", "--base", "v1.0", "--head", "v2.0",
-                    "--snapshot", "--repo-path", ".",
-                ])
+                result = runner.invoke(
+                    main,
+                    [
+                        "diff-graph",
+                        "--base",
+                        "v1.0",
+                        "--head",
+                        "v2.0",
+                        "--snapshot",
+                        "--repo-path",
+                        ".",
+                    ],
+                )
                 assert result.exit_code == 0
                 assert "Snapshot Diff" in result.output
                 MockDGA.return_value.diff_snapshots.assert_called_once_with(
-                    base_ref="v1.0", head_ref="v2.0",
+                    base_ref="v1.0",
+                    head_ref="v2.0",
                 )
 
 
@@ -227,9 +272,11 @@ class TestReviewCommand:
     def test_review_markdown(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA, \
-                 patch("navegador.analysis.review.ReviewGenerator") as MockRG:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA,
+                patch("navegador.analysis.review.ReviewGenerator") as MockRG,
+            ):
                 MockDGA.return_value.diff_refs.return_value = self._mock_diff_report()
                 mock_review = MagicMock()
                 comment = MagicMock()
@@ -244,9 +291,11 @@ class TestReviewCommand:
     def test_review_json(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA, \
-                 patch("navegador.analysis.review.ReviewGenerator") as MockRG:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.analysis.diffgraph.DiffGraphAnalyzer") as MockDGA,
+                patch("navegador.analysis.review.ReviewGenerator") as MockRG,
+            ):
                 MockDGA.return_value.diff_refs.return_value = self._mock_diff_report()
                 mock_review = MagicMock()
                 comment = MagicMock()
@@ -266,8 +315,10 @@ class TestReviewCommand:
 class TestCrossImpactCommand:
     def test_cross_impact_markdown(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.analysis.crossrepo.CrossRepoImpactAnalyzer") as MockCR:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.analysis.crossrepo.CrossRepoImpactAnalyzer") as MockCR,
+        ):
             mock_result = MagicMock()
             mock_result.to_markdown.return_value = "# Cross-repo impact\n- 3 repos affected"
             MockCR.return_value.blast_radius.return_value = mock_result
@@ -277,8 +328,10 @@ class TestCrossImpactCommand:
 
     def test_cross_impact_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.analysis.crossrepo.CrossRepoImpactAnalyzer") as MockCR:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.analysis.crossrepo.CrossRepoImpactAnalyzer") as MockCR,
+        ):
             mock_result = MagicMock()
             mock_result.to_json.return_value = '{"repos": ["api", "worker"]}'
             MockCR.return_value.blast_radius.return_value = mock_result
@@ -294,8 +347,10 @@ class TestCrossImpactCommand:
 class TestRepoGroupJsonPaths:
     def test_repo_list_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.multirepo.MultiRepoManager") as MockMRM:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.multirepo.MultiRepoManager") as MockMRM,
+        ):
             MockMRM.return_value.list_repos.return_value = [
                 {"name": "api", "path": "/code/api"},
             ]
@@ -306,8 +361,10 @@ class TestRepoGroupJsonPaths:
 
     def test_repo_ingest_all_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.multirepo.MultiRepoManager") as MockMRM:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.multirepo.MultiRepoManager") as MockMRM,
+        ):
             MockMRM.return_value.ingest_all.return_value = {
                 "api": {"files": 10, "nodes": 50},
             }
@@ -318,8 +375,10 @@ class TestRepoGroupJsonPaths:
 
     def test_repo_search_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.multirepo.MultiRepoManager") as MockMRM:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.multirepo.MultiRepoManager") as MockMRM,
+        ):
             MockMRM.return_value.cross_repo_search.return_value = [
                 {"label": "Function", "name": "auth", "file_path": "auth.py"},
             ]
@@ -335,8 +394,10 @@ class TestRepoGroupJsonPaths:
 class TestRenameCommand:
     def test_rename_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.refactor.SymbolRenamer") as MockSR:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.refactor.SymbolRenamer") as MockSR,
+        ):
             mock_result = MagicMock()
             mock_result.old_name = "old_fn"
             mock_result.new_name = "new_fn"
@@ -360,10 +421,14 @@ class TestCodeownersCommand:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("repo").mkdir()
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.codeowners.CodeownersIngester") as MockCI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.codeowners.CodeownersIngester") as MockCI,
+            ):
                 MockCI.return_value.ingest.return_value = {
-                    "owners": 3, "patterns": 5, "edges": 8,
+                    "owners": 3,
+                    "patterns": 5,
+                    "edges": 8,
                 }
                 result = runner.invoke(main, ["codeowners", "repo", "--json"])
                 assert result.exit_code == 0
@@ -380,10 +445,13 @@ class TestADRIngestCommand:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("adrs").mkdir()
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.adr.ADRIngester") as MockAI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.adr.ADRIngester") as MockAI,
+            ):
                 MockAI.return_value.ingest.return_value = {
-                    "decisions": 4, "skipped": 1,
+                    "decisions": 4,
+                    "skipped": 1,
                 }
                 result = runner.invoke(main, ["adr", "ingest", "adrs", "--json"])
                 assert result.exit_code == 0
@@ -401,10 +469,13 @@ class TestAPIIngestAutoDetect:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("swagger.json").write_text("{}")
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.api_schema.APISchemaIngester") as MockASI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.api_schema.APISchemaIngester") as MockASI,
+            ):
                 MockASI.return_value.ingest_openapi.return_value = {
-                    "endpoints": 5, "schemas": 3,
+                    "endpoints": 5,
+                    "schemas": 3,
                 }
                 result = runner.invoke(main, ["api", "ingest", "swagger.json"])
                 assert result.exit_code == 0
@@ -420,8 +491,10 @@ class TestDepsIngestCommand:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("package.json").write_text("{}")
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.dependencies.DependencyIngester") as MockDI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.dependencies.DependencyIngester") as MockDI,
+            ):
                 MockDI.return_value.ingest_npm.return_value = {"packages": 12}
                 result = runner.invoke(main, ["deps", "ingest", "package.json"])
                 assert result.exit_code == 0
@@ -432,8 +505,10 @@ class TestDepsIngestCommand:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("requirements.txt").write_text("")
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.dependencies.DependencyIngester") as MockDI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.dependencies.DependencyIngester") as MockDI,
+            ):
                 MockDI.return_value.ingest_pip.return_value = {"packages": 7}
                 result = runner.invoke(main, ["deps", "ingest", "requirements.txt", "--json"])
                 assert result.exit_code == 0
@@ -445,8 +520,10 @@ class TestDepsIngestCommand:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("Cargo.toml").write_text("")
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.dependencies.DependencyIngester") as MockDI:
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.dependencies.DependencyIngester") as MockDI,
+            ):
                 MockDI.return_value.ingest_cargo.return_value = {"packages": 4}
                 result = runner.invoke(main, ["deps", "ingest", "Cargo.toml"])
                 assert result.exit_code == 0
@@ -495,9 +572,11 @@ class TestWorkspaceIngestCommand:
         with runner.isolated_filesystem():
             Path("api").mkdir()
             Path("web").mkdir()
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.multirepo.WorkspaceManager") as MockWM, \
-                 patch("navegador.multirepo.WorkspaceMode"):
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.multirepo.WorkspaceManager") as MockWM,
+                patch("navegador.multirepo.WorkspaceMode"),
+            ):
                 MockWM.return_value.ingest_all.return_value = {
                     "api": {"files": 5, "nodes": 20},
                     "web": {"files": 3, "nodes": 10},
@@ -514,9 +593,11 @@ class TestWorkspaceIngestCommand:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("svc").mkdir()
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.multirepo.WorkspaceManager") as MockWM, \
-                 patch("navegador.multirepo.WorkspaceMode"):
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.multirepo.WorkspaceManager") as MockWM,
+                patch("navegador.multirepo.WorkspaceMode"),
+            ):
                 MockWM.return_value.ingest_all.return_value = {
                     "svc": {"files": 2, "nodes": 8},
                 }
@@ -529,9 +610,11 @@ class TestWorkspaceIngestCommand:
         runner = CliRunner()
         with runner.isolated_filesystem():
             Path("bad").mkdir()
-            with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-                 patch("navegador.multirepo.WorkspaceManager") as MockWM, \
-                 patch("navegador.multirepo.WorkspaceMode"):
+            with (
+                patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+                patch("navegador.multirepo.WorkspaceManager") as MockWM,
+                patch("navegador.multirepo.WorkspaceMode"),
+            ):
                 MockWM.return_value.ingest_all.return_value = {
                     "bad": {"error": "not a git repo"},
                 }
@@ -540,11 +623,14 @@ class TestWorkspaceIngestCommand:
                 assert "Error" in result.output
                 assert "not a git repo" in result.output
 
-    def test_workspace_ingest_invalid_spec(self):
+    def test_workspace_ingest_bare_path_is_accepted(self):
+        """Since #130 a spec without '=' is a PATH whose name defaults to the
+        directory basename; a nonexistent path surfaces as a per-repo error."""
         runner = CliRunner()
-        result = runner.invoke(main, ["workspace", "ingest", "no-equals-sign"])
-        assert result.exit_code != 0
-        assert "NAME=PATH" in result.output
+        with patch("navegador.cli.commands._get_store", return_value=_mock_store()):
+            result = runner.invoke(main, ["workspace", "ingest", "/nonexistent/bare-path"])
+        assert result.exit_code == 0
+        assert "Error ingesting bare-path" in result.output
 
 
 # ── pack (lines 2345-2359) ──────────────────────────────────────────────────
@@ -553,8 +639,10 @@ class TestWorkspaceIngestCommand:
 class TestPackCommand:
     def test_pack_symbol(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.taskpack.TaskPackBuilder") as MockTPB:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.taskpack.TaskPackBuilder") as MockTPB,
+        ):
             mock_pack = MagicMock()
             mock_pack.to_markdown.return_value = "# Task Pack\nImplement AuthService"
             MockTPB.return_value.for_symbol.return_value = mock_pack
@@ -565,8 +653,10 @@ class TestPackCommand:
 
     def test_pack_file_path(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.taskpack.TaskPackBuilder") as MockTPB:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.taskpack.TaskPackBuilder") as MockTPB,
+        ):
             mock_pack = MagicMock()
             mock_pack.to_json.return_value = '{"target": "app/auth.py"}'
             MockTPB.return_value.for_file.return_value = mock_pack
@@ -581,8 +671,9 @@ class TestPackCommand:
 
 
 class TestDocLinkSuggestCommand:
-    def _mock_candidate(self, source="API Guide", target="AuthService",
-                        strategy="EXACT_NAME", confidence=0.9):
+    def _mock_candidate(
+        self, source="API Guide", target="AuthService", strategy="EXACT_NAME", confidence=0.9
+    ):
         c = MagicMock()
         c.source_name = source
         c.target_name = target
@@ -590,16 +681,20 @@ class TestDocLinkSuggestCommand:
         c.strategy = strategy
         c.confidence = confidence
         c.__dict__ = {
-            "source_name": source, "target_name": target,
-            "target_file": "auth.py", "strategy": strategy,
+            "source_name": source,
+            "target_name": target,
+            "target_file": "auth.py",
+            "strategy": strategy,
             "confidence": confidence,
         }
         return c
 
     def test_suggest_table_output(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.intelligence.doclink.DocLinker") as MockDL:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.intelligence.doclink.DocLinker") as MockDL,
+        ):
             MockDL.return_value.suggest_links.return_value = [self._mock_candidate()]
             result = runner.invoke(main, ["doclink", "suggest"])
             assert result.exit_code == 0
@@ -608,8 +703,10 @@ class TestDocLinkSuggestCommand:
 
     def test_suggest_json_output(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.intelligence.doclink.DocLinker") as MockDL:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.intelligence.doclink.DocLinker") as MockDL,
+        ):
             MockDL.return_value.suggest_links.return_value = [self._mock_candidate()]
             result = runner.invoke(main, ["doclink", "suggest", "--json"])
             assert result.exit_code == 0
@@ -619,8 +716,10 @@ class TestDocLinkSuggestCommand:
 
     def test_suggest_no_candidates(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.intelligence.doclink.DocLinker") as MockDL:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.intelligence.doclink.DocLinker") as MockDL,
+        ):
             MockDL.return_value.suggest_links.return_value = []
             result = runner.invoke(main, ["doclink", "suggest"])
             assert result.exit_code == 0
@@ -628,14 +727,23 @@ class TestDocLinkSuggestCommand:
 
     def test_suggest_strategy_filter(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.intelligence.doclink.DocLinker") as MockDL:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.intelligence.doclink.DocLinker") as MockDL,
+        ):
             exact = self._mock_candidate(strategy="EXACT_NAME")
             fuzzy = self._mock_candidate(source="Readme", target="parse", strategy="FUZZY")
             MockDL.return_value.suggest_links.return_value = [exact, fuzzy]
-            result = runner.invoke(main, [
-                "doclink", "suggest", "--strategy", "EXACT_NAME", "--json",
-            ])
+            result = runner.invoke(
+                main,
+                [
+                    "doclink",
+                    "suggest",
+                    "--strategy",
+                    "EXACT_NAME",
+                    "--json",
+                ],
+            )
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert len(data) == 1
@@ -648,9 +756,11 @@ class TestDocLinkSuggestCommand:
 class TestDocLinkAcceptCommand:
     def test_accept_existing_candidate(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.intelligence.doclink.DocLinker") as MockDL, \
-             patch("navegador.intelligence.doclink.LinkCandidate"):
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.intelligence.doclink.DocLinker") as MockDL,
+            patch("navegador.intelligence.doclink.LinkCandidate"),
+        ):
             candidate = MagicMock()
             candidate.source_name = "API Guide"
             candidate.target_name = "AuthService"
@@ -664,9 +774,11 @@ class TestDocLinkAcceptCommand:
 
     def test_accept_manual_fallback(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.intelligence.doclink.DocLinker") as MockDL, \
-             patch("navegador.intelligence.doclink.LinkCandidate") as MockLC:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.intelligence.doclink.DocLinker") as MockDL,
+            patch("navegador.intelligence.doclink.LinkCandidate") as MockLC,
+        ):
             MockDL.return_value.suggest_links.return_value = []
             result = runner.invoke(main, ["doclink", "accept", "README", "parse_token"])
             assert result.exit_code == 0
@@ -681,8 +793,10 @@ class TestDocLinkAcceptCommand:
 class TestDocLinkAcceptAllCommand:
     def test_accept_all_dry_run(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.intelligence.doclink.DocLinker") as MockDL:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.intelligence.doclink.DocLinker") as MockDL,
+        ):
             MockDL.return_value.suggest_links.return_value = [MagicMock(), MagicMock()]
             result = runner.invoke(main, ["doclink", "accept-all", "--dry-run"])
             assert result.exit_code == 0
@@ -692,8 +806,10 @@ class TestDocLinkAcceptAllCommand:
 
     def test_accept_all_writes_edges(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.intelligence.doclink.DocLinker") as MockDL:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.intelligence.doclink.DocLinker") as MockDL,
+        ):
             candidates = [MagicMock(), MagicMock(), MagicMock()]
             MockDL.return_value.suggest_links.return_value = candidates
             MockDL.return_value.accept_all.return_value = 3
@@ -709,8 +825,10 @@ class TestDocLinkAcceptAllCommand:
 class TestLensListCommand:
     def test_lens_list_table(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.lenses.LensEngine") as MockLE:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.lenses.LensEngine") as MockLE,
+        ):
             MockLE.return_value.list_lenses.return_value = [
                 {"name": "request_path", "builtin": True, "description": "HTTP request flow"},
                 {"name": "ownership_map", "builtin": True, "description": "Code owners"},
@@ -722,8 +840,10 @@ class TestLensListCommand:
 
     def test_lens_list_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.lenses.LensEngine") as MockLE:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.lenses.LensEngine") as MockLE,
+        ):
             MockLE.return_value.list_lenses.return_value = [
                 {"name": "request_path", "builtin": True, "description": "flow"},
             ]
@@ -739,8 +859,10 @@ class TestLensListCommand:
 class TestLensApplyCommand:
     def test_lens_apply_markdown(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.lenses.LensEngine") as MockLE:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.lenses.LensEngine") as MockLE,
+        ):
             mock_result = MagicMock()
             mock_result.to_markdown.return_value = "# Request Path\nauth -> handler -> db"
             MockLE.return_value.apply.return_value = mock_result
@@ -750,15 +872,24 @@ class TestLensApplyCommand:
 
     def test_lens_apply_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.lenses.LensEngine") as MockLE:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.lenses.LensEngine") as MockLE,
+        ):
             mock_result = MagicMock()
             mock_result.to_json.return_value = '{"lens": "ownership_map", "nodes": []}'
             MockLE.return_value.apply.return_value = mock_result
-            result = runner.invoke(main, [
-                "lens", "apply", "ownership_map",
-                "--domain", "auth", "--json",
-            ])
+            result = runner.invoke(
+                main,
+                [
+                    "lens",
+                    "apply",
+                    "ownership_map",
+                    "--domain",
+                    "auth",
+                    "--json",
+                ],
+            )
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["lens"] == "ownership_map"
@@ -768,8 +899,10 @@ class TestLensApplyCommand:
 
     def test_lens_apply_unknown_lens_error(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.lenses.LensEngine") as MockLE:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.lenses.LensEngine") as MockLE,
+        ):
             MockLE.return_value.apply.side_effect = ValueError("Unknown lens: bogus")
             result = runner.invoke(main, ["lens", "apply", "bogus"])
             assert result.exit_code != 0
@@ -782,8 +915,10 @@ class TestLensApplyCommand:
 class TestSnapshotCommand:
     def test_snapshot_head(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             info = MagicMock()
             info.ref = "HEAD"
             info.commit_sha = "abc1234"
@@ -797,8 +932,10 @@ class TestSnapshotCommand:
 
     def test_snapshot_tag(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             info = MagicMock()
             info.ref = "v2.0.0"
             info.commit_sha = "def5678"
@@ -815,8 +952,10 @@ class TestSnapshotCommand:
 class TestHistoryCommand:
     def test_history_markdown(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             mock_report = MagicMock()
             mock_report.to_markdown.return_value = "# History of AuthService\nFirst seen in v1.0"
             MockHS.return_value.history.return_value = mock_report
@@ -826,8 +965,10 @@ class TestHistoryCommand:
 
     def test_history_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             mock_report = MagicMock()
             mock_report.to_json.return_value = '{"name": "AuthService", "events": []}'
             MockHS.return_value.history.return_value = mock_report
@@ -838,8 +979,10 @@ class TestHistoryCommand:
 
     def test_history_with_file_filter(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             mock_report = MagicMock()
             mock_report.to_markdown.return_value = "# History"
             MockHS.return_value.history.return_value = mock_report
@@ -854,8 +997,10 @@ class TestHistoryCommand:
 class TestGraphAtCommand:
     def test_graph_at_table_output(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             sym1 = MagicMock()
             sym1.label = "Function"
             sym1.name = "parse_token"
@@ -875,8 +1020,10 @@ class TestGraphAtCommand:
 
     def test_graph_at_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             sym = MagicMock()
             sym.__dict__ = {"label": "Function", "name": "foo", "file_path": "bar.py"}
             MockHS.return_value.symbols_at.return_value = [sym]
@@ -887,8 +1034,10 @@ class TestGraphAtCommand:
 
     def test_graph_at_no_snapshot(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             MockHS.return_value.symbols_at.return_value = []
             result = runner.invoke(main, ["graph-at", "nonexistent"])
             assert result.exit_code == 0
@@ -901,8 +1050,10 @@ class TestGraphAtCommand:
 class TestLineageCommand:
     def test_lineage_markdown(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             mock_report = MagicMock()
             mock_report.to_markdown.return_value = "# Lineage: AuthService\nRenamed from Auth"
             MockHS.return_value.lineage.return_value = mock_report
@@ -912,8 +1063,10 @@ class TestLineageCommand:
 
     def test_lineage_json(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store", return_value=_mock_store()), \
-             patch("navegador.history.HistoryStore") as MockHS:
+        with (
+            patch("navegador.cli.commands._get_store", return_value=_mock_store()),
+            patch("navegador.history.HistoryStore") as MockHS,
+        ):
             mock_report = MagicMock()
             mock_report.to_json.return_value = '{"name": "AuthService", "chain": []}'
             MockHS.return_value.lineage.return_value = mock_report

--- a/tests/test_metarepo_ingest.py
+++ b/tests/test_metarepo_ingest.py
@@ -1,0 +1,214 @@
+"""Tests for #130 — native exclusion (--exclude / .navignore) and metarepo
+authored/full ingest modes (recursive nested-clone discovery)."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from navegador.cli.commands import main
+from navegador.graph.store import GraphStore
+from navegador.ingestion.parser import RepoIngester
+from navegador.multirepo import discover_nested_repos
+
+
+def _mock_store():
+    store = MagicMock()
+    store.query.return_value = MagicMock(result_set=[])
+    return store
+
+
+def _write(root: Path, rel: str, content: str = "x = 1\n") -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ── Exclusion patterns ─────────────────────────────────────────────────────
+
+
+class TestExclusion:
+    def test_exclude_glob_prunes_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _write(root, "app.py")
+            _write(root, "generated/big.py")
+            files = {
+                p.name
+                for p in RepoIngester(_mock_store(), exclude=["generated"])._iter_source_files(root)
+            }
+        assert files == {"app.py"}
+
+    def test_exclude_matches_relative_path_glob(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _write(root, "docs/gen/a.py")
+            _write(root, "docs/handwritten/b.py")
+            files = {
+                p.name
+                for p in RepoIngester(_mock_store(), exclude=["docs/gen/*"])._iter_source_files(
+                    root
+                )
+            }
+        assert files == {"b.py"}
+
+    def test_exclude_matches_file_component(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _write(root, "app.py")
+            _write(root, "sub/schema.gen.py")
+            files = {
+                p.name
+                for p in RepoIngester(_mock_store(), exclude=["*.gen.py"])._iter_source_files(root)
+            }
+        assert files == {"app.py"}
+
+    def test_navignore_is_honored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _write(root, "app.py")
+            _write(root, "vendored-core/huge.py")
+            _write(root, "tmp.gen.py")
+            (root / ".navignore").write_text(
+                "# vendored OSS tree\nvendored-core/\n*.gen.py\n", encoding="utf-8"
+            )
+            files = {p.name for p in RepoIngester(_mock_store())._iter_source_files(root)}
+        assert files == {"app.py"}
+
+    def test_include_nested_repos_descends_into_clones(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _write(root, "own.py")
+            nested = root / "core"
+            (nested / ".git").mkdir(parents=True)
+            _write(root, "core/vendored.py")
+
+            default = {p.name for p in RepoIngester(_mock_store())._iter_source_files(root)}
+            full = {
+                p.name
+                for p in RepoIngester(_mock_store(), include_nested_repos=True)._iter_source_files(
+                    root
+                )
+            }
+        assert default == {"own.py"}
+        assert full == {"own.py", "vendored.py"}
+
+
+# ── Nested repo discovery ──────────────────────────────────────────────────
+
+
+def _metarepo(tmpdir: str) -> Path:
+    """Metarepo root: own source + two nested clones, one vendoring a clone."""
+    root = Path(tmpdir)
+    (root / ".git").mkdir()
+    _write(root, "scripts/deploy.py")
+
+    plain = root / "nodes" / "plain-node"
+    (plain / ".git").mkdir(parents=True)
+    _write(root, "nodes/plain-node/node.py")
+
+    wrapper = root / "nodes" / "wrapper-node"
+    (wrapper / ".git").mkdir(parents=True)
+    _write(root, "nodes/wrapper-node/wrapper.py")
+    vendored = wrapper / "oss-core"
+    (vendored / ".git").mkdir(parents=True)
+    _write(root, "nodes/wrapper-node/oss-core/core.py")
+    return root
+
+
+class TestDiscoverNestedRepos:
+    def test_finds_clones_at_depth_and_stops_at_boundaries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _metarepo(tmpdir)
+            found = discover_nested_repos(root)
+        names = [name for name, _ in found]
+        assert names == ["nodes-plain-node", "nodes-wrapper-node"]
+        # the vendored clone inside wrapper-node stays inside its boundary
+        assert "nodes-wrapper-node-oss-core" not in names
+
+    def test_skip_dirs_and_hidden_dirs_are_not_scanned(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            hidden_clone = root / ".cache" / "repo"
+            (hidden_clone / ".git").mkdir(parents=True)
+            vendor_clone = root / "node_modules" / "dep"
+            (vendor_clone / ".git").mkdir(parents=True)
+            assert discover_nested_repos(root) == []
+
+
+# ── workspace ingest CLI (metarepo modes) ──────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def central(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("metarepo") / "graph.db"))
+    yield s
+    s.close()
+
+
+def _graph_files(central, graph_name: str) -> set:
+    result = central.with_graph(graph_name).query("MATCH (f:File) RETURN f.name")
+    return {row[0] for row in result.result_set or []}
+
+
+class TestWorkspaceIngestMetarepoModes:
+    def test_authored_mode_federates_clones_and_skips_vendored(self, central):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _metarepo(tmpdir)
+            runner = CliRunner()
+            with patch("navegador.cli.commands._get_store", return_value=central):
+                result = runner.invoke(
+                    main,
+                    ["workspace", "ingest", f"meta={root}", "--recursive", "--mode", "authored"],
+                )
+
+            assert result.exit_code == 0, result.output
+            assert _graph_files(central, "navegador_meta") == {"deploy.py"}
+            assert _graph_files(central, "navegador_meta-nodes-plain-node") == {"node.py"}
+            assert _graph_files(central, "navegador_meta-nodes-wrapper-node") == {"wrapper.py"}
+
+    def test_full_mode_includes_vendored_cores(self, central):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _metarepo(tmpdir)
+            runner = CliRunner()
+            with patch("navegador.cli.commands._get_store", return_value=central):
+                result = runner.invoke(
+                    main, ["workspace", "ingest", f"meta={root}", "--mode", "full"]
+                )
+
+            assert result.exit_code == 0, result.output
+            # full implies --recursive; the vendored core lands in its wrapper's graph
+            assert _graph_files(central, "navegador_meta-nodes-wrapper-node") == {
+                "wrapper.py",
+                "core.py",
+            }
+
+    def test_bare_path_defaults_name_to_basename(self, central):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "solo"
+            root.mkdir()
+            _write(root, "solo.py")
+            runner = CliRunner()
+            with patch("navegador.cli.commands._get_store", return_value=central):
+                result = runner.invoke(
+                    main, ["workspace", "ingest", str(root), "--mode", "federated"]
+                )
+
+            assert result.exit_code == 0, result.output
+            assert _graph_files(central, "navegador_solo") == {"solo.py"}
+
+    def test_name_path_specs_still_work_unified(self, central):
+        central.clear()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "uni"
+            root.mkdir()
+            _write(root, "uni.py")
+            runner = CliRunner()
+            with patch("navegador.cli.commands._get_store", return_value=central):
+                result = runner.invoke(main, ["workspace", "ingest", f"uni={root}"])
+
+            assert result.exit_code == 0, result.output
+            result_set = central.query("MATCH (f:File) RETURN f.name").result_set or []
+        assert {row[0] for row in result_set} == {"uni.py"}


### PR DESCRIPTION
## Summary
- **Native exclusion:** `RepoIngester` takes `exclude` glob patterns, merged with a repo-root `.navignore` (one glob per line, `#` comments). Patterns match repo-relative POSIX paths or single path components (gitignore-style), and matching **directories are pruned before descent** — excluding a 14GB vendored tree costs nothing. `navegador ingest --exclude GLOB` and `workspace ingest --exclude GLOB` (repeatable). `.gitignore` is deliberately not honored (it lists artifacts you may still want indexed, and its negation semantics don't map to pruning).
- **Metarepo discovery:** `workspace ingest <root> --recursive` discovers nested git clones under each root via `discover_nested_repos` (skip-dirs and hidden dirs pruned; discovery boundary-stops at each found clone, so a clone's vendored clones stay inside its boundary). Each becomes its own repo named `<root>-<relpath-slug>`; the root itself is ingested as the wrapper repo.
- **Modes:** `--mode` gains `authored` and `full`, both implying `--recursive` + federated per-repo graphs. `authored` boundary-stops each repo at internal vendored clones (the #128 default); `full` sets `include_nested_repos=True` so vendored cores are indexed into their wrapper's graph. `unified`/`federated` behave exactly as before.
- **Spec relaxation:** bare `PATH` (no `NAME=`) is accepted; the name defaults to the directory basename — so the acceptance command `navegador workspace ingest <metarepo-root> --recursive --mode authored` works verbatim.

Together with #127/#128/#129/#124 this closes out the metarepo federation chain; `scripts/ingest-substrate.sh` in the calliope metarepo reduces to one `workspace ingest` + one `aggregate` call.

## Test plan
- New `tests/test_metarepo_ingest.py` (11 tests): exclude by dir name / relative-path glob / file component; `.navignore` honored incl. trailing-slash dirs; `include_nested_repos` descends; discovery finds clones at depth, boundary-stops, skips hidden/skip dirs; CLI end-to-end on a synthetic metarepo against a real embedded store in authored and full modes (per-graph file assertions); bare-PATH naming; NAME=PATH unified unchanged.
- Updated `test_workspace_ingest_invalid_spec` → bare paths are now valid; a nonexistent path surfaces as a per-repo error.
- Full suite: 2895 passed locally.

Fixes #130