### PR TITLE
pm: issue comments, LLM decision extraction, brain-memory retrofit

### DIFF
--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -2432,9 +2432,33 @@ def pm():
     help="GitHub issue state filter.",
 )
 @click.option("--limit", default=100, show_default=True, help="Maximum number of issues to fetch.")
+@click.option(
+    "--no-comments",
+    is_flag=True,
+    help="Skip fetching issue comment threads (fetched by default).",
+)
+@click.option(
+    "--extract-decisions",
+    is_flag=True,
+    help="After ingesting, surface Decision nodes from issue threads via LLM "
+    "(requires the [llm] extra and provider credentials).",
+)
+@click.option("--llm-provider", default="anthropic", show_default=True)
+@click.option("--llm-model", default="", help="Override the provider's default model.")
 @DB_OPTION
 @click.option("--json", "as_json", is_flag=True)
-def pm_ingest(github_repo: str, token: str, state: str, limit: int, db: str, as_json: bool):
+def pm_ingest(
+    github_repo: str,
+    token: str,
+    state: str,
+    limit: int,
+    no_comments: bool,
+    extract_decisions: bool,
+    llm_provider: str,
+    llm_model: str,
+    db: str,
+    as_json: bool,
+):
     """Ingest tickets from a PM tool into the knowledge graph.
 
     \b
@@ -2442,6 +2466,7 @@ def pm_ingest(github_repo: str, token: str, state: str, limit: int, db: str, as_
       navegador pm ingest --github owner/repo
       navegador pm ingest --github owner/repo --token ghp_...
       navegador pm ingest --github owner/repo --state all --limit 200
+      navegador pm ingest --github owner/repo --extract-decisions
     """
     if not github_repo:
         raise click.UsageError(
@@ -2451,7 +2476,19 @@ def pm_ingest(github_repo: str, token: str, state: str, limit: int, db: str, as_
     from navegador.pm import TicketIngester
 
     ing = TicketIngester(_get_store(db))
-    stats = ing.ingest_github_issues(github_repo, token=token, state=state, limit=limit)
+    stats = ing.ingest_github_issues(
+        github_repo,
+        token=token,
+        state=state,
+        limit=limit,
+        include_comments=not no_comments,
+    )
+
+    if extract_decisions:
+        domain = github_repo.split("/")[-1]
+        stats.update(
+            ing.extract_decisions(domain=domain, llm_provider=llm_provider, llm_model=llm_model)
+        )
 
     if as_json:
         click.echo(json.dumps(stats, indent=2))
@@ -2462,6 +2499,58 @@ def pm_ingest(github_repo: str, token: str, state: str, limit: int, db: str, as_
         for k, v in stats.items():
             table.add_row(k.capitalize(), str(v))
         console.print(table)
+
+
+@pm.command("decisions")
+@click.option(
+    "--to-markdown",
+    "memory_dir",
+    default="",
+    metavar="DIR",
+    help="Write one project_<slug>.md per decision into DIR "
+    "(frontmatter format readable by `navegador memory ingest`).",
+)
+@click.option(
+    "--to-json",
+    "json_path",
+    default="",
+    metavar="FILE",
+    help="Write the decision list as JSON to FILE (e.g. app/decisions.json).",
+)
+@click.option("--domain", default="", help="Only export decisions from this domain.")
+@DB_OPTION
+@click.option("--json", "as_json", is_flag=True, help="Output stats as JSON.")
+def pm_decisions(memory_dir: str, json_path: str, domain: str, db: str, as_json: bool):
+    """Retrofit Decision nodes into a brain's memory store.
+
+    \b
+    Examples:
+      navegador pm decisions --to-markdown memory/
+      navegador pm decisions --to-json app/decisions.json --domain myrepo
+    """
+    if not memory_dir and not json_path:
+        raise click.UsageError("Provide --to-markdown DIR and/or --to-json FILE.")
+
+    from navegador.pm import retrofit_decisions
+
+    stats = retrofit_decisions(
+        _get_store(db),
+        memory_dir=memory_dir or None,
+        json_path=json_path or None,
+        domain=domain,
+    )
+
+    if as_json:
+        click.echo(json.dumps(stats, indent=2))
+    else:
+        markdown_note = (
+            f" → {stats['markdown_files']} markdown file(s) in {memory_dir}" if memory_dir else ""
+        )
+        json_note = f" → {json_path}" if json_path else ""
+        console.print(
+            f"[green]Retrofitted[/green] {stats['decisions']} decision(s)"
+            f"{markdown_note}{json_note}"
+        )
 
 
 # ── Dependencies: external package ingestion (#58) ────────────────────────────

--- a/navegador/pm.py
+++ b/navegador/pm.py
@@ -44,6 +44,134 @@ logger = logging.getLogger(__name__)
 # schema — they represent requirements and commitments from the PM tool.
 _TICKET_LABEL = NodeLabel.Rule
 
+# Comment threads can run long; keep the stored discussion bounded.
+_DISCUSSION_MAX_CHARS = 8000
+
+_DECISION_PROMPT = """\
+You are extracting architectural/product decisions from a project ticket thread.
+
+Return a JSON array (and nothing else). Each element:
+  {{"name": "short imperative decision title",
+    "description": "what was decided",
+    "rationale": "why, per the thread",
+    "alternatives": "alternatives considered, or empty string",
+    "code_refs": ["function or class names the decision concerns"]}}
+
+Only include genuine decisions (a choice was made or a direction settled).
+Return [] if the thread contains none.
+
+Thread:
+
+{thread}
+"""
+
+
+def _strip_code_fences(text: str) -> str:
+    """Strip a surrounding ```json ... ``` fence if the LLM added one."""
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else ""
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+    return text.strip()
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")[:60] or "decision"
+
+
+def retrofit_decisions(
+    store: GraphStore,
+    memory_dir: str | None = None,
+    json_path: str | None = None,
+    domain: str = "",
+) -> dict[str, Any]:
+    """
+    Write Decision nodes back into a brain's memory store.
+
+    Markdown files use the frontmatter format MemoryIngester ingests
+    (``type: project`` maps back to Decision), so the loop
+    issues → graph → brain memory round-trips. JSON output is a plain list
+    suitable for an ``app/decisions.json`` store.
+
+    Args:
+        store: Graph to read Decision nodes from.
+        memory_dir: When set, write one ``project_<slug>.md`` per decision here.
+        json_path: When set, write the full decision list as JSON here.
+        domain: Optional domain filter.
+
+    Returns:
+        dict with keys: decisions, markdown_files, json_path
+    """
+    from pathlib import Path
+
+    cypher = "MATCH (d:Decision)"
+    params: dict[str, Any] = {}
+    if domain:
+        cypher += " WHERE d.domain = $domain"
+        params["domain"] = domain
+    cypher += (
+        " RETURN d.name, d.description, d.rationale, d.alternatives, d.status, d.date, d.domain"
+        " ORDER BY d.name"
+    )
+    result = store.query(cypher, params)
+
+    decisions = [
+        {
+            "name": str(row[0]),
+            "description": str(row[1] or ""),
+            "rationale": str(row[2] or ""),
+            "alternatives": str(row[3] or ""),
+            "status": str(row[4] or ""),
+            "date": str(row[5] or ""),
+            "domain": str(row[6] or ""),
+        }
+        for row in (result.result_set or [])
+        if row[0]
+    ]
+
+    markdown_files = 0
+    if memory_dir:
+        out_dir = Path(memory_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for decision in decisions:
+            first_line = decision["description"].splitlines()[0] if decision["description"] else ""
+            body_parts = [decision["description"]]
+            if decision["rationale"]:
+                body_parts.append(f"**Rationale:** {decision['rationale']}")
+            if decision["alternatives"]:
+                body_parts.append(f"**Alternatives considered:** {decision['alternatives']}")
+            content = (
+                "---\n"
+                f"name: {decision['name']}\n"
+                f"description: {first_line[:200]}\n"
+                "type: project\n"
+                "---\n\n" + "\n\n".join(part for part in body_parts if part) + "\n"
+            )
+            (out_dir / f"project_{_slugify(decision['name'])}.md").write_text(
+                content, encoding="utf-8"
+            )
+            markdown_files += 1
+
+    if json_path:
+        import json as _json
+
+        path = Path(json_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_json.dumps(decisions, indent=2) + "\n", encoding="utf-8")
+
+    logger.info(
+        "retrofit_decisions: %d decisions → markdown=%s json=%s",
+        len(decisions),
+        memory_dir or "-",
+        json_path or "-",
+    )
+    return {
+        "decisions": len(decisions),
+        "markdown_files": markdown_files,
+        "json_path": json_path or "",
+    }
+
 
 class TicketIngester:
     """
@@ -72,6 +200,7 @@ class TicketIngester:
         token: str = "",
         state: str = "open",
         limit: int = 100,
+        include_comments: bool = True,
     ) -> dict[str, Any]:
         """
         Fetch GitHub issues for *repo* and ingest them into the graph.
@@ -87,13 +216,15 @@ class TicketIngester:
             ``"open"``, ``"closed"``, or ``"all"``.
         limit:
             Maximum number of issues to fetch (GitHub paginates at 100/page).
+        include_comments:
+            When True (default), each issue's comment thread is fetched and
+            stored on the Ticket node as a ``discussion`` property — that is
+            where most architectural "why" discussion actually lives.
 
         Returns
         -------
-        dict with keys: tickets, linked
+        dict with keys: tickets, comments, linked
         """
-        import urllib.request
-
         headers: dict[str, str] = {
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
@@ -106,11 +237,7 @@ class TicketIngester:
         url = f"https://api.github.com/repos/{repo}/issues?state={state}&per_page={per_page}&page=1"
 
         try:
-            req = urllib.request.Request(url, headers=headers)
-            with urllib.request.urlopen(req, timeout=15) as resp:
-                import json
-
-                issues: list[dict] = json.loads(resp.read().decode())
+            issues: list[dict] = self._fetch_json(url, headers)
         except Exception as exc:
             raise RuntimeError(f"Failed to fetch GitHub issues for {repo!r}: {exc}") from exc
 
@@ -119,6 +246,7 @@ class TicketIngester:
 
         domain = repo.split("/")[-1] if "/" in repo else repo
         tickets_created = 0
+        comments_ingested = 0
 
         for issue in issues[:limit]:
             number = issue.get("number", 0)
@@ -127,6 +255,17 @@ class TicketIngester:
             html_url = issue.get("html_url", "")
             labels = [lbl.get("name", "") for lbl in issue.get("labels", [])]
             severity = self._github_severity(labels)
+
+            discussion = ""
+            comments_count = int(issue.get("comments") or 0)
+            if include_comments and comments_count:
+                comments = self._fetch_issue_comments(repo, number, headers)
+                comments_ingested += len(comments)
+                discussion = "\n\n".join(
+                    f"**{c.get('user', {}).get('login', 'unknown')}**: "
+                    f"{(c.get('body') or '').strip()}"
+                    for c in comments
+                )
 
             node_name = f"#{number}: {title}"[:200]
             self.store.create_node(
@@ -138,6 +277,8 @@ class TicketIngester:
                     "severity": severity,
                     "rationale": html_url,
                     "examples": "",
+                    "discussion": discussion[:_DISCUSSION_MAX_CHARS],
+                    "comments_count": comments_count,
                 },
             )
             tickets_created += 1
@@ -160,12 +301,144 @@ class TicketIngester:
 
         linked = self._link_to_code(domain)
         logger.info(
-            "TicketIngester.ingest_github_issues(%s): tickets=%d linked=%d",
+            "TicketIngester.ingest_github_issues(%s): tickets=%d comments=%d linked=%d",
             repo,
             tickets_created,
+            comments_ingested,
             linked,
         )
-        return {"tickets": tickets_created, "linked": linked}
+        return {"tickets": tickets_created, "comments": comments_ingested, "linked": linked}
+
+    @staticmethod
+    def _fetch_json(url: str, headers: dict[str, str]) -> Any:
+        import json
+        import urllib.request
+
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode())
+
+    def _fetch_issue_comments(self, repo: str, number: int, headers: dict[str, str]) -> list[dict]:
+        """Fetch one page (up to 100) of comments for an issue; [] on failure."""
+        url = f"https://api.github.com/repos/{repo}/issues/{number}/comments?per_page=100"
+        try:
+            comments = self._fetch_json(url, headers)
+            return comments if isinstance(comments, list) else []
+        except Exception:
+            logger.warning("Could not fetch comments for %s#%d", repo, number, exc_info=True)
+            return []
+
+    # ── Decision extraction (LLM) ─────────────────────────────────────────────
+
+    def extract_decisions(
+        self,
+        domain: str = "",
+        llm_provider: str = "anthropic",
+        llm_model: str = "",
+    ) -> dict[str, Any]:
+        """
+        Surface architectural decisions from ingested ticket threads.
+
+        Runs each ticket's title + body + discussion through an LLM (reuses
+        the ``[llm]`` provider abstraction) prompting for a strict-JSON list
+        of decisions. Each becomes a Decision node linked DOCUMENTS → the
+        Ticket, and DOCUMENTS → any code symbols the decision references by
+        name.
+
+        Returns
+        -------
+        dict with keys: tickets_scanned, decisions, code_links
+        """
+        import json as _json
+
+        from navegador.llm import get_provider
+
+        provider = get_provider(llm_provider, llm_model)
+
+        result = self.store.query(
+            "MATCH (t:Rule) WHERE t.domain = $domain AND t.rationale STARTS WITH 'http' "
+            "RETURN t.name, t.description, t.discussion",
+            {"domain": domain},
+        )
+        tickets = [
+            (str(row[0]), str(row[1] or ""), str(row[2] or ""))
+            for row in (result.result_set or [])
+            if row[0]
+        ]
+
+        decisions_created = 0
+        code_links = 0
+        for t_name, t_desc, t_discussion in tickets:
+            thread = f"# {t_name}\n\n{t_desc}\n\n## Discussion\n\n{t_discussion}".strip()
+            try:
+                response = provider.complete(_DECISION_PROMPT.format(thread=thread[:12000]))
+                decisions = _json.loads(_strip_code_fences(response))
+            except Exception:
+                logger.warning("Decision extraction failed for %s", t_name, exc_info=True)
+                continue
+            if not isinstance(decisions, list):
+                continue
+
+            for decision in decisions:
+                if not isinstance(decision, dict) or not decision.get("name"):
+                    continue
+                d_name = str(decision["name"]).strip()[:200]
+                self.store.create_node(
+                    NodeLabel.Decision,
+                    {
+                        "name": d_name,
+                        "description": str(decision.get("description") or "")[:2000],
+                        "domain": domain,
+                        "rationale": str(decision.get("rationale") or "")[:2000],
+                        "alternatives": str(decision.get("alternatives") or "")[:2000],
+                        "date": "",
+                        "status": "extracted",
+                    },
+                )
+                self.store.create_edge(
+                    NodeLabel.Decision,
+                    {"name": d_name},
+                    EdgeType.DOCUMENTS,
+                    _TICKET_LABEL,
+                    {"name": t_name},
+                )
+                decisions_created += 1
+                code_refs = decision.get("code_refs") or []
+                if isinstance(code_refs, list):
+                    code_links += self._link_decision_to_code(d_name, code_refs)
+
+        logger.info(
+            "TicketIngester.extract_decisions(%s): tickets=%d decisions=%d code_links=%d",
+            domain,
+            len(tickets),
+            decisions_created,
+            code_links,
+        )
+        return {
+            "tickets_scanned": len(tickets),
+            "decisions": decisions_created,
+            "code_links": code_links,
+        }
+
+    def _link_decision_to_code(self, decision_name: str, code_refs: list) -> int:
+        """DOCUMENTS edges from a Decision to code symbols it references by name."""
+        linked = 0
+        for ref in code_refs:
+            ref = str(ref).strip()
+            if not ref:
+                continue
+            for label in ("Function", "Class", "Method"):
+                cypher = (
+                    "MATCH (d:Decision {name: $dn}), (c:" + label + " {name: $cn}) "
+                    "MERGE (d)-[r:DOCUMENTS]->(c) RETURN count(r)"
+                )
+                try:
+                    result = self.store.query(cypher, {"dn": decision_name, "cn": ref})
+                    if result.result_set and result.result_set[0][0]:
+                        linked += int(result.result_set[0][0])
+                except Exception:
+                    logger.debug("Could not link decision %s → %s", decision_name, ref)
+        return linked
 
     # ── Linear (stub) ─────────────────────────────────────────────────────────
 

--- a/tests/test_pm_decisions.py
+++ b/tests/test_pm_decisions.py
@@ -1,0 +1,247 @@
+"""Tests for #125 — pm ingest pulls issue comment threads, extracts Decision
+nodes from them via LLM, and retrofits decisions into a brain's memory store.
+
+Graph assertions run against real embedded FalkorDB stores; the GitHub API
+and LLM provider are mocked at their seams."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from navegador.cli.commands import main
+from navegador.graph.store import GraphStore
+from navegador.ingestion.memory import MemoryIngester
+from navegador.pm import TicketIngester, _strip_code_fences, retrofit_decisions
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("pm") / "graph.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture(autouse=True)
+def _clean(store):
+    store.clear()
+
+
+_ISSUE = {
+    "number": 7,
+    "title": "Pick a cache layer",
+    "body": "We need caching.",
+    "html_url": "https://github.com/o/r/issues/7",
+    "labels": [],
+    "assignees": [],
+    "comments": 2,
+}
+
+_COMMENTS = [
+    {"user": {"login": "leo"}, "body": "Redis fits the existing infra."},
+    {"user": {"login": "ana"}, "body": "Agreed — decision: use Redis over memcached."},
+]
+
+
+def _fake_fetch(url, headers):
+    if "/comments" in url:
+        return list(_COMMENTS)
+    return [dict(_ISSUE)]
+
+
+def _ticket_row(store):
+    result = store.query("MATCH (t:Rule) RETURN t.name, t.discussion, t.comments_count LIMIT 1")
+    return result.result_set[0]
+
+
+# ── Comment ingestion ──────────────────────────────────────────────────────
+
+
+class TestCommentIngestion:
+    def test_comments_attached_to_ticket(self, store):
+        ing = TicketIngester(store)
+        with patch.object(TicketIngester, "_fetch_json", side_effect=_fake_fetch):
+            stats = ing.ingest_github_issues("o/r")
+
+        assert stats["tickets"] == 1
+        assert stats["comments"] == 2
+        name, discussion, comments_count = _ticket_row(store)
+        assert name == "#7: Pick a cache layer"
+        assert "**leo**: Redis fits the existing infra." in discussion
+        assert "**ana**: Agreed" in discussion
+        assert comments_count == 2
+
+    def test_no_comments_flag_skips_fetch(self, store):
+        ing = TicketIngester(store)
+        with patch.object(TicketIngester, "_fetch_json", side_effect=_fake_fetch) as fetch:
+            stats = ing.ingest_github_issues("o/r", include_comments=False)
+
+        assert stats["comments"] == 0
+        assert fetch.call_count == 1  # only the issue list, no comment calls
+        _, discussion, _ = _ticket_row(store)
+        assert discussion == ""
+
+    def test_comment_fetch_failure_degrades_gracefully(self, store):
+        def _failing_fetch(url, headers):
+            if "/comments" in url:
+                raise OSError("rate limited")
+            return [dict(_ISSUE)]
+
+        ing = TicketIngester(store)
+        with patch.object(TicketIngester, "_fetch_json", side_effect=_failing_fetch):
+            stats = ing.ingest_github_issues("o/r")
+
+        assert stats["tickets"] == 1
+        assert stats["comments"] == 0
+
+
+# ── Decision extraction ────────────────────────────────────────────────────
+
+
+_LLM_RESPONSE = """```json
+[{"name": "Use Redis for caching",
+  "description": "Redis chosen as the cache layer.",
+  "rationale": "Fits the existing infra.",
+  "alternatives": "memcached",
+  "code_refs": ["get_cached"]}]
+```"""
+
+
+def _provider(response):
+    provider = MagicMock()
+    provider.complete.return_value = response
+    return provider
+
+
+class TestDecisionExtraction:
+    def _seed(self, store):
+        ing = TicketIngester(store)
+        with patch.object(TicketIngester, "_fetch_json", side_effect=_fake_fetch):
+            ing.ingest_github_issues("o/r")
+        store.create_node("Function", {"name": "get_cached", "file_path": "cache.py"})
+        return ing
+
+    def test_decisions_extracted_and_linked(self, store):
+        ing = self._seed(store)
+        with patch("navegador.llm.get_provider", return_value=_provider(_LLM_RESPONSE)):
+            stats = ing.extract_decisions(domain="r")
+
+        assert stats == {"tickets_scanned": 1, "decisions": 1, "code_links": 1}
+        result = store.query("MATCH (d:Decision) RETURN d.name, d.rationale, d.status").result_set
+        assert result == [["Use Redis for caching", "Fits the existing infra.", "extracted"]]
+
+        ticket_edges = store.query(
+            "MATCH (d:Decision)-[:DOCUMENTS]->(t:Rule) RETURN t.name"
+        ).result_set
+        assert ticket_edges == [["#7: Pick a cache layer"]]
+        code_edges = store.query(
+            "MATCH (d:Decision)-[:DOCUMENTS]->(f:Function) RETURN f.name"
+        ).result_set
+        assert code_edges == [["get_cached"]]
+
+    def test_invalid_llm_json_is_skipped(self, store):
+        ing = self._seed(store)
+        with patch("navegador.llm.get_provider", return_value=_provider("not json at all")):
+            stats = ing.extract_decisions(domain="r")
+
+        assert stats["decisions"] == 0
+        assert (store.query("MATCH (d:Decision) RETURN count(d)").result_set)[0][0] == 0
+
+    def test_strip_code_fences(self):
+        assert _strip_code_fences('```json\n[{"a": 1}]\n```') == '[{"a": 1}]'
+        assert _strip_code_fences('[{"a": 1}]') == '[{"a": 1}]'
+
+
+# ── Retrofit into brain memory ─────────────────────────────────────────────
+
+
+class TestRetrofit:
+    def _seed_decision(self, store):
+        store.create_node(
+            "Decision",
+            {
+                "name": "Use Redis for caching",
+                "description": "Redis chosen as the cache layer.",
+                "domain": "r",
+                "rationale": "Fits the existing infra.",
+                "alternatives": "memcached",
+                "date": "",
+                "status": "extracted",
+            },
+        )
+
+    def test_markdown_round_trips_through_memory_ingester(self, store, tmp_path):
+        self._seed_decision(store)
+        memory_dir = tmp_path / "memory"
+        stats = retrofit_decisions(store, memory_dir=str(memory_dir))
+
+        assert stats["decisions"] == 1
+        assert stats["markdown_files"] == 1
+        md = (memory_dir / "project_use-redis-for-caching.md").read_text(encoding="utf-8")
+        assert "name: Use Redis for caching" in md
+        assert "type: project" in md
+        assert "**Rationale:** Fits the existing infra." in md
+
+        # Round-trip: the brain's MemoryIngester reads it back as a Decision
+        brain = GraphStore.sqlite(str(tmp_path / "brain" / "graph.db"))
+        try:
+            MemoryIngester(brain).ingest(memory_dir, repo_name="brain")
+            rows = brain.query("MATCH (d:Decision) RETURN d.name, d.memory_type").result_set
+            assert rows == [["Use Redis for caching", "project"]]
+        finally:
+            brain.close()
+
+    def test_json_export(self, store, tmp_path):
+        self._seed_decision(store)
+        json_path = tmp_path / "app" / "decisions.json"
+        stats = retrofit_decisions(store, json_path=str(json_path))
+
+        assert stats["decisions"] == 1
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+        assert payload[0]["name"] == "Use Redis for caching"
+        assert payload[0]["alternatives"] == "memcached"
+
+    def test_domain_filter(self, store, tmp_path):
+        self._seed_decision(store)
+        stats = retrofit_decisions(store, json_path=str(tmp_path / "d.json"), domain="other")
+        assert stats["decisions"] == 0
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+class TestPmCli:
+    def test_decisions_requires_an_output(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["pm", "decisions"])
+        assert result.exit_code != 0
+        assert "--to-markdown" in result.output
+
+    def test_decisions_writes_markdown(self, store, tmp_path):
+        store.create_node(
+            "Decision",
+            {"name": "CLI decision", "description": "d", "domain": "", "rationale": ""},
+        )
+        runner = CliRunner()
+        with patch("navegador.cli.commands._get_store", return_value=store):
+            result = runner.invoke(
+                main, ["pm", "decisions", "--to-markdown", str(tmp_path / "mem")]
+            )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "mem" / "project_cli-decision.md").exists()
+
+    def test_pm_ingest_no_comments_flag(self, store):
+        runner = CliRunner()
+        with (
+            patch("navegador.cli.commands._get_store", return_value=store),
+            patch.object(TicketIngester, "_fetch_json", side_effect=_fake_fetch) as fetch,
+        ):
+            result = runner.invoke(
+                main, ["pm", "ingest", "--github", "o/r", "--no-comments", "--json"]
+            )
+        assert result.exit_code == 0, result.output
+        assert fetch.call_count == 1
+        assert json.loads(result.output)["comments"] == 0


### PR DESCRIPTION
## Summary
- **Comments:** `ingest_github_issues` gains `include_comments=True` — issues with comments get their thread fetched (`/issues/{n}/comments`, one page of 100) and stored on the Ticket node as `discussion` (`**author**: body` entries, bounded at 8k chars) plus `comments_count`; stats report totals. A failed comment fetch degrades to an empty thread instead of failing the ingest. `pm ingest --no-comments` opts out.
- **Decision extraction:** `TicketIngester.extract_decisions()` (CLI: `pm ingest --extract-decisions [--llm-provider/--llm-model]`) runs each ticket's title+body+discussion through one LLM completion prompting for a strict-JSON decision list. Each becomes a `Decision` node (`status: extracted`) linked `DOCUMENTS` → the Ticket and `DOCUMENTS` → referenced Function/Class/Method symbols matched by name. Fenced JSON is unwrapped; unparseable responses are skipped with a warning.
- **Retrofit bridge:** new `pm decisions` command — `--to-markdown memory/` writes one `project_<slug>.md` per decision in the exact frontmatter format `MemoryIngester` ingests (`type: project` maps back to Decision, verified round-trip in tests); `--to-json app/decisions.json` writes the plain list. `--domain` filters.

## Test plan
- New `tests/test_pm_decisions.py` (12 tests) against real embedded stores with GitHub API/LLM mocked at their seams: discussion attach + counts, `--no-comments` skips the fetch, comment-fetch failure degrades gracefully, extraction creates the Decision with both DOCUMENTS edges, invalid LLM JSON skipped, markdown retrofit **round-trips through the real MemoryIngester**, JSON export, domain filter, CLI usage error + happy paths.
- Full suite: 2903 passed locally.

Fixes #125