### PR TITLE
Keep incoming REFERENCES edges on incremental document re-parse

### DIFF
--- a/navegador/graph/queries.py
+++ b/navegador/graph/queries.py
@@ -270,9 +270,13 @@ MATCH (d:Document {path: $path})
 RETURN d.content_hash AS hash
 """
 
-DELETE_DOCUMENT = """
-MATCH (d:Document {path: $path})
-DETACH DELETE d
+# Clear a document's outgoing REFERENCES before re-parse. The node itself is
+# kept (re-parse MERGEs it by path) so incoming REFERENCES from documents that
+# are not being re-parsed survive — detach-deleting the node destroyed them
+# and nothing rebuilt them (#142).
+CLEAR_DOCUMENT_REFERENCES = """
+MATCH (d:Document {path: $path})-[r:REFERENCES]->()
+DELETE r
 """
 
 # ── Memory-backed knowledge nodes ─────────────────────────────────────────────

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -269,7 +269,7 @@ class RepoIngester:
     def _clear_file_subgraph(self, rel_path: str) -> None:
         suffix = Path(rel_path).suffix.lower()
         if suffix in self._DOCUMENT_EXTENSIONS:
-            self.store.query(queries.DELETE_DOCUMENT, {"path": rel_path})
+            self.store.query(queries.CLEAR_DOCUMENT_REFERENCES, {"path": rel_path})
         else:
             self.store.query(queries.DELETE_FILE_SUBGRAPH, {"path": rel_path})
 

--- a/tests/test_incremental_references.py
+++ b/tests/test_incremental_references.py
@@ -1,0 +1,109 @@
+"""Regression tests for #142 — incremental ingest must not drop cross-document
+REFERENCES edges when documents are re-parsed.
+
+Uses a real embedded FalkorDB graph: the bug was a DETACH DELETE destroying
+incoming edges, which mocked stores cannot observe.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from navegador.graph.store import GraphStore
+from navegador.ingestion.parser import RepoIngester
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("incref") / "graph.db"))
+    yield s
+    s.close()
+
+
+def _write_docs(root: Path) -> None:
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text("# Conventions\n\nshared doc\n", encoding="utf-8")
+    # guide1 -> guide2 -> guide3 -> guide1 cycle, all -> README
+    for i in (1, 2, 3):
+        nxt = i % 3 + 1
+        (root / "docs" / f"guide{i}.md").write_text(
+            f"# Guide {i}\n\nsee [conventions](../README.md) and [next](guide{nxt}.md)\n",
+            encoding="utf-8",
+        )
+
+
+def _references(store) -> set[tuple[str, str]]:
+    result = store.query("MATCH (a:Document)-[:REFERENCES]->(b:Document) RETURN a.path, b.path")
+    return {(row[0], row[1]) for row in result.result_set or []}
+
+
+FULL_EDGE_SET = {
+    ("docs/guide1.md", "README.md"),
+    ("docs/guide2.md", "README.md"),
+    ("docs/guide3.md", "README.md"),
+    ("docs/guide1.md", "docs/guide2.md"),
+    ("docs/guide2.md", "docs/guide3.md"),
+    ("docs/guide3.md", "docs/guide1.md"),
+}
+
+
+class TestIncrementalReferences:
+    def test_full_ingest_builds_all_edges(self, store, tmp_path):
+        _write_docs(tmp_path)
+        RepoIngester(store).ingest(tmp_path, clear=True)
+        assert _references(store) == FULL_EDGE_SET
+
+    def test_reparse_keeps_incoming_edges_from_unchanged_docs(self, store, tmp_path):
+        """Editing guide1 must not lose guide3 -> guide1 (guide3 is hash-skipped)."""
+        _write_docs(tmp_path)
+        ingester = RepoIngester(store)
+        ingester.ingest(tmp_path, clear=True)
+
+        guide1 = tmp_path / "docs" / "guide1.md"
+        guide1.write_text(guide1.read_text(encoding="utf-8") + "\nedited\n", encoding="utf-8")
+        stats = ingester.ingest(tmp_path, incremental=True)
+
+        assert stats["skipped"] >= 2  # the other docs were hash-skipped
+        assert _references(store) == FULL_EDGE_SET
+
+    def test_reparse_of_two_linked_docs_keeps_edge_between_them(self, store, tmp_path):
+        """Editing guide1 AND guide2: guide2's re-parse must not destroy the
+        guide1 -> guide2 edge that guide1's earlier re-parse just rebuilt."""
+        _write_docs(tmp_path)
+        ingester = RepoIngester(store)
+        ingester.ingest(tmp_path, clear=True)
+
+        for name in ("guide1.md", "guide2.md"):
+            doc = tmp_path / "docs" / name
+            doc.write_text(doc.read_text(encoding="utf-8") + "\nedited\n", encoding="utf-8")
+        ingester.ingest(tmp_path, incremental=True)
+
+        assert _references(store) == FULL_EDGE_SET
+
+    def test_removed_link_disappears_on_reparse(self, store, tmp_path):
+        """Outgoing edges still track current content — dropping a link removes its edge."""
+        _write_docs(tmp_path)
+        ingester = RepoIngester(store)
+        ingester.ingest(tmp_path, clear=True)
+
+        (tmp_path / "docs" / "guide1.md").write_text(
+            "# Guide 1\n\nsee [next](guide2.md)\n", encoding="utf-8"
+        )
+        ingester.ingest(tmp_path, incremental=True)
+
+        assert _references(store) == FULL_EDGE_SET - {("docs/guide1.md", "README.md")}
+
+    def test_incremental_matches_full_ingest_fixpoint(self, store, tmp_path):
+        """After edits + incremental ingest, the edge set equals a from-scratch full ingest."""
+        _write_docs(tmp_path)
+        ingester = RepoIngester(store)
+        ingester.ingest(tmp_path, clear=True)
+
+        for name in ("guide1.md", "guide2.md", "guide3.md"):
+            doc = tmp_path / "docs" / name
+            doc.write_text(doc.read_text(encoding="utf-8") + "\nedited\n", encoding="utf-8")
+        ingester.ingest(tmp_path, incremental=True)
+        incremental_edges = _references(store)
+
+        ingester.ingest(tmp_path, clear=True)
+        assert incremental_edges == _references(store)

--- a/tests/test_parser_dispatch.py
+++ b/tests/test_parser_dispatch.py
@@ -26,7 +26,7 @@ def _make_store(file_hash_result=None):
                 r.result_set = [[file_hash_result]]
             else:
                 r.result_set = []
-        elif cypher in (queries.DELETE_FILE_SUBGRAPH, queries.DELETE_DOCUMENT):
+        elif cypher in (queries.DELETE_FILE_SUBGRAPH, queries.CLEAR_DOCUMENT_REFERENCES):
             r.result_set = []
         else:
             r.result_set = []
@@ -150,8 +150,8 @@ class TestFileUnchanged:
 
 
 class TestClearFileSubgraph:
-    def test_md_file_uses_delete_document_query(self):
-        """For .md files, _clear_file_subgraph should use DELETE_DOCUMENT."""
+    def test_md_file_uses_clear_document_references_query(self):
+        """For .md files, _clear_file_subgraph should use CLEAR_DOCUMENT_REFERENCES."""
         store = MagicMock()
         call_log = []
 
@@ -165,7 +165,7 @@ class TestClearFileSubgraph:
         ingester = RepoIngester(store)
         ingester._clear_file_subgraph("docs/guide.md")
 
-        assert any(queries.DELETE_DOCUMENT in q for q in call_log)
+        assert any(queries.CLEAR_DOCUMENT_REFERENCES in q for q in call_log)
 
     def test_py_file_uses_delete_file_subgraph_query(self):
         """For .py files, _clear_file_subgraph should use DELETE_FILE_SUBGRAPH."""


### PR DESCRIPTION
Fixes #142.

## What changed

Incremental re-parse of a changed markdown document used `DELETE_DOCUMENT` — a `DETACH DELETE` of the Document node — before re-parsing. Detaching the node destroyed its **incoming** REFERENCES edges, and nothing rebuilt them:

1. An unchanged doc B linking a changed doc A is hash-skipped, so B→A is destroyed by A's detach-delete and never recreated.
2. When two changed docs link each other (A→B, A walked first), A's re-parse rebuilds A→B, then B's own detach-delete destroys it again — this is the reported "N edited docs all linking a shared doc lose exactly those N edges" shape.

The query is replaced by `CLEAR_DOCUMENT_REFERENCES`, which deletes only the document's *outgoing* REFERENCES edges and keeps the node. The re-parse MERGEs the Document by path (updating name/title/content in place) and recreates outgoing edges from current content, so removed links still disappear correctly.

## Test plan

- `tests/test_incremental_references.py` — 5 regression tests against a **real embedded FalkorDB** graph: full-ingest edge set, incoming-edge survival from unchanged docs, edge survival between two re-parsed docs, removed-link cleanup, and incremental == full-ingest fixpoint. 4 of 5 fail without the fix.
- Existing `test_parser_dispatch.py` updated for the renamed query.
- Full suite: 2919 passed.
- End-to-end CLI verification of the exact reported scenario (7 referencing docs edited, `ingest --incremental`, conflict-kg export diff): 0 edges lost.