### PR TITLE
Reach call-graph fixpoint in a single ingest pass

### DIFF
--- a/navegador/graph/store.py
+++ b/navegador/graph/store.py
@@ -155,8 +155,15 @@ class GraphStore:
         to_label: str,
         to_key: dict[str, Any],
         props: dict[str, Any] | None = None,
-    ) -> None:
-        """Create a directed edge between two nodes, merging if it already exists."""
+    ) -> bool:
+        """
+        Create a directed edge between two nodes, merging if it already exists.
+
+        Returns True when both endpoints matched (edge created or already
+        present), False when an endpoint node does not exist — the MERGE
+        silently no-ops in that case, so callers that can retry later (e.g.
+        the ingest resolution sweep, #143) need the distinction.
+        """
         from_match = ", ".join(f"{k}: $from_{k}" for k in from_key)
         to_match = ", ".join(f"{k}: $to_{k}" for k in to_key)
         prop_set = ""
@@ -165,14 +172,17 @@ class GraphStore:
 
         cypher = (
             f"MATCH (a:{from_label} {{{from_match}}}), (b:{to_label} {{{to_match}}}) "
-            f"MERGE (a)-[r:{edge_type}]->(b){prop_set}"
+            f"MERGE (a)-[r:{edge_type}]->(b){prop_set} "
+            f"RETURN count(r) AS matched"
         )
         params = {f"from_{k}": v for k, v in from_key.items()}
         params.update({f"to_{k}": v for k, v in to_key.items()})
         if props:
             params.update({f"p_{k}": v for k, v in props.items()})
 
-        self.query(cypher, params)
+        result = self.query(cypher, params)
+        rows = result.result_set or []
+        return bool(rows and rows[0][0])
 
     def clear(self) -> None:
         """Delete all nodes and edges in the graph."""

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -135,6 +135,21 @@ class RepoIngester:
         if clear:
             self.store.clear()
 
+        # Proxy the store for this pass: create_edge calls whose endpoint
+        # nodes don't exist yet (forward references — callee parsed later)
+        # are queued and replayed once after the walk, when the node set is
+        # final, so a single pass reaches the call-graph fixpoint (#143).
+        original_store = self.store
+        proxy = _EdgeDeferringStore(original_store)
+        self.store = proxy
+        try:
+            stats = self._ingest_walk(repo_path, incremental)
+        finally:
+            self.store = original_store
+        stats["edges_resolved"] = self._resolve_deferred_edges(proxy.deferred)
+        return stats
+
+    def _ingest_walk(self, repo_path: Path, incremental: bool) -> dict[str, int]:
         # Create repository node
         self.store.create_node(
             NodeLabel.Repository,
@@ -220,6 +235,31 @@ class RepoIngester:
             stats["skipped"],
         )
         return stats
+
+    def _resolve_deferred_edges(self, deferred: list[tuple[tuple, dict]]) -> int:
+        """
+        Replay edge creations that missed an endpoint during the walk.
+
+        By now every node from the pass exists, so one replay reaches the
+        fixpoint — edges never create nodes. Entries whose endpoint is
+        genuinely absent from the repo (library calls, builtins) stay
+        unresolved and are dropped, exactly as before.
+        """
+        resolved = 0
+        seen: set[str] = set()
+        for args, kwargs in deferred:
+            key = repr((args, kwargs))
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                if self.store.create_edge(*args, **kwargs):
+                    resolved += 1
+            except Exception:
+                logger.exception("Failed to replay deferred edge: %r", args)
+        if resolved:
+            logger.info("Resolution sweep created %d forward-reference edges", resolved)
+        return resolved
 
     def watch(
         self,
@@ -557,6 +597,31 @@ class RepoIngester:
 
             return MarkdownParser()
         raise ValueError(f"Unsupported language: {language}")
+
+
+class _EdgeDeferringStore:
+    """
+    Proxy over a GraphStore for the duration of one ingest pass.
+
+    ``create_edge`` calls whose endpoints don't both exist yet (forward
+    references — the callee's node is created by a file parsed later) are
+    recorded in ``deferred`` instead of being silently dropped;
+    :meth:`RepoIngester._resolve_deferred_edges` replays them once after the
+    walk (#143). Every other attribute passes through to the real store.
+    """
+
+    def __init__(self, store: GraphStore) -> None:
+        self._store = store
+        self.deferred: list[tuple[tuple, dict]] = []
+
+    def __getattr__(self, name):
+        return getattr(self._store, name)
+
+    def create_edge(self, *args, **kwargs) -> bool:
+        matched = self._store.create_edge(*args, **kwargs)
+        if not matched:
+            self.deferred.append((args, kwargs))
+        return matched
 
 
 def _file_hash(path: Path) -> str:

--- a/tests/test_ingest_fixpoint.py
+++ b/tests/test_ingest_fixpoint.py
@@ -1,0 +1,106 @@
+"""Regression tests for #143 — a single ingest pass must reach the
+call-graph fixpoint. Forward references (a caller parsed before its callee's
+node exists) were silently dropped by the MATCH...MERGE edge query, so repeat
+passes kept adding CALLS edges.
+
+Uses a real embedded FalkorDB graph — the bug lives in MERGE no-op semantics
+that mocked stores cannot observe.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from navegador.graph.store import GraphStore
+from navegador.ingestion.parser import RepoIngester
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("fixpoint") / "graph.db"))
+    yield s
+    s.close()
+
+
+def _calls(store) -> set[tuple[str, str]]:
+    result = store.query(
+        "MATCH (a)-[:CALLS]->(b) RETURN a.name + ':' + a.file_path, b.name + ':' + b.file_path"
+    )
+    return {(row[0], row[1]) for row in result.result_set or []}
+
+
+def _all_edges(store) -> set[tuple]:
+    result = store.query(
+        "MATCH (a)-[r]->(b) RETURN labels(a)[0], a.name, type(r), labels(b)[0], b.name, "
+        "coalesce(a.file_path, a.path, ''), coalesce(b.file_path, b.path, '')"
+    )
+    return {tuple(row) for row in result.result_set or []}
+
+
+def _write(root: Path, rel: str, content: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestCallGraphFixpoint:
+    def test_forward_reference_within_file_resolved_in_one_pass(self, store, tmp_path):
+        """A function calling a helper defined *below* it gets its CALLS edge
+        on the first pass."""
+        _write(
+            tmp_path,
+            "app.py",
+            "def caller():\n    return helper()\n\n\ndef helper():\n    return 1\n",
+        )
+        RepoIngester(store).ingest(tmp_path, clear=True)
+        assert ("caller:app.py", "helper:app.py") in _calls(store)
+
+    def test_call_to_undefined_function_stays_absent(self, store, tmp_path):
+        """Calls to builtins/library functions never materialize an edge."""
+        _write(tmp_path, "app.py", "def caller():\n    return len([1])\n")
+        RepoIngester(store).ingest(tmp_path, clear=True)
+        assert _calls(store) == set()
+
+    def test_single_pass_reaches_fixpoint(self, store, tmp_path):
+        """Re-running ingest on the resulting graph adds zero edges."""
+        _write(
+            tmp_path,
+            "app.py",
+            "def a():\n    b()\n    c()\n\n\ndef b():\n    c()\n\n\ndef c():\n    pass\n",
+        )
+        _write(
+            tmp_path,
+            "util.py",
+            "def top():\n    return bottom()\n\n\ndef bottom():\n    return 0\n",
+        )
+        ingester = RepoIngester(store)
+        ingester.ingest(tmp_path, clear=True)
+        first_pass = _all_edges(store)
+
+        ingester.ingest(tmp_path)  # same cycle again, no clear
+        assert _all_edges(store) == first_pass
+
+    def test_clean_rebuild_matches_repeat_pass_graph(self, store, tmp_path):
+        """clean rebuild == maintained graph: --clear rebuild produces the
+        same edge set as a graph that went through repeated passes."""
+        _write(
+            tmp_path,
+            "app.py",
+            "def a():\n    b()\n\n\ndef b():\n    a()\n",
+        )
+        ingester = RepoIngester(store)
+        ingester.ingest(tmp_path, clear=True)
+        ingester.ingest(tmp_path)
+        maintained = _all_edges(store)
+
+        ingester.ingest(tmp_path, clear=True)
+        assert _all_edges(store) == maintained
+
+    def test_stats_report_resolved_forward_references(self, store, tmp_path):
+        _write(
+            tmp_path,
+            "app.py",
+            "def caller():\n    return helper()\n\n\ndef helper():\n    return 1\n",
+        )
+        stats = RepoIngester(store).ingest(tmp_path, clear=True)
+        assert stats["edges_resolved"] == 1


### PR DESCRIPTION
Fixes #143.

## What changed

Parsers create CALLS/DEPENDS_ON edges with `MATCH (caller), (callee) MERGE ...`. When the callee's node doesn't exist yet — a forward reference to a function defined later in the walk — the MATCH finds nothing and the MERGE silently no-ops, dropping the call site. A second full pass found the callee already in the graph and added the edge, hence the monotonic edge growth across repeat passes reported in the issue.

Two changes:

- `GraphStore.create_edge` now appends `RETURN count(r)` and returns a bool: True when both endpoints matched (edge created or already present), False when an endpoint was missing.
- `RepoIngester.ingest` proxies the store for the duration of the pass (`_EdgeDeferringStore`): unresolved `create_edge` calls are queued and replayed once after the full walk, when the node set is final. One replay reaches the fixpoint because edges never create nodes. Unresolvable entries (builtins, library calls) drop exactly as before. The sweep result is reported as `stats["edges_resolved"]`.

This covers all 13+ language parsers and every workspace flow (monorepo, submodules, multirepo) automatically — they all drive `RepoIngester.ingest` per repo and all edges go through `store.create_edge`.

## Test plan

- `tests/test_ingest_fixpoint.py` — 5 tests against a real embedded FalkorDB: forward reference resolved in one pass, undefined callee stays absent, pass 2 adds zero edges, clean `--clear` rebuild == maintained graph, stats reporting. 4 of 5 fail without the fix.
- Full suite: 2919 passed.
- E2E on navegador's own source tree: pass 1 resolves 23 forward-reference edges, pass 2 resolves 0 and total edge count is unchanged (1531 == 1531).