### PR TITLE
Key Repository nodes by portable identity, not absolute checkout path

### DIFF
--- a/navegador/ingestion/optimization.py
+++ b/navegador/ingestion/optimization.py
@@ -361,12 +361,13 @@ class ParallelIngester:
         if clear:
             self._store.clear()
 
-        # Repository node (same as RepoIngester.ingest).
+        # Repository node (same as RepoIngester.ingest) — keyed by name, not
+        # the machine-local checkout path (#145).
         self._store.create_node(
             NodeLabel.Repository,
             {
                 "name": repo_path.name,
-                "path": str(repo_path),
+                "path": repo_path.name,
             },
         )
 

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -116,6 +116,7 @@ class RepoIngester:
         repo_path: str | Path,
         clear: bool = False,
         incremental: bool = False,
+        repo_key: str | None = None,
     ) -> dict[str, int]:
         """
         Ingest a repository into the graph.
@@ -124,6 +125,10 @@ class RepoIngester:
             repo_path: Path to the repository root.
             clear: If True, wipe the graph before ingesting.
             incremental: If True, skip files whose content hash hasn't changed.
+            repo_key: Portable graph identity for the Repository node
+                (defaults to the repo directory name). Workspace ingesters
+                pass the workspace-relative path here so nested repos with
+                the same basename stay distinct.
 
         Returns:
             Dict with counts: files, functions, classes, edges, skipped.
@@ -143,19 +148,23 @@ class RepoIngester:
         proxy = _EdgeDeferringStore(original_store)
         self.store = proxy
         try:
-            stats = self._ingest_walk(repo_path, incremental)
+            stats = self._ingest_walk(repo_path, incremental, repo_key)
         finally:
             self.store = original_store
         stats["edges_resolved"] = self._resolve_deferred_edges(proxy.deferred)
         return stats
 
-    def _ingest_walk(self, repo_path: Path, incremental: bool) -> dict[str, int]:
-        # Create repository node
+    def _ingest_walk(
+        self, repo_path: Path, incremental: bool, repo_key: str | None = None
+    ) -> dict[str, int]:
+        # Create repository node. Keyed by a portable identity, not the
+        # absolute checkout path — exports are committed/shared, and machine
+        # paths churned ids across machines and leaked local layout (#145).
         self.store.create_node(
             NodeLabel.Repository,
             {
                 "name": repo_path.name,
-                "path": str(repo_path),
+                "path": repo_key or repo_path.name,
                 "file_path": "",
             },
         )

--- a/navegador/monorepo.py
+++ b/navegador/monorepo.py
@@ -424,12 +424,13 @@ class MonorepoIngester:
         if clear:
             self.store.clear()
 
-        # Root node for the whole monorepo
+        # Root node for the whole monorepo. Keyed by workspace name, not the
+        # machine-local checkout path (#145).
         self.store.create_node(
             NodeLabel.Repository,
             {
                 "name": config.name,
-                "path": str(repo_path),
+                "path": config.name,
                 "file_path": "",
             },
         )
@@ -449,14 +450,17 @@ class MonorepoIngester:
                 continue
 
             pkg_name = pkg_path.name
+            pkg_rel = str(pkg_path.relative_to(repo_path))
             logger.info("Ingesting package: %s (%s)", pkg_name, pkg_path)
 
-            # Package-level Repository node
+            # Package-level Repository node, keyed by its workspace-relative
+            # path — portable, and distinct even when two packages share a
+            # directory basename (#145).
             self.store.create_node(
                 NodeLabel.Repository,
                 {
                     "name": pkg_name,
-                    "path": str(pkg_path),
+                    "path": pkg_rel,
                     "file_path": "",
                 },
             )
@@ -464,16 +468,16 @@ class MonorepoIngester:
             # Link package to monorepo root
             self.store.create_edge(
                 from_label=NodeLabel.Repository,
-                from_key={"name": config.name, "path": str(repo_path)},
+                from_key={"name": config.name, "path": config.name},
                 edge_type=EdgeType.CONTAINS,
                 to_label=NodeLabel.Repository,
-                to_key={"name": pkg_name, "path": str(pkg_path)},
+                to_key={"name": pkg_name, "path": pkg_rel},
             )
 
             # Ingest files in this package
             pkg_ingester = RepoIngester(self.store)
             try:
-                pkg_stats = pkg_ingester.ingest(pkg_path, clear=False)
+                pkg_stats = pkg_ingester.ingest(pkg_path, clear=False, repo_key=pkg_rel)
                 for key in ("files", "functions", "classes", "edges", "skipped"):
                     aggregate[key] = aggregate.get(key, 0) + pkg_stats.get(key, 0)
                 ingested_packages.append((pkg_name, pkg_path))

--- a/navegador/submodules.py
+++ b/navegador/submodules.py
@@ -105,12 +105,13 @@ class SubmoduleIngester:
         logger.info("SubmoduleIngester: ingesting parent %s", repo_root)
         parent_stats = ingester.ingest(str(repo_root), clear=clear)
 
-        # Ensure parent Repository node exists
+        # Ensure parent Repository node exists. Keyed by name, not the
+        # machine-local checkout path (#145).
         self.store.create_node(
             NodeLabel.Repository,
             {
                 "name": parent_name,
-                "path": str(repo_root),
+                "path": parent_name,
                 "language": "",
                 "description": "parent repository",
             },
@@ -135,7 +136,7 @@ class SubmoduleIngester:
 
             logger.info("SubmoduleIngester: ingesting submodule %s → %s", sub_name, sub_path)
             try:
-                sub_stats = ingester.ingest(str(sub_path), clear=False)
+                sub_stats = ingester.ingest(str(sub_path), clear=False, repo_key=sub["path"])
                 sub_results[sub_name] = sub_stats
                 total_files += sub_stats.get("files", 0)
             except Exception as exc:  # noqa: BLE001
@@ -143,12 +144,14 @@ class SubmoduleIngester:
                 sub_results[sub_name] = {"error": str(exc)}
                 continue
 
-            # Create submodule Repository node
+            # Create submodule Repository node, keyed by its parent-relative
+            # path — portable across machines, and distinct even when two
+            # submodules share a directory basename (#145).
             self.store.create_node(
                 NodeLabel.Repository,
                 {
                     "name": sub_name,
-                    "path": str(sub_path),
+                    "path": sub["path"],
                     "language": "",
                     "description": sub.get("url", ""),
                 },

--- a/tests/test_portable_repo_ids.py
+++ b/tests/test_portable_repo_ids.py
@@ -1,0 +1,121 @@
+"""Regression tests for #145 — Repository nodes must be keyed by a portable
+identity, never the machine-local absolute checkout path. Absolute paths in
+committed conflict-kg exports leaked the contributor's filesystem layout and
+churned ids across machines.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from navegador.graph.interchange import collect_graph
+from navegador.graph.store import GraphStore
+from navegador.ingestion.parser import RepoIngester
+from navegador.submodules import SubmoduleIngester
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("portable") / "graph.db"))
+    yield s
+    s.close()
+
+
+def _repositories(store) -> dict[str, str]:
+    result = store.query("MATCH (r:Repository) RETURN r.name, r.path")
+    return {row[0]: row[1] for row in result.result_set or []}
+
+
+def _write(root: Path, rel: str, content: str = "x = 1\n") -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestRepoIngesterPortableIds:
+    def test_repository_path_is_repo_name(self, store, tmp_path):
+        repo = tmp_path / "myrepo"
+        _write(repo, "app.py")
+        RepoIngester(store).ingest(repo, clear=True)
+
+        assert _repositories(store) == {"myrepo": "myrepo"}
+
+    def test_repo_key_override(self, store, tmp_path):
+        repo = tmp_path / "core"
+        _write(repo, "app.py")
+        RepoIngester(store).ingest(repo, clear=True, repo_key="libs/core")
+
+        assert _repositories(store) == {"core": "libs/core"}
+
+    def test_export_contains_no_absolute_paths(self, store, tmp_path):
+        repo = tmp_path / "myrepo"
+        _write(repo, "app.py")
+        RepoIngester(store).ingest(repo, clear=True)
+
+        nodes, _ = collect_graph(store)
+        repo_nodes = [n for n in nodes if n["type"] == "Repository"]
+        assert repo_nodes, "export should contain the Repository node"
+        for node in repo_nodes:
+            assert node["id"] == "Repository:myrepo:myrepo"
+            assert str(tmp_path) not in node["id"]
+            assert str(tmp_path) not in str(node["props"])
+
+    def test_exports_reproducible_across_checkout_locations(self, store, tmp_path):
+        """Two checkouts of the same repo at different paths produce
+        identical Repository nodes."""
+        checkout_a = tmp_path / "home-alice" / "myrepo"
+        checkout_b = tmp_path / "work-bob" / "myrepo"
+        for checkout in (checkout_a, checkout_b):
+            _write(checkout, "app.py")
+
+        RepoIngester(store).ingest(checkout_a, clear=True)
+        nodes_a, _ = collect_graph(store)
+
+        RepoIngester(store).ingest(checkout_b, clear=True)
+        nodes_b, _ = collect_graph(store)
+
+        assert nodes_a == nodes_b
+
+
+class TestSubmodulePortableIds:
+    def _metarepo(self, root: Path) -> Path:
+        meta = root / "meta"
+        _write(meta, "deploy.py")
+        (meta / ".git").mkdir(parents=True, exist_ok=True)
+        (meta / ".gitmodules").write_text(
+            '[submodule "libs/core"]\n'
+            "    path = libs/core\n"
+            "    url = https://example.com/core.git\n",
+            encoding="utf-8",
+        )
+        sub = meta / "libs" / "core"
+        _write(sub, "core.py")
+        (sub / ".git").mkdir(parents=True, exist_ok=True)
+        return meta
+
+    def test_submodule_keyed_by_relative_path(self, store, tmp_path):
+        meta = self._metarepo(tmp_path)
+        SubmoduleIngester(store).ingest_with_submodules(meta, clear=True)
+
+        repos = _repositories(store)
+        assert repos["meta"] == "meta"
+        assert repos["libs/core"] == "libs/core"
+        assert not any(path.startswith(str(tmp_path)) for path in repos.values())
+
+    def test_depends_on_edge_survives(self, store, tmp_path):
+        meta = self._metarepo(tmp_path)
+        SubmoduleIngester(store).ingest_with_submodules(meta, clear=True)
+
+        result = store.query(
+            "MATCH (a:Repository)-[:DEPENDS_ON]->(b:Repository) RETURN a.path, b.path"
+        )
+        assert [tuple(r) for r in result.result_set or []] == [("meta", "libs/core")]
+
+    def test_no_duplicate_repository_node_per_submodule(self, store, tmp_path):
+        """RepoIngester's node (via repo_key) and SubmoduleIngester's node
+        must merge onto one key."""
+        meta = self._metarepo(tmp_path)
+        SubmoduleIngester(store).ingest_with_submodules(meta, clear=True)
+
+        result = store.query("MATCH (r:Repository) RETURN count(r)")
+        assert result.result_set[0][0] == 2  # parent + one submodule


### PR DESCRIPTION
Fixes #145.

## What changed

Repository nodes were keyed (and exported) by `str(repo_path)` — the machine-local absolute checkout path — leaking filesystem layout/username into committed conflict-kg exports and making exports irreproducible across machines.

Repository nodes now use a portable identity (the convention federation anchors already used, `path = <repo-name>`):

- `RepoIngester.ingest` — `path` = repo directory name; new optional `repo_key` parameter lets workspace ingesters pass a workspace-relative path.
- `submodules ingest` — parent keyed by name; each submodule keyed by its parent-relative path from `.gitmodules`, passed down as `repo_key` so the RepoIngester-created node and the SubmoduleIngester node merge onto a single key (also removes the same-basename collision risk).
- `monorepo` — root keyed by workspace name, packages by workspace-relative path; CONTAINS edge keys updated to match.
- `optimization.py` parallel ingest mirrors RepoIngester.

Deliberately untouched: `WorkspaceManager.add_repo` / `MultiRepoManager.add_repo` registry nodes — recording local checkout paths is their purpose and they are not produced by ingest. `memory.py`'s abs-path repo lookup falls back to the directory name, which matches the new node name (covered by existing tests).

## Test plan

- `tests/test_portable_repo_ids.py` — 7 tests against a real embedded FalkorDB: path == name, `repo_key` override, export id shape `Repository:myrepo:myrepo` with zero absolute paths, byte-identical exports from two different checkout locations, submodule keyed by relative path, DEPENDS_ON survival, no duplicate Repository nodes per submodule.
- Full suite: 2931 passed (monorepo, federation, workspace, memory suites all green under the new key scheme).
- E2E CLI: ingest + conflict-kg export → `Repository:myrepo:myrepo`, 0 nodes containing the checkout path.