### PR TITLE
Repo attribution: BELONGS_TO edges and repo-prefixed node ids

### DIFF
--- a/navegador/graph/schema.py
+++ b/navegador/graph/schema.py
@@ -55,7 +55,7 @@ class EdgeType(StrEnum):
     DECORATES = "DECORATES"  # Decorator -DECORATES-> Function/Class
 
     # ── Knowledge structural ──────────────────────────────────────────────────
-    BELONGS_TO = "BELONGS_TO"  # any node -BELONGS_TO-> Domain
+    BELONGS_TO = "BELONGS_TO"  # any node -> Domain; File/Document -> Repository
     RELATED_TO = "RELATED_TO"  # Concept -RELATED_TO-> Concept (bidirectional intent)
     GOVERNS = "GOVERNS"  # Rule -GOVERNS-> Concept/Function/Class
     DOCUMENTS = "DOCUMENTS"  # WikiPage/Decision -DOCUMENTS-> any node

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -32,7 +32,7 @@ import time
 from pathlib import Path
 
 from navegador.graph import queries
-from navegador.graph.schema import NodeLabel
+from navegador.graph.schema import EdgeType, NodeLabel
 from navegador.graph.store import GraphStore
 
 logger = logging.getLogger(__name__)
@@ -117,6 +117,7 @@ class RepoIngester:
         clear: bool = False,
         incremental: bool = False,
         repo_key: str | None = None,
+        rel_root: str | Path | None = None,
     ) -> dict[str, int]:
         """
         Ingest a repository into the graph.
@@ -129,6 +130,11 @@ class RepoIngester:
                 (defaults to the repo directory name). Workspace ingesters
                 pass the workspace-relative path here so nested repos with
                 the same basename stay distinct.
+            rel_root: Ancestor directory that node paths are recorded
+                relative to (defaults to repo_path). Workspace ingesters pass
+                the workspace root so a nested repo's nodes carry a
+                repo-prefixed path (``libs/core/main.tf``) — otherwise two
+                repos owning the same relative path collide on id (#144).
 
         Returns:
             Dict with counts: files, functions, classes, edges, skipped.
@@ -136,6 +142,9 @@ class RepoIngester:
         repo_path = Path(repo_path).resolve()
         if not repo_path.exists():
             raise FileNotFoundError(f"Repository not found: {repo_path}")
+
+        rel_root = Path(rel_root).resolve() if rel_root else repo_path
+        repo_path.relative_to(rel_root)  # raises ValueError unless an ancestor
 
         if clear:
             self.store.clear()
@@ -148,15 +157,21 @@ class RepoIngester:
         proxy = _EdgeDeferringStore(original_store)
         self.store = proxy
         try:
-            stats = self._ingest_walk(repo_path, incremental, repo_key)
+            stats = self._ingest_walk(repo_path, incremental, repo_key, rel_root)
         finally:
             self.store = original_store
         stats["edges_resolved"] = self._resolve_deferred_edges(proxy.deferred)
         return stats
 
     def _ingest_walk(
-        self, repo_path: Path, incremental: bool, repo_key: str | None = None
+        self,
+        repo_path: Path,
+        incremental: bool,
+        repo_key: str | None = None,
+        rel_root: Path | None = None,
     ) -> dict[str, int]:
+        rel_root = rel_root or repo_path
+        repo_key = repo_key or repo_path.name
         # Create repository node. Keyed by a portable identity, not the
         # absolute checkout path — exports are committed/shared, and machine
         # paths churned ids across machines and leaked local layout (#145).
@@ -164,7 +179,7 @@ class RepoIngester:
             NodeLabel.Repository,
             {
                 "name": repo_path.name,
-                "path": repo_key or repo_path.name,
+                "path": repo_key,
                 "file_path": "",
             },
         )
@@ -188,7 +203,7 @@ class RepoIngester:
                 stats["grammar_skipped"] += 1
                 continue
 
-            rel_path = str(source_file.relative_to(repo_path))
+            rel_path = str(source_file.relative_to(rel_root))
             content_hash = _file_hash(source_file)
 
             if incremental and self._file_unchanged(rel_path, content_hash):
@@ -198,7 +213,7 @@ class RepoIngester:
             if incremental:
                 self._clear_file_subgraph(rel_path)
 
-            parse_path, effective_root = self._maybe_redact_to_tmp(source_file, repo_path)
+            parse_path, effective_root = self._maybe_redact_to_tmp(source_file, rel_root)
             try:
                 file_stats = parser.parse_file(parse_path, effective_root, self.store)
                 stats["files"] += 1
@@ -207,6 +222,8 @@ class RepoIngester:
                 stats["edges"] += file_stats.get("edges", 0)
 
                 self._store_file_hash(rel_path, content_hash)
+                self._link_file_to_repo(rel_path, repo_key)
+                stats["edges"] += 1
                 if stats["files"] % 1000 == 0:
                     logger.info(
                         "Ingest progress %s: %d files parsed", repo_path.name, stats["files"]
@@ -215,13 +232,13 @@ class RepoIngester:
                 logger.exception("Failed to parse %s", source_file)
             finally:
                 # Remove the temporary redacted directory if one was created
-                if effective_root is not repo_path:
+                if effective_root is not rel_root:
                     import shutil
 
                     shutil.rmtree(effective_root, ignore_errors=True)
 
         # Ansible pass — heuristically detect and parse Ansible YAML files
-        self._ingest_ansible(repo_path, stats, incremental)
+        self._ingest_ansible(repo_path, stats, incremental, rel_root, repo_key)
 
         # Fossil mirror pass — if the repo is also a Fossil checkout (e.g. a
         # Git repo mirrored to/from Fossil), ingest wiki pages and tickets.
@@ -321,6 +338,22 @@ class RepoIngester:
             self.store.query(queries.CLEAR_DOCUMENT_REFERENCES, {"path": rel_path})
         else:
             self.store.query(queries.DELETE_FILE_SUBGRAPH, {"path": rel_path})
+
+    def _link_file_to_repo(self, rel_path: str, repo_key: str) -> None:
+        """
+        BELONGS_TO edge from a parsed File/Document to its Repository (#144),
+        so consumers can answer "which repo is this node from" in one hop
+        instead of guessing by path prefix.
+        """
+        suffix = Path(rel_path).suffix.lower()
+        label = NodeLabel.Document if suffix in self._DOCUMENT_EXTENSIONS else NodeLabel.File
+        self.store.create_edge(
+            label,
+            {"path": rel_path},
+            EdgeType.BELONGS_TO,
+            NodeLabel.Repository,
+            {"path": repo_key},
+        )
 
     def _store_file_hash(self, rel_path: str, content_hash: str) -> None:
         suffix = Path(rel_path).suffix.lower()
@@ -463,10 +496,19 @@ class RepoIngester:
             if path.suffix in LANGUAGE_MAP:
                 yield path
 
-    def _ingest_ansible(self, repo_path: Path, stats: dict[str, int], incremental: bool) -> None:
+    def _ingest_ansible(
+        self,
+        repo_path: Path,
+        stats: dict[str, int],
+        incremental: bool,
+        rel_root: Path | None = None,
+        repo_key: str | None = None,
+    ) -> None:
         """Detect and parse Ansible YAML files (playbooks, roles, tasks)."""
         from navegador.ingestion.ansible import AnsibleParser
 
+        rel_root = rel_root or repo_path
+        repo_key = repo_key or repo_path.name
         is_ansible_file = AnsibleParser.is_ansible_file
 
         ansible_parser: AnsibleParser | None = None
@@ -477,7 +519,7 @@ class RepoIngester:
             if not is_ansible_file(path, repo_path):
                 continue
 
-            rel_path = str(path.relative_to(repo_path))
+            rel_path = str(path.relative_to(rel_root))
             content_hash = _file_hash(path)
 
             if incremental and self._file_unchanged(rel_path, content_hash):
@@ -490,12 +532,14 @@ class RepoIngester:
             if ansible_parser is None:
                 ansible_parser = AnsibleParser()
             try:
-                file_stats = ansible_parser.parse_file(path, repo_path, self.store)
+                file_stats = ansible_parser.parse_file(path, rel_root, self.store)
                 stats["files"] += 1
                 stats["functions"] += file_stats.get("functions", 0)
                 stats["classes"] += file_stats.get("classes", 0)
                 stats["edges"] += file_stats.get("edges", 0)
                 self._store_file_hash(rel_path, content_hash)
+                self._link_file_to_repo(rel_path, repo_key)
+                stats["edges"] += 1
             except Exception:
                 logger.exception("Failed to parse Ansible file %s", path)
 

--- a/navegador/monorepo.py
+++ b/navegador/monorepo.py
@@ -477,7 +477,9 @@ class MonorepoIngester:
             # Ingest files in this package
             pkg_ingester = RepoIngester(self.store)
             try:
-                pkg_stats = pkg_ingester.ingest(pkg_path, clear=False, repo_key=pkg_rel)
+                pkg_stats = pkg_ingester.ingest(
+                    pkg_path, clear=False, repo_key=pkg_rel, rel_root=repo_path
+                )
                 for key in ("files", "functions", "classes", "edges", "skipped"):
                     aggregate[key] = aggregate.get(key, 0) + pkg_stats.get(key, 0)
                 ingested_packages.append((pkg_name, pkg_path))

--- a/navegador/submodules.py
+++ b/navegador/submodules.py
@@ -136,7 +136,9 @@ class SubmoduleIngester:
 
             logger.info("SubmoduleIngester: ingesting submodule %s → %s", sub_name, sub_path)
             try:
-                sub_stats = ingester.ingest(str(sub_path), clear=False, repo_key=sub["path"])
+                sub_stats = ingester.ingest(
+                    str(sub_path), clear=False, repo_key=sub["path"], rel_root=repo_root
+                )
                 sub_results[sub_name] = sub_stats
                 total_files += sub_stats.get("files", 0)
             except Exception as exc:  # noqa: BLE001

--- a/tests/test_ingestion_code.py
+++ b/tests/test_ingestion_code.py
@@ -114,7 +114,7 @@ class TestRepoIngester:
             assert stats["files"] == 1
             assert stats["functions"] == 3
             assert stats["classes"] == 1
-            assert stats["edges"] == 5
+            assert stats["edges"] == 6  # 5 from parser + 1 BELONGS_TO (#144)
 
     def test_ingests_multiple_python_files(self):
         store = _make_store()
@@ -173,7 +173,7 @@ class TestRepoIngester:
             assert stats["files"] == 2
             assert stats["functions"] == 8
             assert stats["classes"] == 3
-            assert stats["edges"] == 15
+            assert stats["edges"] == 17  # 15 from parsers + 2 BELONGS_TO (#144)
 
 
 # ── _iter_source_files() ──────────────────────────────────────────────────────

--- a/tests/test_repo_attribution.py
+++ b/tests/test_repo_attribution.py
@@ -1,0 +1,121 @@
+"""Regression tests for #144 — submodules/monorepo ingest must attribute
+nodes to their repository: BELONGS_TO edges from every File/Document to its
+Repository, and workspace-relative node paths so two repos owning the same
+relative path (README.md) don't silently merge.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from navegador.graph.store import GraphStore
+from navegador.ingestion.parser import RepoIngester
+from navegador.submodules import SubmoduleIngester
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("attribution") / "graph.db"))
+    yield s
+    s.close()
+
+
+def _write(root: Path, rel: str, content: str = "x = 1\n") -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _belongs_to(store) -> set[tuple[str, str]]:
+    result = store.query(
+        "MATCH (n)-[:BELONGS_TO]->(r:Repository) RETURN coalesce(n.path, ''), r.path"
+    )
+    return {(row[0], row[1]) for row in result.result_set or []}
+
+
+def _metarepo(root: Path) -> Path:
+    """Parent repo + one submodule, both owning a README.md and an app.py."""
+    meta = root / "meta"
+    _write(meta, "app.py", "def deploy():\n    pass\n")
+    (meta / "README.md").write_text("# Meta\n", encoding="utf-8")
+    (meta / ".git").mkdir(parents=True, exist_ok=True)
+    (meta / ".gitmodules").write_text(
+        '[submodule "libs/core"]\n    path = libs/core\n    url = https://example.com/core.git\n',
+        encoding="utf-8",
+    )
+    sub = meta / "libs" / "core"
+    _write(sub, "app.py", "def run():\n    pass\n")
+    (sub / "README.md").write_text("# Core\n", encoding="utf-8")
+    (sub / ".git").mkdir(parents=True, exist_ok=True)
+    return meta
+
+
+class TestPlainIngestAttribution:
+    def test_files_and_documents_link_to_repository(self, store, tmp_path):
+        repo = tmp_path / "myrepo"
+        _write(repo, "app.py")
+        (repo / "README.md").write_text("# Readme\n", encoding="utf-8")
+        RepoIngester(store).ingest(repo, clear=True)
+
+        assert _belongs_to(store) == {("app.py", "myrepo"), ("README.md", "myrepo")}
+
+    def test_plain_ingest_paths_stay_repo_relative(self, store, tmp_path):
+        repo = tmp_path / "myrepo"
+        _write(repo, "src/app.py")
+        RepoIngester(store).ingest(repo, clear=True)
+
+        result = store.query("MATCH (f:File) RETURN f.path")
+        assert [row[0] for row in result.result_set] == ["src/app.py"]
+
+    def test_rel_root_must_be_ancestor(self, store, tmp_path):
+        repo = tmp_path / "myrepo"
+        _write(repo, "app.py")
+        with pytest.raises(ValueError):
+            RepoIngester(store).ingest(repo, rel_root=tmp_path / "elsewhere")
+
+
+class TestSubmoduleAttribution:
+    def test_same_named_files_do_not_merge(self, store, tmp_path):
+        meta = _metarepo(tmp_path)
+        SubmoduleIngester(store).ingest_with_submodules(meta, clear=True)
+
+        result = store.query("MATCH (d:Document) RETURN d.path ORDER BY d.path")
+        assert [row[0] for row in result.result_set] == ["README.md", "libs/core/README.md"]
+
+        result = store.query("MATCH (f:File) RETURN f.path ORDER BY f.path")
+        assert [row[0] for row in result.result_set] == ["app.py", "libs/core/app.py"]
+
+    def test_every_node_attributable_to_its_repo(self, store, tmp_path):
+        meta = _metarepo(tmp_path)
+        SubmoduleIngester(store).ingest_with_submodules(meta, clear=True)
+
+        assert _belongs_to(store) == {
+            ("app.py", "meta"),
+            ("README.md", "meta"),
+            ("libs/core/app.py", "libs/core"),
+            ("libs/core/README.md", "libs/core"),
+        }
+
+    def test_symbols_attributable_via_containing_file(self, store, tmp_path):
+        """which repo is this function from — File CONTAINS + BELONGS_TO."""
+        meta = _metarepo(tmp_path)
+        SubmoduleIngester(store).ingest_with_submodules(meta, clear=True)
+
+        result = store.query(
+            "MATCH (f:File)-[:CONTAINS]->(fn:Function {name: 'run'}), "
+            "(f)-[:BELONGS_TO]->(r:Repository) RETURN r.path"
+        )
+        assert [row[0] for row in result.result_set] == ["libs/core"]
+
+    def test_incremental_reingest_keeps_attribution(self, store, tmp_path):
+        meta = _metarepo(tmp_path)
+        ingester = SubmoduleIngester(store)
+        ingester.ingest_with_submodules(meta, clear=True)
+        before = _belongs_to(store)
+
+        (meta / "libs" / "core" / "app.py").write_text(
+            "def run():\n    return 2\n", encoding="utf-8"
+        )
+        ingester.ingest_with_submodules(meta, clear=False)
+
+        assert _belongs_to(store) == before


### PR DESCRIPTION
Fixes #144. Builds on the `repo_key` parameter from #148.

## What changed

Both remedies suggested in the issue, (a) and (b):

- **(b) repo-prefixed node ids:** `RepoIngester.ingest` gains `rel_root` — the ancestor directory that node paths are recorded against (defaults to the repo itself; plain single-repo ingest is byte-for-byte unchanged). `submodules ingest` passes the parent root and monorepo passes the workspace root, so a submodule's nodes get paths like `libs/core/main.tf`. Two repos owning `README.md` no longer merge into one node, and the owning repo is readable from the id. The monorepo ingester had the identical collision (two packages with `src/index.ts`) and gets the same treatment.
- **(a) File → Repository linkage:** every parsed File/Document gets a `BELONGS_TO` edge to its Repository node (keyed by the portable `repo_key` from #148), created during the walk — including the Ansible pass — and preserved across incremental re-ingests (re-parse keeps the File/Document node). "Which repo is this node from" is now a one-hop query.

Export shape on the issue's metarepo scenario:

```
Document:README.md:Meta            -> Repository:meta:meta
Document:libs/core/README.md:Core  -> Repository:libs/core:libs/core
File:libs/core/app.py:app.py       -> Repository:libs/core:libs/core
```

Two pre-existing mock-parser tests asserting exact edge counts were updated (+1 per file for the BELONGS_TO edge).

## Test plan

- `tests/test_repo_attribution.py` — 7 tests against a real embedded FalkorDB: BELONGS_TO for File+Document on plain ingest, unchanged repo-relative paths for single-repo, `rel_root` ancestor validation, same-named files across parent/submodule kept distinct, full attribution map, symbol→repo one-hop query, attribution preserved across incremental re-ingest. 5 of 7 fail without the change.
- Full suite: 2938 passed.
- E2E CLI: `submodules ingest` + conflict-kg export → distinct prefixed ids and BELONGS_TO edges for every File/Document (output above).