### PR TITLE
fix: stop shipping a Windows binary that cannot run

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -15,22 +15,19 @@ permissions:
 
 jobs:
   build:
+    # No Windows target: falkordblite (a hard dependency) publishes no Windows
+    # wheel and its sdist refuses to build on win32, so `pip install -e .` cannot
+    # succeed there. Windows users run navegador under WSL2. See issue #151.
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: linux-x86_64
-            ext: ""
           - os: macos-latest
             target: macos-arm64
-            ext: ""
           - os: macos-15-intel
             target: macos-x86_64
-            ext: ""
-          - os: windows-latest
-            target: windows-x86_64
-            ext: ".exe"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -43,6 +40,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
+        # Explicit bash so a failing `pip install` aborts the step. Without it a
+        # non-bash default shell lets an intermediate failure pass silently and
+        # PyInstaller happily builds a binary with nothing bundled in it.
+        shell: bash
         run: |
           pip install -e .
           pip install pyinstaller
@@ -74,8 +75,14 @@ jobs:
             --collect-all navegador \
             navegador/cli/commands.py
 
+      - name: Smoke-test binary
+        # Never upload an artifact nobody has run. A binary built without its
+        # dependencies bundled still lands in dist/ and only fails at launch.
+        shell: bash
+        run: ./dist/navegador-${{ matrix.target }} --help > /dev/null
+
       - name: Upload binary to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          files: dist/navegador-${{ matrix.target }}${{ matrix.ext }}
+          files: dist/navegador-${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -276,7 +276,10 @@ No Python required — download prebuilt binaries from [GitHub Releases](https:/
 | macOS (Apple Silicon) | `navegador-macos-arm64` |
 | macOS (Intel) | `navegador-macos-x86_64` |
 | Linux | `navegador-linux-x86_64` |
-| Windows | `navegador-windows-x86_64.exe` |
+
+Navegador is POSIX-only — its embedded graph backend (`falkordblite`) has no native
+Windows build. On Windows, run navegador inside [WSL2](https://learn.microsoft.com/windows/wsl/install)
+and use the Linux binary.
 
 ### From source
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,6 +4,29 @@
 
 - Python **3.12 or later** — required by `falkordblite`, the embedded SQLite backend
 - pip 23+
+- A **POSIX** platform — Linux, macOS, or WSL2
+
+## Platform support
+
+| Platform | Supported |
+|----------|-----------|
+| Linux | Yes |
+| macOS (Apple Silicon and Intel) | Yes |
+| Windows via [WSL2](https://learn.microsoft.com/windows/wsl/install) | Yes |
+| Windows (native) | No |
+
+Native Windows is not supported. `falkordblite` — the embedded graph backend, and a
+required dependency — publishes no Windows wheel, and its source distribution declines
+to build on `win32`. `pip install navegador` therefore fails on native Windows:
+
+```
+The redislite module is not supported on the 'win32' platform
+ERROR: Failed to build 'falkordblite'
+```
+
+Install and run navegador inside WSL2 instead. It behaves exactly as it does on Linux,
+including for pre-commit hooks and editor MCP integrations — point them at the WSL2
+interpreter rather than a Windows one.
 
 ## Install
 

--- a/navegador/graph/store.py
+++ b/navegador/graph/store.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import logging
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -44,10 +45,21 @@ class GraphStore:
         the method name is kept for API compatibility.
 
         Requires: pip install FalkorDB falkordblite
+
+        POSIX only (Linux/macOS/WSL2) — falkordblite has no native Windows build.
         """
         try:
             from redislite import FalkorDB  # type: ignore[import]  # provided by falkordblite
         except ImportError as e:
+            if sys.platform == "win32":
+                # falkordblite ships no Windows wheel and its sdist refuses to
+                # build on win32, so telling the user to pip install it would
+                # send them in a loop. Point at the two paths that do work.
+                raise ImportError(
+                    "The embedded graph backend is not available on native Windows: "
+                    "falkordblite has no Windows build. Run navegador under WSL2, "
+                    "or use a Redis-backed FalkorDB via GraphStore.redis(url)."
+                ) from e
             raise ImportError(
                 "Install graph dependencies: pip install FalkorDB falkordblite"
             ) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,10 @@ keywords = ["ast", "knowledge-graph", "code-analysis", "ai-agents", "mcp", "cont
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "Operating System :: OS Independent",
+    # Not OS Independent: falkordblite has no Windows build. See issue #151.
+    "Operating System :: POSIX",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/tests/test_graph_store.py
+++ b/tests/test_graph_store.py
@@ -57,6 +57,19 @@ class TestSqliteConstructor:
             with pytest.raises(ImportError, match="falkordblite"):
                 GraphStore.sqlite("/tmp/test.db")
 
+    def test_windows_error_does_not_suggest_an_impossible_pip_install(self):
+        # falkordblite has no Windows build, so "pip install falkordblite" can
+        # never succeed there — the message must point at WSL2/Redis instead.
+        with patch.dict("sys.modules", {"redislite": None}):
+            with patch("navegador.graph.store.sys.platform", "win32"):
+                with pytest.raises(ImportError) as exc:
+                    GraphStore.sqlite("/tmp/test.db")
+
+        message = str(exc.value)
+        assert "WSL2" in message
+        assert "GraphStore.redis" in message
+        assert "pip install" not in message
+
 
 # ── redis() classmethod ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #151.

## What I found

The issue was filed as "Windows is shipped but never tested." Investigation showed it is worse than that: the Windows binary we publish **cannot run at all**, and the release job that builds it is green by accident.

`falkordblite` is a hard, non-optional dependency and publishes no Windows wheel — its classifiers are `MacOS X` / `POSIX` / `POSIX :: Linux`. The sdist fallback declines to build. From the actual Windows job log of the v1.4.0 release run ([job 86735803571](https://github.com/ConflictHQ/navegador/actions/runs/29224493229)):

```
Collecting falkordblite>=0.8.0 (from navegador==1.4.0)
  Downloading falkordblite-0.10.0.tar.gz (23.7 MB)
  Getting requirements to build wheel: finished with status 'error'
  The redislite module is not supported on the 'win32' platform
ERROR: Failed to build 'falkordblite' when getting requirements to build wheel
```

The install step was a multi-line `run:` with no `shell:` override. On Windows that runs under **pwsh**, which does not abort on a non-zero exit of an intermediate command — only the last command sets step status:

```yaml
run: |
  pip install -e .        # fails
  pip install pyinstaller # succeeds, step goes green
```

PyInstaller then built against a package that was never installed. Same log:

```
WARNING: collect_data_files - skipping data collection for module 'navegador' as it is not a package.
WARNING: collect_dynamic_libs - skipping library collection for module 'navegador' as it is not a package.
```

So `navegador-windows-x86_64.exe` has no click, no rich, no tree-sitter, no falkordb bundled. It has been attached to every release back through v1.0.1 and `ImportError`s on launch.

## Why option 2, not option 1

Adding `windows-latest` to the CI matrix is not reachable — `pip install` fails at dependency resolution, so the job would be permanently red with nothing on our side to fix. The dependency chain terminates at Redis C sources requiring `fork()` and POSIX sockets.

I considered marking `falkordblite` as `; sys_platform != "win32"` so navegador installs on Windows against a **remote** FalkorDB over `redis://`. Rejected for this issue: the flow that motivated the filing is das-meridian-core's `graph-sync` pre-commit hook, which uses the default **embedded** backend, so a mode requiring a separate FalkorDB server would not serve it. WSL2 is already the steered path and is covered by `ubuntu-latest`. Worth a separate issue if remote-backend Windows support is ever actually wanted.

## What changed

- **`release-binaries.yml`** — drop the `windows-x86_64` target. Pin the install step to `shell: bash` so a failed install can never again pass silently. Add a smoke-test step that runs each built binary (`--help`) before upload — the guard that would have caught the hollow artifact.
- **`pyproject.toml`** — replace the false `Operating System :: OS Independent` classifier with `POSIX`, `POSIX :: Linux`, `MacOS :: MacOS X`.
- **`navegador/graph/store.py`** — `GraphStore.sqlite()` told a failing user to `pip install FalkorDB falkordblite`, which on Windows can never succeed. Now raises a platform-aware error pointing at WSL2 or `GraphStore.redis(url)`.
- **Docs** — Windows row removed from the README binary table; a "Platform support" section added to the installation guide with the real error text.

Smoke test uses `--help` rather than `--version` deliberately: `--version` goes through `click.version_option(package_name=...)`, which reads installed distribution metadata that is not guaranteed present inside a PyInstaller onefile bundle without `--copy-metadata`. `--help` exercises the interpreter, click, rich, and the command tree, and would have failed loudly on the hollow binary — with no risk of a false red.

## Test plan

- `pytest tests/` — **2939 passed**
- `ruff check navegador/` — clean
- `mypy navegador/graph/store.py` — no new errors
- New regression test `test_windows_error_does_not_suggest_an_impossible_pip_install` asserts the win32 path yields a WSL2/Redis message and never a `pip install` instruction. Verified it fails against the old message.

## Needs a decision (not in this PR)

The already-published `navegador-windows-x86_64.exe` assets on v1.0.1–v1.4.0 are still downloadable and still broken. Deleting them is outward-facing and irreversible, so I left them alone — but anyone who grabs one today gets a binary that crashes on launch.