### PR TITLE
fix: standalone binaries never invoked the CLI

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -76,10 +76,23 @@ jobs:
             navegador/cli/commands.py
 
       - name: Smoke-test binary
-        # Never upload an artifact nobody has run. A binary built without its
-        # dependencies bundled still lands in dist/ and only fails at launch.
+        # Never upload an artifact nobody has run. Assert on output, not just
+        # exit status: a binary that defines the command group and falls off the
+        # end without invoking it also exits 0, so an exit-code-only check
+        # passes a completely inert binary.
         shell: bash
-        run: ./dist/navegador-${{ matrix.target }} --help > /dev/null
+        run: |
+          BIN=./dist/navegador-${{ matrix.target }}
+          "$BIN" --help | grep -q "Usage:" \
+            || { echo "::error::--help produced no usage output"; exit 1; }
+          "$BIN" ingest --help | grep -q "ingest" \
+            || { echo "::error::subcommands are not registered"; exit 1; }
+          "$BIN" --version | grep -q "version" \
+            || { echo "::error::--version is empty; package metadata not bundled"; exit 1; }
+          if "$BIN" --definitely-not-a-flag >/dev/null 2>&1; then
+            echo "::error::binary accepts unknown flags; CLI is not dispatching"
+            exit 1
+          fi
 
       - name: Upload binary to release
         uses: softprops/action-gh-release@v2

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -3474,3 +3474,11 @@ def lens_apply(
         click.echo(result.to_json())
     else:
         console.print(result.to_markdown())
+
+
+if __name__ == "__main__":
+    # PyInstaller builds the standalone binaries by targeting this file, which
+    # runs it as __main__ rather than going through the `navegador` console
+    # script. Without this guard the module only defines the command group and
+    # exits 0 without doing anything.
+    main()


### PR DESCRIPTION
Closes #154. Follows #152 — and fixes a hole in the guard that PR added.

## The bug

Every standalone binary navegador has ever shipped is inert. Downloaded `navegador-linux-x86_64` from the v1.4.0 release, ran it in a clean `ubuntu:24.04` container:

```
./navegador-linux-x86_64 --help                   -> 0 bytes, exit 0
./navegador-linux-x86_64 --version                -> 0 bytes, exit 0
./navegador-linux-x86_64 --definitely-not-a-flag  -> exit 0     (click would exit 2)
```

Accepting an unknown flag with exit 0 is the tell — the CLI is never dispatched.

This is a **different bug from #151**. That one found the Windows binary was hollow because `pip install -e .` failed silently under pwsh. The Linux and macOS binaries bundle their dependencies correctly and are still inert.

## Root cause

`navegador/cli/commands.py` has no `if __name__ == "__main__":` guard, and the workflow points PyInstaller at the file. PyInstaller runs it as `__main__`, so it defines the `@click.group()` and all 50+ subcommands, hits the end of the module, and exits 0 having invoked nothing.

No PyInstaller needed to reproduce:

```
$ python navegador/cli/commands.py --help
(0 bytes, exit 0)

$ navegador --help
Usage: navegador [OPTIONS] COMMAND [ARGS]...
```

The console script works because `[project.scripts]` declares `navegador = "navegador.cli.commands:main"`. Nothing else called `main()`.

The README's "No Python required — download prebuilt binaries" has therefore never worked, on any platform, for any release.

## My smoke test in #152 did not catch this

#152 added a smoke test specifically to stop inert artifacts from shipping. It checked only the exit code:

```yaml
run: ./dist/navegador-${{ matrix.target }} --help > /dev/null
```

An inert binary exits 0, so it passed. That guard was ineffective as written — my error.

## Changes

1. **`navegador/cli/commands.py`** — add the `if __name__ == "__main__": main()` guard.
2. **`release-binaries.yml`** — replace the exit-code check with assertions on behaviour: `--help` contains `Usage:`, `ingest --help` resolves (subcommands registered), `--version` is non-empty (metadata bundled), and an unknown flag exits **non-zero** (click dispatching).

## Verification

Built a real PyInstaller binary locally with the guard, using the same flags as the release workflow:

```
--help         -> 4649 bytes, "Usage: ... [OPTIONS] COMMAND [ARGS]..."
ingest --help  -> "Ingest a repository's code into the graph (AST + call graph)."
--bogus-flag   -> exit 2
--version      -> "navegador-testbuild, version 1.4.0"
```

Each of the four new assertions fails against the current shipped binary and passes against the fixed one.

- `pytest tests/` — **2939 passed**
- `ruff check navegador/` — clean

Also settles the open question I left in #152: `--version` works fine in a bundle. `--collect-all navegador` already brings the distribution metadata along, so no `--copy-metadata` is required — the empty `--version` was this same bug. The smoke test now asserts it.

## Still open

The Linux and macOS assets on v1.0.1–v1.4.0 are published and inert. (The Windows ones were removed under #151.) Worth deciding whether to withdraw them or leave them until a release ships with this fix — happy to do either.