### PR TITLE
release: bump to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.4.1 — 2026-07-27
+
+Distribution fixes. No functional changes to the library, CLI or graph engine.
+
+### Standalone binaries
+
+- **Binaries now actually run** — every published binary was inert: it started, did nothing and exited 0. `navegador/cli/commands.py` had no `if __name__ == "__main__"` guard and PyInstaller targets that file, so the binary defined the command group and all 50+ subcommands, reached the end of the module and exited without dispatching. Affected `linux-x86_64`, `macos-arm64` and `macos-x86_64` in every release from 1.0.1 onward (#154)
+- **Release smoke test asserts behaviour, not exit status** — an inert binary exits 0, so an exit-code-only check passed it. The release job now verifies `--help` contains usage text, subcommands resolve, `--version` is non-empty, and an unknown flag exits non-zero (#154)
+
+### Platform support
+
+- **Windows binary withdrawn** — `falkordblite` publishes no Windows wheel and its sdist refuses to build on `win32`, so `pip install` cannot succeed there. The `windows-x86_64` target shipped anyway because the release job's install step ran under a shell that does not abort on an intermediate command's failure, producing a binary with no dependencies bundled. Target removed and the install step pinned to bash (#151)
+- **Honest platform metadata** — the `Operating System :: OS Independent` classifier is replaced with `POSIX`, `POSIX :: Linux` and `MacOS :: MacOS X`. Windows users run navegador under WSL2 (#151)
+- **Actionable error on Windows** — `GraphStore.sqlite()` told a failing user to `pip install falkordblite`, which can never succeed on Windows. It now points at WSL2 or a Redis-backed FalkorDB (#151)
+
 ## 1.4.0 — 2026-07-12
 
 ### Ingestion

--- a/navegador/__init__.py
+++ b/navegador/__init__.py
@@ -2,7 +2,7 @@
 Navegador — AST + knowledge graph context engine for AI coding agents.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "CONFLICT LLC"
 
 from navegador.sdk import Navegador

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "navegador"
-version = "1.4.0"
+version = "1.4.1"
 description = "AST + knowledge graph context engine for AI coding agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch release covering the distribution fixes from #151 and #154. No functional changes to the library, CLI or graph engine.

## Why now

`main` carries two fixes that only reach users through a release:

- **#155 (`95bf433`)** — every published binary was inert. Missing `__main__` guard meant PyInstaller's target defined the command group and exited 0 without dispatching. Affected `linux-x86_64`, `macos-arm64` and `macos-x86_64` in every release since 1.0.1.
- **#152 (`cf3bf4e`)** — withdrew the unbuildable `windows-x86_64` target, corrected the false `OS Independent` classifier, and made `GraphStore.sqlite()` fail with actionable advice on Windows.

The classifier correction and the Windows error message ship via PyPI; the binary fix ships via the release assets.

## Changes

- `pyproject.toml` and `navegador/__init__.py` → `1.4.1`
- `CHANGELOG.md` → 1.4.1 entry

## Test plan

- `pytest tests/` — **2939 passed**
- `ruff check navegador/` — clean
- No test asserts a version string, so the bump is inert to the suite

## On merge

Publishing the v1.4.1 release fires both `release-binaries.yml` and `publish.yml`, so this cuts binaries **and** pushes 1.4.1 to PyPI. Confirmed with @ragelink before tagging.

The new smoke test is the thing to watch on the release run: it asserts `--help` contains usage text, subcommands resolve, `--version` is non-empty, and an unknown flag exits non-zero. If the binaries are still broken, the release job fails loudly instead of silently attaching them.