### PR TITLE
fix: eight issues where the graph confidently disagreed with the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,29 @@
 - **`doctor` tells "never ingested" apart from "already migrated"** — it reads the node count of the graph the project actually resolves to. An empty one is a problem (queries return nothing, which is not the same as not-found); a populated one with a leftover local file is a note, not a warning to live with forever
 - **`navegador scan <root>`** inventories every project under a tree, flags the ones ingesting where nothing reads, and recommends a shared server with its reasons
 
+### Graph fidelity
+
+- **Export/import dropped every edge and reported success** — the JSONL export wrote node ids derived from array position, so an import re-derived different ids and every edge referenced an endpoint that did not exist. `create_edge` returned falsy, nothing checked it, and the summary counted edges it had described rather than edges it had written. A round-trip of a 4,000-node graph restored 4,000 nodes and 0 edges, which reads as a repo with no call structure rather than a failed import. Ids are now content-derived so they survive the round trip, the created count comes from the store, and a shortfall raises instead of printing a total (#173)
+- **Ingest never removed nodes for files deleted from disk** — incremental ingest compared mtimes to decide what to re-parse and had no branch at all for files that had gone. A renamed module left its old symbols in the graph indefinitely, and impact queries cited functions that no longer existed anywhere in the repository. The file set present on disk is now recorded before parse decisions are made, and the difference is pruned (#168)
+- **Repository identity survived neither a worktree nor a renamed clone** — the `Repository` node was keyed by the checkout directory's basename, so `git clone <url> myproj-review` produced a second, indistinguishable `Repository`, and files ended up owned by every node they had been ingested under. Identity now comes from the normalized git remote, the only thing constant across all three, with the directory name as the fallback outside a repo (#167)
+- **Python call edges never crossed a file boundary** — `_extract_calls` recorded every callee as living in the calling file, so an imported function resolved to a node that does not exist and the edge was dropped. On a multi-package fixture the graph held the right symbols and *zero* `CALLS` edges, so explain, trace, and impact stopped dead at each file and looked like code with no callers. Imports are now resolved to repo files (absolute, relative, and function-local), and a callable passed to a higher-order helper is recorded as `REFERENCES` rather than lost (#163)
+- **`from x import y` produced no `Import` nodes at all** — the parser matched a node type (`import_from_member`) that does not exist in the tree-sitter Python grammar; both the module and its members are `dotted_name` (#163)
+- **testmap invented confident cross-repository `TESTS` edges** — the heuristic stripped `test_`, tried ever-shorter prefixes, and took the first symbol with that name anywhere in the graph, so `test_request_returns_200` degraded to `request` and linked to an unrelated repository's method at full confidence. A wrong `TESTS` edge is worse than a missing one, because impact and context queries then cite it. Candidates are now scored on repository, path proximity, and name distinctiveness; generic verbs are never candidates at any threshold; test-module helpers are never targets; edges carry their confidence and evidence; and ties are reported as ambiguous rather than resolved by iteration order (#166)
+
+### LLM configuration
+
+- **`[llm]` in `config.toml` was written by `init` and read by nothing** — `resolve_llm()` now layers it the same way storage is resolved, with provenance
+- **Provider discovery required only that the SDK import** — Anthropic was selected whenever the package was installed, credentials or not, and the failure surfaced later as a raw auth error from inside the call. Availability now means a usable credential, and the error names what each provider is missing (#164)
+- **The default Anthropic model was retired** — `claude-3-5-haiku-20241022` has 404'd since 2026-02-19, so every fallback path was calling a model that no longer exists (#164)
+- **Generated Cypher was not executable** — the NLP engine emitted `(n:Class|Function)`, which FalkorDB rejects: a node pattern takes exactly one label. Alternative *relationship* types are valid and are left alone. Node alternatives are rewritten to `WHERE (n:Class OR n:Function)`, and a query that still fails is retried once with the error fed back (#165)
+
+### Supergraph interoperability
+
+- **Contract v1.0 conformance** — navegador owns the `code` realm and is addressable from every other graph in the system as `[<repo>/]code:<path>[#<symbol>]`. Conformance is a mapping layer at the tool surface; internal ids, the store, and the schema are unchanged (#158)
+- **`navegador contract resolve <address>`** and the `resolve_address` MCP tool complete the brain-to-code hop: a brain-side `implemented_in` edge carries a code address, and resolving it returns the node plus its callers and callees, each with its own address, so traversal continues without a second round trip
+- **`navegador contract propose`** and the `propose_join_edges` MCP tool emit contract-format join-edge proposals with confidence and evidence. Navegador proposes and writes nothing; the brain reviews and commits. Targets that are brain-realm nodes are dropped rather than given a code address we have no authority to mint
+- **Responses that emit addresses declare `contract: "1.0"`**, and `search_symbols` results carry the address a brain would record to point back at them
+
 ### Output and lifecycle correctness
 
 - **`--json` output is parseable** — per-graph progress was printed to stdout alongside the JSON payload, so piping the result into a parser failed on the narration. Progress now goes to stderr

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Python SDK: guide/sdk.md
       - Graph Queries: guide/graph-queries.md
       - MCP Integration: guide/mcp-integration.md
+      - Supergraph Contract: guide/supergraph-contract.md
       - CI/CD: guide/ci-cd.md
       - Cluster Mode: guide/cluster.md
       - Agent Hooks: guide/agent-hooks.md

--- a/navegador/analysis/testmap.py
+++ b/navegador/analysis/testmap.py
@@ -35,23 +35,131 @@ RETURN labels(callee)[0] AS type, callee.name AS name,
        coalesce(callee.file_path, '') AS file_path
 """
 
-# Lookup a production symbol by name (not a test function)
-_FIND_PRODUCTION_SYMBOL = """
+# Every candidate production symbol with that name, with the repository that
+# owns it. Deliberately not LIMIT 1: picking an arbitrary one of many identically
+# named symbols is what produced confident cross-repository nonsense (#166).
+_FIND_PRODUCTION_CANDIDATES = """
 MATCH (n)
 WHERE n.name = $name AND NOT n.name STARTS WITH 'test_'
   AND (n:Function OR n:Method OR n:Class)
+OPTIONAL MATCH (f:File {path: n.file_path})-[:BELONGS_TO]->(r:Repository)
 RETURN labels(n)[0] AS type, n.name AS name,
-       coalesce(n.file_path, '') AS file_path
+       coalesce(n.file_path, '') AS file_path,
+       coalesce(r.path, '') AS repo
+"""
+
+# The repository a test function belongs to, for same-repo scoring.
+_SYMBOL_REPO = """
+MATCH (f:File {path: $file_path})-[:BELONGS_TO]->(r:Repository)
+RETURN coalesce(r.path, '') AS repo
 LIMIT 1
 """
 
-# Create a TESTS edge
+# Create a TESTS edge carrying its evidence, so a consumer can filter on it.
 _CREATE_TESTS_EDGE = """
 MATCH (test), (prod)
 WHERE (test.name = $test_name AND (test.file_path = $test_file OR $test_file = ''))
   AND (prod.name = $prod_name AND (prod.file_path = $prod_file OR $prod_file = ''))
 MERGE (test)-[r:TESTS]->(prod)
+SET r.confidence = $confidence, r.evidence = $evidence
 """
+
+#: Names too common to carry any signal on their own. A test named
+#: `test_request_returns_200` degrades to the candidate `request`, which in a
+#: federated graph matches production code, shell helpers and other tests alike.
+GENERIC_NAMES = frozenset(
+    {
+        "add",
+        "all",
+        "apply",
+        "build",
+        "call",
+        "check",
+        "clean",
+        "clear",
+        "close",
+        "config",
+        "connect",
+        "create",
+        "delete",
+        "do",
+        "execute",
+        "exists",
+        "fetch",
+        "filter",
+        "find",
+        "format",
+        "get",
+        "handle",
+        "init",
+        "insert",
+        "list",
+        "load",
+        "main",
+        "make",
+        "merge",
+        "name",
+        "new",
+        "open",
+        "parse",
+        "process",
+        "publish",
+        "put",
+        "query",
+        "read",
+        "remove",
+        "render",
+        "request",
+        "reset",
+        "resolve",
+        "run",
+        "save",
+        "send",
+        "set",
+        "setup",
+        "start",
+        "stop",
+        "sync",
+        "update",
+        "validate",
+        "value",
+        "write",
+    }
+)
+
+#: Confidence floor for writing an edge. A direct CALLS edge is evidence; a name
+#: that merely coincides across repositories is not.
+DEFAULT_MIN_CONFIDENCE = 0.5
+
+
+def _is_test_path(file_path: str) -> bool:
+    """
+    True when a path looks like test code rather than production code.
+
+    Excluding only symbols *named* ``test_*`` was not enough: a helper called
+    ``build_payload`` living in a test module is still test code, and mapping a
+    test onto it says nothing about what the test covers.
+    """
+    if not file_path:
+        return False
+    lowered = file_path.replace("\\", "/").lower()
+    parts = lowered.split("/")
+    if any(part in ("test", "tests", "testing", "spec", "specs", "__tests__") for part in parts):
+        return True
+    leaf = parts[-1]
+    stem = leaf.rsplit(".", 1)[0]
+    return stem.startswith("test_") or stem.endswith(("_test", "_spec", ".test", ".spec"))
+
+
+def _shared_prefix_depth(a: str, b: str) -> int:
+    """Number of leading path segments two directories have in common."""
+    left, right = a.split("/"), b.split("/")
+    depth = 0
+    for x, y in zip(left, right):
+        if x != y:
+            break
+        depth += 1
+    return depth
 
 
 @dataclass
@@ -64,6 +172,8 @@ class TestLink:
     prod_file: str
     prod_type: str
     source: str  # "calls" | "heuristic"
+    confidence: float = 1.0
+    evidence: str = ""
 
 
 @dataclass
@@ -72,6 +182,7 @@ class TestMapResult:
 
     links: list[TestLink] = field(default_factory=list)
     unmatched_tests: list[dict[str, Any]] = field(default_factory=list)
+    ambiguous: list[dict[str, Any]] = field(default_factory=list)
     edges_created: int = 0
 
     def to_dict(self) -> dict[str, Any]:
@@ -84,14 +195,18 @@ class TestMapResult:
                     "prod_file": lnk.prod_file,
                     "prod_type": lnk.prod_type,
                     "source": lnk.source,
+                    "confidence": lnk.confidence,
+                    "evidence": lnk.evidence,
                 }
                 for lnk in self.links
             ],
             "unmatched_tests": self.unmatched_tests,
+            "ambiguous": self.ambiguous,
             "edges_created": self.edges_created,
             "summary": {
                 "matched": len(self.links),
                 "unmatched": len(self.unmatched_tests),
+                "ambiguous": len(self.ambiguous),
                 "edges_created": self.edges_created,
             },
         }
@@ -112,16 +227,25 @@ class TestMapper:
     def __init__(self, store: GraphStore) -> None:
         self.store = store
 
-    def map_tests(self) -> TestMapResult:
+    def map_tests(self, min_confidence: float = DEFAULT_MIN_CONFIDENCE) -> TestMapResult:
         """
         Discover test → production mappings and write TESTS edges.
 
-        Strategy per test function:
-        1. Follow existing CALLS edges to non-test symbols (direct call evidence).
-        2. Apply name heuristics: strip test_ prefix and look for matching symbol.
+        Per test function:
 
-        Returns:
-            TestMapResult with links, unmatched_tests, and edges_created count.
+        1. Follow an existing CALLS edge to a non-test symbol. This is real
+           evidence and is taken at full confidence.
+        2. Otherwise score name-derived candidates, scoped to the repository and
+           module the test lives in. A candidate that only matches because two
+           repositories happen to use the same generic verb scores below the
+           floor and produces no edge.
+
+        A wrong TESTS edge is worse than a missing one: impact and context
+        queries cite it confidently, and users stop trusting the graph (#166).
+
+        Args:
+            min_confidence: Floor for writing an edge. Weaker matches are
+                reported as unmatched or ambiguous instead.
         """
         test_fns = self._get_test_functions()
         if not test_fns:
@@ -129,6 +253,7 @@ class TestMapper:
 
         links: list[TestLink] = []
         unmatched: list[dict[str, Any]] = []
+        ambiguous: list[dict[str, Any]] = []
         edges_created = 0
 
         for test in test_fns:
@@ -136,9 +261,6 @@ class TestMapper:
             test_file = test["file_path"]
 
             resolved = self._resolve_via_calls(test_name, test_file)
-            if not resolved:
-                resolved = self._resolve_via_heuristic(test_name)
-
             if resolved:
                 prod_type, prod_name, prod_file = resolved
                 link = TestLink(
@@ -147,31 +269,69 @@ class TestMapper:
                     prod_name=prod_name,
                     prod_file=prod_file,
                     prod_type=prod_type,
-                    source=(
-                        "calls" if self._resolve_via_calls(test_name, test_file) else "heuristic"
-                    ),
+                    source="calls",
+                    confidence=1.0,
+                    evidence="direct CALLS edge",
                 )
-                links.append(link)
-                # Persist the TESTS edge
-                try:
-                    self.store.query(
-                        _CREATE_TESTS_EDGE,
+            else:
+                scored = self._score_heuristic_candidates(test_name, test_file)
+                if not scored:
+                    unmatched.append(test)
+                    continue
+
+                best = scored[0]
+                rivals = [c for c in scored[1:] if abs(c["score"] - best["score"]) < 0.05]
+                if rivals:
+                    # Several candidates are equally plausible. Reporting the
+                    # ambiguity is honest; picking one at random is not.
+                    ambiguous.append(
                         {
                             "test_name": test_name,
                             "test_file": test_file,
-                            "prod_name": prod_name,
-                            "prod_file": prod_file,
-                        },
+                            "candidates": [
+                                {"name": c["name"], "file_path": c["file_path"], "repo": c["repo"]}
+                                for c in [best, *rivals][:5]
+                            ],
+                        }
                     )
-                    edges_created += 1
-                except Exception:
-                    pass
-            else:
-                unmatched.append(test)
+                    continue
+
+                if best["score"] < min_confidence:
+                    unmatched.append(test)
+                    continue
+
+                link = TestLink(
+                    test_name=test_name,
+                    test_file=test_file,
+                    prod_name=best["name"],
+                    prod_file=best["file_path"],
+                    prod_type=best["type"],
+                    source="heuristic",
+                    confidence=round(best["score"], 2),
+                    evidence=best["evidence"],
+                )
+
+            links.append(link)
+            try:
+                self.store.query(
+                    _CREATE_TESTS_EDGE,
+                    {
+                        "test_name": link.test_name,
+                        "test_file": link.test_file,
+                        "prod_name": link.prod_name,
+                        "prod_file": link.prod_file,
+                        "confidence": link.confidence,
+                        "evidence": link.evidence,
+                    },
+                )
+                edges_created += 1
+            except Exception:
+                pass
 
         return TestMapResult(
             links=links,
             unmatched_tests=unmatched,
+            ambiguous=ambiguous,
             edges_created=edges_created,
         )
 
@@ -201,32 +361,104 @@ class TestMapper:
             return (row[0] or "Function", row[1] or "", row[2] or "")
         return None
 
-    def _resolve_via_heuristic(self, test_name: str) -> tuple[str, str, str] | None:
+    def _score_heuristic_candidates(self, test_name: str, test_file: str) -> list[dict[str, Any]]:
         """
-        Strip test_ prefix and try increasingly shorter name suffixes.
+        Rank name-derived candidates, best first.
 
-        test_validate_token → validate_token, then validate
+        The old resolver stripped ``test_`` and tried ever-shorter prefixes,
+        taking the first symbol with that name anywhere in the graph. In a
+        federated graph ``test_request_returns_200`` degraded to ``request`` and
+        matched an unrelated repository's method with total confidence.
+
+        Scoring rewards evidence and penalises coincidence:
+
+        - the full stripped name beats a truncated prefix
+        - the same repository beats a different one
+        - a neighbouring module beats an unrelated path
+        - a generic verb on its own scores near zero
         """
         if not test_name.startswith("test_"):
-            return None
+            return []
 
         stripped = test_name[len("test_") :]
-        parts = stripped.split("_")
+        parts = [p for p in stripped.split("_") if p]
+        if not parts:
+            return []
 
-        # Try full stripped name first, then progressively shorter prefixes
-        candidates = []
-        for i in range(len(parts), 0, -1):
-            candidates.append("_".join(parts[:i]))
+        test_repo = self._repo_of(test_file)
+        test_dir = test_file.rsplit("/", 1)[0] if "/" in test_file else ""
 
-        for candidate in candidates:
-            try:
-                result = self.store.query(_FIND_PRODUCTION_SYMBOL, {"name": candidate})
-                rows = result.result_set or []
-            except Exception:
+        scored: list[dict[str, Any]] = []
+        seen: set[tuple[str, str]] = set()
+
+        for length in range(len(parts), 0, -1):
+            candidate = "_".join(parts[:length])
+            # Longer names are more distinctive; a bare generic verb is not a
+            # signal at all.
+            specificity = length / len(parts)
+            if candidate in GENERIC_NAMES and length == 1:
                 continue
 
-            if rows:
-                row = rows[0]
-                return (row[0] or "Function", row[1] or "", row[2] or "")
+            for row in self._production_candidates(candidate):
+                key = (row["name"], row["file_path"])
+                if key in seen:
+                    continue
+                seen.add(key)
 
-        return None
+                if _is_test_path(row["file_path"]):
+                    # Mapping a test onto another test is never what was meant.
+                    continue
+
+                score = 0.35 * specificity
+                evidence = [f"name match on {candidate!r}"]
+
+                if test_repo and row["repo"] == test_repo:
+                    score += 0.35
+                    evidence.append("same repository")
+                elif test_repo and row["repo"]:
+                    score -= 0.15
+                    evidence.append("different repository")
+
+                prod_dir = row["file_path"].rsplit("/", 1)[0] if "/" in row["file_path"] else ""
+                if test_dir and prod_dir and _shared_prefix_depth(test_dir, prod_dir) >= 1:
+                    score += 0.25
+                    evidence.append("neighbouring module")
+
+                if length == len(parts):
+                    score += 0.15
+                    evidence.append("full name")
+
+                scored.append(
+                    {
+                        **row,
+                        "score": max(0.0, min(1.0, score)),
+                        "evidence": ", ".join(evidence),
+                    }
+                )
+
+        scored.sort(key=lambda c: -c["score"])
+        return scored
+
+    def _repo_of(self, file_path: str) -> str:
+        if not file_path:
+            return ""
+        try:
+            rows = self.store.query(_SYMBOL_REPO, {"file_path": file_path}).result_set or []
+        except Exception:
+            return ""
+        return (rows[0][0] or "") if rows else ""
+
+    def _production_candidates(self, name: str) -> list[dict[str, Any]]:
+        try:
+            rows = self.store.query(_FIND_PRODUCTION_CANDIDATES, {"name": name}).result_set or []
+        except Exception:
+            return []
+        return [
+            {
+                "type": row[0] or "Function",
+                "name": row[1] or "",
+                "file_path": row[2] or "",
+                "repo": row[3] or "",
+            }
+            for row in rows
+        ]

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -81,9 +81,7 @@ def _get_llm(llm_provider: str, llm_model: str, target: str | None = None):
             return get_provider(config.provider, model=config.model)
         return auto_provider(model=config.model)
     except (RuntimeError, ValueError, ImportError) as e:
-        raise click.ClickException(
-            f"Cannot use LLM provider {config.describe()}.\n{e}"
-        ) from e
+        raise click.ClickException(f"Cannot use LLM provider {config.describe()}.\n{e}") from e
 
 
 def _emit(text: str, fmt: str) -> None:
@@ -4455,6 +4453,106 @@ def _migrate_server(
     except Exception as e:  # noqa: BLE001
         return {**result, "status": "failed", "error": str(e)}
     return result
+
+
+# ── Supergraph contract v1.0 (#158) ──────────────────────────────────────────
+
+
+@main.group()
+def contract():
+    """Supergraph interop contract — the code realm's output boundary."""
+
+
+@contract.command("resolve")
+@click.argument("address")
+@DB_OPTION
+@click.option("--json", "as_json", is_flag=True)
+def contract_resolve(address: str, db: str, as_json: bool):
+    """Resolve a contract ADDRESS into the code graph.
+
+    \b
+    This is the brain-to-code hop: given the target of an `implemented_in` join
+    edge, it returns the node and the callers/callees traversal continues to.
+
+    \b
+    Examples:
+      navegador contract resolve "code:src/auth.py#validate_token"
+      navegador contract resolve "myrepo/code:src/auth.py"
+    """
+    from navegador.contract import AddressError, resolve
+
+    store = _get_store(db)
+    try:
+        resolved = resolve(store, address)
+    except AddressError as e:
+        raise click.ClickException(str(e)) from e
+
+    if as_json:
+        click.echo(json.dumps(resolved.to_dict(), indent=2, default=str))
+        raise SystemExit(0 if resolved.found else 1)
+
+    if not resolved.found:
+        console.print(f"[yellow]No node at[/yellow] {resolved.address}")
+        console.print(
+            "  The repo may not be ingested, or its paths may be recorded "
+            "relative to a different root. Check: [cyan]navegador repo nodes[/cyan]"
+        )
+        raise SystemExit(1)
+
+    console.print(f"[green]{resolved.label}[/green] {resolved.name}")
+    console.print(f"  address: {resolved.address}")
+    console.print(f"  path:    {resolved.path}")
+
+
+@contract.command("propose")
+@click.option("--repo", default="", help="Federation namespace to qualify targets with.")
+@click.option(
+    "--min-confidence",
+    default=0.5,
+    show_default=True,
+    help="Drop proposals scoring below this.",
+)
+@DB_OPTION
+@click.option("--json", "as_json", is_flag=True)
+def contract_propose(repo: str, min_confidence: float, db: str, as_json: bool):
+    """Propose join edges from inferred documentation-to-code affinity.
+
+    \b
+    Emits contract-format `implemented_in` proposals with confidence and
+    evidence. Navegador proposes; the brain reviews and decides what to commit.
+
+    \b
+    Examples:
+      navegador contract propose --repo myrepo --json
+      navegador contract propose --min-confidence 0.8
+    """
+    from navegador.contract import propose_join_edges
+
+    payload = propose_join_edges(_get_store(db), repo=repo, min_confidence=min_confidence)
+
+    if as_json:
+        click.echo(json.dumps(payload, indent=2, default=str))
+        return
+
+    proposals = payload["proposals"]
+    if not proposals:
+        console.print("No join edges to propose above that confidence.")
+        return
+
+    table = Table(title=f"{len(proposals)} join-edge proposal(s), contract {payload['contract']}")
+    table.add_column("Source", style="cyan", overflow="fold")
+    table.add_column("Edge")
+    table.add_column("Target address", overflow="fold")
+    table.add_column("Conf.", justify="right")
+    for item in proposals:
+        table.add_row(
+            f"{item['source']['kind']}:{item['source']['name']}",
+            item["edge"],
+            item["target"],
+            f"{item['confidence']:.2f}",
+        )
+    console.print(table)
+    console.print("\nReview and commit these in the brain — navegador only proposes.")
 
 
 # ── Manual: documentation packaged with the CLI (#172) ───────────────────────

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -63,6 +63,29 @@ def _open_store(db: str, target: str | None = None):
         raise click.ClickException(str(e)) from e
 
 
+def _get_llm(llm_provider: str, llm_model: str, target: str | None = None):
+    """
+    Build the configured LLM provider, or fail with something actionable.
+
+    Resolves through the same layering as storage — flags, environment, project
+    config, user config — so `[llm]` in config.toml is finally honoured (#164),
+    and turns provider/credential problems into a Click error naming the
+    provider, the layer that chose it, and the fix.
+    """
+    from navegador.config import resolve_llm
+    from navegador.llm import auto_provider, get_provider
+
+    config = resolve_llm(llm_provider or None, llm_model or None, target=target)
+    try:
+        if config.provider:
+            return get_provider(config.provider, model=config.model)
+        return auto_provider(model=config.model)
+    except (RuntimeError, ValueError, ImportError) as e:
+        raise click.ClickException(
+            f"Cannot use LLM provider {config.describe()}.\n{e}"
+        ) from e
+
+
 def _emit(text: str, fmt: str) -> None:
     if fmt == "json":
         click.echo(text)
@@ -3044,14 +3067,9 @@ def semantic_search(
       navegador semantic-search "database connection" --index --provider openai
     """
     from navegador.intelligence.search import SemanticSearch
-    from navegador.llm import auto_provider, get_provider
 
     store = _get_store(db)
-    provider = (
-        get_provider(llm_provider, model=llm_model)
-        if llm_provider
-        else auto_provider(model=llm_model)
-    )
+    provider = _get_llm(llm_provider, llm_model)
     ss = SemanticSearch(store, provider)
 
     if do_index:
@@ -3170,14 +3188,9 @@ def ask(question: str, db: str, llm_provider: str, llm_model: str):
       navegador ask "What concepts are in the auth domain?"
     """
     from navegador.intelligence.nlp import NLPEngine
-    from navegador.llm import auto_provider, get_provider
 
     store = _get_store(db)
-    provider = (
-        get_provider(llm_provider, model=llm_model)
-        if llm_provider
-        else auto_provider(model=llm_model)
-    )
+    provider = _get_llm(llm_provider, llm_model)
     engine = NLPEngine(store, provider)
 
     with console.status("[bold]Thinking...[/bold]"):
@@ -3209,14 +3222,9 @@ def generate_docs_cmd(name: str, db: str, llm_provider: str, llm_model: str, fil
       navegador generate-docs GraphStore --file navegador/graph/store.py
     """
     from navegador.intelligence.nlp import NLPEngine
-    from navegador.llm import auto_provider, get_provider
 
     store = _get_store(db)
-    provider = (
-        get_provider(llm_provider, model=llm_model)
-        if llm_provider
-        else auto_provider(model=llm_model)
-    )
+    provider = _get_llm(llm_provider, llm_model)
     engine = NLPEngine(store, provider)
 
     with console.status("[bold]Generating docs...[/bold]"):

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -216,6 +216,15 @@ def init(
     help="Detect and ingest as a monorepo workspace (Turborepo, Nx, Yarn, pnpm, Cargo, Go).",
 )
 @click.option(
+    "--repo-name",
+    "repo_key",
+    default="",
+    metavar="NAME",
+    help="Pin the Repository node's identity. Defaults to the git remote's "
+    "owner/repo, falling back to the directory name — so a worktree or a "
+    "renamed clone does not create a second, phantom repository.",
+)
+@click.option(
     "--exclude",
     "excludes",
     multiple=True,
@@ -233,6 +242,7 @@ def ingest(
     as_json: bool,
     redact: bool,
     monorepo: bool,
+    repo_key: str,
     excludes: tuple[str, ...],
 ):
     """Ingest a repository's code into the graph (AST + call graph)."""
@@ -278,11 +288,15 @@ def ingest(
         return
 
     if as_json:
-        stats = ingester.ingest(repo_path, clear=clear, incremental=incremental)
+        stats = ingester.ingest(
+            repo_path, clear=clear, incremental=incremental, repo_key=repo_key or None
+        )
         click.echo(json.dumps(stats, indent=2))
     else:
         with console.status(f"[bold]Ingesting[/bold] {repo_path}..."):
-            stats = ingester.ingest(repo_path, clear=clear, incremental=incremental)
+            stats = ingester.ingest(
+                repo_path, clear=clear, incremental=incremental, repo_key=repo_key or None
+            )
         table = Table(title="Ingestion complete")
         table.add_column("Metric", style="cyan")
         table.add_column("Count", justify="right", style="green")
@@ -2209,6 +2223,111 @@ def cycles(db: str, check_imports: bool, check_calls: bool, as_json: bool):
 @main.group()
 def repo():
     """Manage and query across multiple repositories."""
+
+
+@repo.command("nodes")
+@DB_OPTION
+@click.option("--json", "as_json", is_flag=True)
+def repo_nodes(db: str, as_json: bool):
+    """List Repository nodes in the graph with how many files each owns.
+
+    \b
+    Useful for spotting phantom repositories — before repository identity was
+    derived from the git remote, a worktree or a renamed clone created a second
+    node indistinguishable from a real one (#167).
+    """
+    store = _get_store(db)
+    rows = (
+        store.query(
+            "MATCH (r:Repository) "
+            "OPTIONAL MATCH (f)-[:BELONGS_TO]->(r) "
+            "RETURN r.path AS path, r.name AS name, count(f) AS files "
+            "ORDER BY r.path"
+        ).result_set
+        or []
+    )
+    entries = [{"path": r[0], "name": r[1], "files": r[2]} for r in rows]
+
+    if as_json:
+        click.echo(json.dumps(entries, indent=2))
+        return
+    if not entries:
+        console.print("No Repository nodes in this graph.")
+        return
+
+    table = Table(title=f"{len(entries)} Repository node(s)")
+    table.add_column("Identity", style="cyan", overflow="fold")
+    table.add_column("Name")
+    table.add_column("Files", justify="right")
+    for e in entries:
+        table.add_row(str(e["path"]), str(e["name"]), str(e["files"]))
+    console.print(table)
+
+    names = [e["name"] for e in entries]
+    dupes = sorted({n for n in names if names.count(n) > 1})
+    if dupes:
+        console.print(
+            f"\n[yellow]{len(dupes)} name(s) held by more than one node[/yellow]: "
+            f"{', '.join(dupes)}\n"
+            "If these are the same repository under different checkout names, merge them:\n"
+            "  [cyan]navegador repo merge <phantom-identity> <canonical-identity>[/cyan]"
+        )
+
+
+@repo.command("merge")
+@click.argument("source")
+@click.argument("target")
+@DB_OPTION
+@click.option("--json", "as_json", is_flag=True)
+def repo_merge(source: str, target: str, db: str, as_json: bool):
+    """Merge Repository node SOURCE into TARGET, then delete SOURCE.
+
+    \b
+    Repairs graphs that accumulated phantom repositories before identity was
+    derived from the git remote. Every file owned by SOURCE is re-pointed at
+    TARGET; files already owned by both simply lose the duplicate edge.
+
+    \b
+    Example:
+      navegador repo merge myproj-worktree ExampleOrg/myproj
+    """
+    store = _get_store(db)
+
+    def count(identity: str) -> int | None:
+        rows = store.query(
+            "MATCH (r:Repository {path: $p}) RETURN count(r)", {"p": identity}
+        ).result_set
+        return rows[0][0] if rows else 0
+
+    if not count(source):
+        raise click.ClickException(f"No Repository node with identity {source!r}.")
+    if not count(target):
+        raise click.ClickException(
+            f"No Repository node with identity {target!r}. "
+            f"Merging into a node that does not exist would lose the files instead."
+        )
+    if source == target:
+        raise click.ClickException("SOURCE and TARGET are the same identity.")
+
+    moved = (
+        store.query(
+            "MATCH (f)-[old:BELONGS_TO]->(:Repository {path: $src}), "
+            "(t:Repository {path: $tgt}) "
+            "DELETE old "
+            "MERGE (f)-[:BELONGS_TO]->(t) "
+            "RETURN count(f)",
+            {"src": source, "tgt": target},
+        ).result_set
+        or [[0]]
+    )[0][0]
+
+    store.query("MATCH (r:Repository {path: $src}) DETACH DELETE r", {"src": source})
+
+    result = {"source": source, "target": target, "files_moved": moved}
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+    else:
+        console.print(f"[green]Merged[/green] {source} → {target} ({moved} file(s) re-pointed)")
 
 
 @repo.command("add")

--- a/navegador/config.py
+++ b/navegador/config.py
@@ -162,6 +162,55 @@ def storage_from_file(path: Path, label: str) -> StorageConfig | None:
     return None
 
 
+@dataclass(frozen=True)
+class LLMConfig:
+    """A resolved LLM provider selection, with the layer that produced it."""
+
+    provider: str = ""
+    model: str = ""
+    source: str = "default"
+
+    def describe(self) -> str:
+        return f"{self.provider or '(auto)'}/{self.model or '(default)'} (from {self.source})"
+
+
+def resolve_llm(
+    provider: str | None = None,
+    model: str | None = None,
+    target: str | Path | None = None,
+) -> LLMConfig:
+    """
+    Resolve which LLM provider and model to use, and record why.
+
+    Layered exactly like storage: explicit flags, then environment, then the
+    project's ``[llm]`` table, then the user's. `navegador init` has always
+    written ``[llm] provider`` and ``model``, and nothing read them (#164).
+    """
+    if provider or model:
+        return LLMConfig(provider=provider or "", model=model or "", source="command line")
+
+    env_provider = os.environ.get("NAVEGADOR_LLM_PROVIDER", "").strip()
+    env_model = os.environ.get("NAVEGADOR_LLM_MODEL", "").strip()
+    if env_provider or env_model:
+        return LLMConfig(provider=env_provider, model=env_model, source="environment")
+
+    for path, label in (
+        (find_project_config(target), "project config"),
+        (user_config_path(), "user config"),
+    ):
+        if not path or not Path(path).is_file():
+            continue
+        section = read_config(path).get("llm")
+        if not isinstance(section, dict):
+            continue
+        name = str(section.get("provider", "")).strip()
+        model_id = str(section.get("model", "")).strip()
+        if name or model_id:
+            return LLMConfig(provider=name, model=model_id, source=f"{label} {path}")
+
+    return LLMConfig()
+
+
 # ── Resolution ────────────────────────────────────────────────────────────────
 
 

--- a/navegador/contract.py
+++ b/navegador/contract.py
@@ -1,0 +1,316 @@
+"""
+Supergraph interop contract v1.0 — the code realm's output boundary.
+
+The contract (ConflictHQ/project-brain#60) lets every graph in the system
+address and traverse the others as one network. Navegador owns the **code
+realm**: the live code graph, which is deliberately never compiled into a brain.
+Brain-side traversals reach it through join edges and continue here.
+
+Conformance is a mapping layer at the tool surface — internal ids, the graph
+store, and the schema are untouched. Integrate, don't refactor.
+
+Address grammar (global)::
+
+    [<repo>/]<kind>:<id>
+
+The code realm owns its own id convention: a repo-relative POSIX path,
+optionally followed by ``#`` and a qualified symbol. So::
+
+    calliope-astrolift/code:src/auth.py                    a file
+    calliope-astrolift/code:src/auth.py#validate_token     a function
+    calliope-astrolift/code:src/auth.py#Auth.validate      a method
+    code:src/auth.py#validate_token                        instance-local
+
+The brain is authoritative for its own kinds and decides which proposed join
+edges to commit; navegador only proposes. Code addresses appear in brain
+artifacts solely as join-edge targets.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from navegador.graph import GraphStore
+
+#: Contract version emitted in every conformant tool response.
+CONTRACT_VERSION = "1.0"
+
+#: This producer's realm.
+REALM = "code"
+
+#: The join edge the contract declares for brain → code.
+JOIN_EDGE = "implemented_in"
+
+#: Edge types a brain instance may commit from our proposals. `implemented_in`
+#: is the join edge; the other two are ordinary contract edges that our
+#: doc-link inference can also evidence.
+PROPOSABLE_EDGES = frozenset({"implemented_in", "references", "about"})
+
+#: Graph labels that denote a code entity addressable in this realm.
+_SYMBOL_LABELS = ("Function", "Method", "Class", "Variable")
+_FILE_LABELS = ("File", "Document")
+
+
+class AddressError(ValueError):
+    """Raised when a string is not a well-formed contract address."""
+
+
+@dataclass(frozen=True)
+class CodeAddress:
+    """A parsed code-realm address."""
+
+    path: str
+    symbol: str = ""
+    repo: str = ""
+
+    def __str__(self) -> str:
+        return format_address(self.path, self.symbol, self.repo)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "address": str(self),
+            "realm": REALM,
+            "repo": self.repo,
+            "path": self.path,
+            "symbol": self.symbol,
+            "contract": CONTRACT_VERSION,
+        }
+
+
+def format_address(path: str, symbol: str = "", repo: str = "") -> str:
+    """
+    Build a contract address for a code entity.
+
+    Args:
+        path: Repo-relative POSIX path. The file is the identity.
+        symbol: Optional qualified symbol within the file (``Auth.validate``).
+        repo: Optional federation namespace. Omitted for instance-local
+            addresses, exactly as the grammar specifies.
+    """
+    path = (path or "").replace("\\", "/").lstrip("/")
+    if not path:
+        raise AddressError("A code address needs a repo-relative path.")
+    body = f"{path}#{symbol}" if symbol else path
+    return f"{repo}/{REALM}:{body}" if repo else f"{REALM}:{body}"
+
+
+def parse_address(address: str) -> CodeAddress:
+    """
+    Parse ``[<repo>/]code:<path>[#<symbol>]``.
+
+    Raises:
+        AddressError: when the string is not a code-realm address. A brain
+            passing an address for a kind we do not own should get a clear
+            rejection, not a silent miss.
+    """
+    raw = (address or "").strip()
+    if not raw:
+        raise AddressError("Empty address.")
+
+    repo = ""
+    marker = f"{REALM}:"
+    index = raw.find(marker)
+    if index == -1:
+        raise AddressError(
+            f"{address!r} is not a code-realm address. Expected [<repo>/]{REALM}:<path>[#<symbol>]."
+        )
+    if index:
+        repo = raw[:index].rstrip("/")
+        if not repo:
+            raise AddressError(f"{address!r} has an empty repo namespace.")
+
+    body = raw[index + len(marker) :]
+    if not body:
+        raise AddressError(f"{address!r} names no path.")
+
+    path, _, symbol = body.partition("#")
+    path = path.replace("\\", "/").lstrip("/")
+    if not path:
+        raise AddressError(f"{address!r} names no path.")
+    return CodeAddress(path=path, symbol=symbol, repo=repo)
+
+
+@dataclass
+class ResolvedNode:
+    """A code-graph node reached through a contract address."""
+
+    address: str
+    label: str
+    name: str
+    path: str
+    found: bool = True
+    properties: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract": CONTRACT_VERSION,
+            "realm": REALM,
+            "address": self.address,
+            "found": self.found,
+            "label": self.label,
+            "name": self.name,
+            "path": self.path,
+            "properties": self.properties,
+        }
+
+
+def resolve(store: GraphStore, address: str) -> ResolvedNode:
+    """
+    Resolve a contract address to a node in the code graph.
+
+    This is the supergraph hop: a brain-side ``implemented_in`` edge carries a
+    code address, and resolving it here is the entry point from which ordinary
+    traversal — callers, blast radius, owners — continues.
+
+    A path may legitimately be recorded with or without its repo prefix
+    depending on whether the graph was built by a plain or a workspace ingest,
+    so both spellings are tried before reporting a miss.
+    """
+    parsed = parse_address(address)
+    candidates = [parsed.path]
+    if parsed.repo:
+        # Workspace ingests record repo-prefixed paths (#144).
+        candidates.append(f"{parsed.repo}/{parsed.path}")
+
+    for path in candidates:
+        if parsed.symbol:
+            node = _find_symbol(store, path, parsed.symbol)
+        else:
+            node = _find_file(store, path)
+        if node is not None:
+            return ResolvedNode(
+                address=str(parsed),
+                label=node["label"],
+                name=node["name"],
+                path=node["path"],
+                properties=node["properties"],
+            )
+
+    return ResolvedNode(address=str(parsed), label="", name="", path=parsed.path, found=False)
+
+
+def _find_symbol(store: GraphStore, path: str, symbol: str) -> dict | None:
+    """
+    Locate a symbol in a file, accepting a qualified or bare name.
+
+    ``Auth.validate`` should resolve to the method ``validate``; the qualifier
+    is the class it lives in, which the graph records as a separate node.
+    """
+    bare = symbol.rsplit(".", 1)[-1]
+    labels = " OR ".join(f"n:{label}" for label in _SYMBOL_LABELS)
+    rows = store.query(
+        f"MATCH (n) WHERE ({labels}) AND n.file_path = $path AND n.name IN $names "
+        "RETURN labels(n)[0], n.name, n.file_path, properties(n) LIMIT 1",
+        {"path": path, "names": list({symbol, bare})},
+    ).result_set
+    return _row_to_node(rows)
+
+
+def _find_file(store: GraphStore, path: str) -> dict | None:
+    labels = " OR ".join(f"n:{label}" for label in _FILE_LABELS)
+    rows = store.query(
+        f"MATCH (n) WHERE ({labels}) AND n.path = $path "
+        "RETURN labels(n)[0], n.name, n.path, properties(n) LIMIT 1",
+        {"path": path},
+    ).result_set
+    return _row_to_node(rows)
+
+
+def _row_to_node(rows) -> dict | None:
+    if not rows:
+        return None
+    row = rows[0]
+    return {
+        "label": row[0] or "",
+        "name": row[1] or "",
+        "path": row[2] or "",
+        "properties": row[3] if isinstance(row[3], dict) else {},
+    }
+
+
+def address_for_node(label: str, name: str, path: str, repo: str = "") -> str | None:
+    """
+    Contract address for a graph node, or None when it is not a code entity.
+
+    Knowledge nodes (Concept, Rule, Decision) belong to the brain realm — the
+    brain is authoritative for those, so emitting a code address for one would
+    claim ownership we do not have.
+    """
+    if label in _FILE_LABELS:
+        return format_address(path, repo=repo) if path else None
+    if label in _SYMBOL_LABELS:
+        return format_address(path, symbol=name, repo=repo) if path else None
+    return None
+
+
+def propose_join_edges(
+    store: GraphStore,
+    repo: str = "",
+    min_confidence: float = 0.5,
+    limit: int = 200,
+) -> dict[str, Any]:
+    """
+    Propose contract-format join edges from inferred doc↔code affinity.
+
+    Navegador proposes; the brain decides. Each proposal carries the confidence
+    and evidence the inference produced, so a brain instance can review before
+    committing anything to files in git.
+
+    Only candidates whose target is a code entity become proposals — a
+    doc→concept affinity is entirely within the brain realm and is not ours to
+    propose.
+    """
+    from navegador.intelligence.doclink import DocLinker
+
+    candidates = DocLinker(store).suggest_links(min_confidence=min_confidence)
+
+    proposals: list[dict[str, Any]] = []
+    for candidate in candidates:
+        target = address_for_node(
+            candidate.target_label, candidate.target_name, candidate.target_file, repo=repo
+        )
+        if target is None:
+            continue
+        proposals.append(
+            {
+                "edge": JOIN_EDGE,
+                "source": {
+                    "kind": _brain_kind(candidate.source_label),
+                    "name": candidate.source_name,
+                },
+                "target": target,
+                "confidence": round(candidate.confidence, 3),
+                "evidence": {
+                    "strategy": candidate.strategy,
+                    "rationale": candidate.rationale,
+                    "producer": "navegador",
+                },
+            }
+        )
+        if len(proposals) >= limit:
+            break
+
+    return {
+        "contract": CONTRACT_VERSION,
+        "realm": REALM,
+        "repo": repo,
+        "join_edge": JOIN_EDGE,
+        "proposals": proposals,
+        "count": len(proposals),
+    }
+
+
+#: Graph labels on the documentation side mapped to the brain kinds they
+#: correspond to. Unmapped labels pass through lowercased — the brain validates
+#: kinds against its own schema and is free to reject one.
+_BRAIN_KINDS = {
+    "Document": "doc",
+    "WikiPage": "wiki-page",
+    "Decision": "decision",
+    "Rule": "decision",
+    "Concept": "glossary-term",
+    "Memory": "memory-note",
+}
+
+
+def _brain_kind(label: str) -> str:
+    return _BRAIN_KINDS.get(label, (label or "").lower())

--- a/navegador/docs/getting-started/configuration.md
+++ b/navegador/docs/getting-started/configuration.md
@@ -176,26 +176,52 @@ max_query_complexity = 100  # Cypher query complexity limit
 
 ---
 
-## LLM provider config
+## LLM provider and model
 
-Configure LLM providers used by `navegador ask`, `navegador docs`, and `navegador semantic-search`. Requires `pip install "navegador[llm]"`.
+LLM-backed commands (`ask`, `docs --provider`, `generate-docs`,
+`semantic-search`, `pm decisions`) resolve their provider the same way storage
+does — first decision wins:
+
+| Priority | Source |
+|---|---|
+| 1 | `--provider` / `--model` flags |
+| 2 | `NAVEGADOR_LLM_PROVIDER` / `NAVEGADOR_LLM_MODEL` |
+| 3 | Project `.navegador/config.toml` `[llm]` |
+| 4 | User `~/.config/navegador/config.toml` `[llm]` |
+| 5 | Auto-discovery across the usable providers |
 
 ```toml
 [llm]
-provider = "anthropic"    # "anthropic", "openai", or "ollama"
-model = "claude-3-5-haiku-20241022"
-
-[llm.anthropic]
-api_key_env = "ANTHROPIC_API_KEY"   # env var name (not the key itself)
-
-[llm.openai]
-api_key_env = "OPENAI_API_KEY"
-model = "gpt-4o-mini"
-
-[llm.ollama]
-base_url = "http://localhost:11434"
-model = "llama3"
+provider = "anthropic"
+model = "claude-opus-5"
 ```
+
+### Credentials
+
+**Credentials are read from the environment only.** Navegador does not read
+`.env` files, keychains, or credential helpers — export the variable, or set it
+in your shell profile or CI secrets:
+
+| Provider | Credential | Notes |
+|---|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` | |
+| `openai` | `OPENAI_API_KEY` | |
+| `ollama` | *(none)* | Must be reachable at `OLLAMA_HOST`, default `http://localhost:11434` |
+
+Auto-discovery considers whether a provider can actually serve a request, not
+merely whether its SDK imports. A provider whose package is installed but whose
+credential is missing is skipped rather than selected, and the resulting error
+names every provider and why each was unusable:
+
+```
+No usable LLM provider.
+  anthropic: no credential in ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN
+  openai: no credential in OPENAI_API_KEY
+  ollama: no Ollama server is reachable at http://localhost:11434
+```
+
+Model defaults track current aliases. Pin one in `[llm] model` if you need a
+specific model rather than the provider's default.
 
 ---
 
@@ -230,6 +256,9 @@ See the [Cluster mode](../guide/cluster.md) guide for full setup instructions.
 | `NAVEGADOR_REDIS_URL` | — | Shared FalkorDB server URL. Takes precedence over `NAVEGADOR_DB` |
 | `NAVEGADOR_DB` | `.navegador/graph.db` | Path to an embedded graph file. **Not** a `redis://` URL |
 | `NAVEGADOR_HOME` | `~/.navegador` | Where `navegador server` keeps its module, config, and data |
+| `NAVEGADOR_GRAPH` | — | Named graph within the store, overriding `[storage] graph` |
+| `NAVEGADOR_LLM_PROVIDER` | — | `anthropic`, `openai`, or `ollama` |
+| `NAVEGADOR_LLM_MODEL` | — | Model ID passed to the provider |
 | `GITHUB_TOKEN` | — | GitHub personal access token for wiki ingestion |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key for LLM features |
 | `OPENAI_API_KEY` | — | OpenAI API key for LLM features |

--- a/navegador/docs/guide/supergraph-contract.md
+++ b/navegador/docs/guide/supergraph-contract.md
@@ -1,0 +1,172 @@
+# Supergraph Contract
+
+Navegador is one graph in a larger network. The supergraph interop contract
+(v1.0) makes every graph in that network addressable and traversable from every
+other one, and navegador owns the **code realm**.
+
+Two properties follow from that ownership, and they explain the rest of this
+page:
+
+- The code graph is a live database, not files in git. It is deliberately
+  **never compiled into a brain** — a brain records an address and traversal
+  continues here.
+- Navegador is authoritative for code and for nothing else. It **proposes** edges
+  into other realms; the owning graph reviews and commits them.
+
+Conformance is a mapping layer at the tool surface. Internal ids, the graph
+store, and the schema are untouched.
+
+## Addresses
+
+The global grammar is:
+
+```
+[<repo>/]<kind>:<id>
+```
+
+Each realm owns its id convention. In the code realm an id is a repo-relative
+POSIX path, optionally followed by `#` and a qualified symbol:
+
+```
+calliope-astrolift/code:src/auth.py                    a file
+calliope-astrolift/code:src/auth.py#validate_token     a function
+calliope-astrolift/code:src/auth.py#Auth.validate      a method
+code:src/auth.py#validate_token                        instance-local
+```
+
+The repo prefix is a federation namespace. Omit it for an address that only has
+to mean something on this instance; include it whenever the address will be
+stored somewhere else, which is nearly always.
+
+A qualified symbol names the path to the symbol, not a distinct node — the class
+in `Auth.validate` is stored separately, and the address resolves to the method.
+
+An address for a kind navegador does not own is rejected rather than missed:
+
+```console
+$ navegador contract resolve "myproj/story:AUTH-1"
+Error: 'myproj/story:AUTH-1' is not a code-realm address.
+Expected [<repo>/]code:<path>[#<symbol>].
+```
+
+## Resolving a join edge
+
+`implemented_in` is the join edge from a work or record node to the code that
+realizes it. The brain holds the edge; its target is a code address; resolving
+that address is the hop into this graph.
+
+```console
+$ navegador contract resolve "calliope-astrolift/code:src/auth.py#validate_token"
+Function validate_token
+  address: calliope-astrolift/code:src/auth.py#validate_token
+  path:    src/auth.py
+```
+
+From the resolved node, ordinary code-graph queries carry on — callers, blast
+radius, owners. Over MCP, `resolve_address` returns the immediate neighbourhood
+with the response, each neighbour carrying its own address, so a traversal does
+not need a second round trip to keep moving:
+
+```json
+{
+  "contract": "1.0",
+  "realm": "code",
+  "address": "calliope-astrolift/code:src/auth.py#validate_token",
+  "found": true,
+  "label": "Function",
+  "name": "validate_token",
+  "path": "src/auth.py",
+  "neighbourhood": {
+    "callers": [
+      {
+        "name": "login",
+        "label": "Function",
+        "address": "calliope-astrolift/code:src/views.py#login"
+      }
+    ],
+    "callees": []
+  }
+}
+```
+
+A miss is reported as `"found": false`, not raised. The usual cause is that the
+repo has not been ingested, or that its paths are recorded relative to a
+different root — check `navegador repo nodes`.
+
+## Proposing join edges
+
+Navegador can infer which documentation describes which code, and emit those
+inferences as contract-format proposals:
+
+```console
+$ navegador contract propose --repo calliope-astrolift --json
+```
+
+```json
+{
+  "contract": "1.0",
+  "realm": "code",
+  "join_edge": "implemented_in",
+  "count": 1,
+  "proposals": [
+    {
+      "edge": "implemented_in",
+      "source": {"kind": "doc", "name": "auth-design.md"},
+      "target": "calliope-astrolift/code:src/auth.py#validate_token",
+      "confidence": 0.95,
+      "evidence": {
+        "strategy": "EXACT_NAME",
+        "rationale": "`validate_token` appears in auth-design.md",
+        "producer": "navegador"
+      }
+    }
+  ]
+}
+```
+
+Three things about this output are deliberate:
+
+- **Nothing is written.** Proposing does not mutate the graph. The brain decides
+  what becomes an edge, because the brain is where the edge lives.
+- **Confidence and evidence travel with the proposal**, so review is possible
+  without re-deriving the inference. Raise the bar with `--min-confidence`.
+- **Targets are always code entities.** A documentation-to-concept affinity is
+  entirely within the brain realm, and minting a code address for it would claim
+  ownership navegador does not have. Those candidates are dropped.
+
+Source labels are mapped into brain kinds (`Document` → `doc`, `Rule` →
+`decision`, `Concept` → `glossary-term`) so the receiving brain can validate them
+against its own schema. An unmapped label passes through lowercased; the brain is
+free to reject it.
+
+## Version declaration
+
+Every response that emits a contract address states the version it conforms to:
+
+```json
+{"contract": "1.0", "realm": "code"}
+```
+
+`search_symbols` results also carry the address a brain would record to point
+back at each hit, which is usually how a join edge gets proposed in the first
+place.
+
+## Python API
+
+```python
+from navegador.contract import (
+    format_address, parse_address, resolve, propose_join_edges,
+)
+
+address = format_address("src/auth.py", "validate_token", repo="myproj")
+# 'myproj/code:src/auth.py#validate_token'
+
+parsed = parse_address(address)
+# CodeAddress(path='src/auth.py', symbol='validate_token', repo='myproj')
+
+node = resolve(store, address)
+if node.found:
+    ...  # continue traversal from node.name / node.path
+
+payload = propose_join_edges(store, repo="myproj", min_confidence=0.8)
+```

--- a/navegador/graph/export.py
+++ b/navegador/graph/export.py
@@ -1,22 +1,39 @@
 """
 Text-based graph export and import for navegador.
 
-Exports the full graph to a deterministic JSON Lines format (.jsonl)
-suitable for committing to version control. Each line is a self-contained
-JSON object — either a node or an edge.
+Exports the full graph to a deterministic JSON Lines format (.jsonl) suitable
+for committing to version control. Each line is a self-contained JSON object —
+either a node or an edge.
 
-Format:
-  {"kind": "node", "label": "Function", "props": {"name": "foo", ...}}
-  {"kind": "edge", "type": "CALLS", "from": {...}, "to": {...}}
+Format (conflict-kg/v1 identity, one record per line)::
+
+  {"kind": "node", "id": "Function::foo", "type": "Function",
+   "name": "foo", "props": {...}}
+  {"kind": "edge", "type": "CALLS", "source": "Function::foo",
+   "target": "Function::bar", "props": {...}}
+
+Node ids are content-derived (``type:path:name``, with a ``#n`` suffix on
+collision) and edges reference them, so a round trip preserves every edge
+exactly. This is the same identity scheme as the conflict-kg interchange
+format, deliberately: two serializations of one canonical shape rather than two
+formats that disagree about what a node is.
+
+Legacy exports — which identified endpoints by ``(name, path)`` merge keys —
+are still readable; see :func:`_import_legacy_edge`.
 """
 
 import json
 import logging
 from pathlib import Path
 
-from navegador.graph.store import GraphStore, paged_query
+from navegador.graph.interchange import collect_graph, merge_key
+from navegador.graph.store import GraphStore
 
 logger = logging.getLogger(__name__)
+
+
+class ExportError(RuntimeError):
+    """Raised when an import cannot reproduce the exported graph."""
 
 
 def export_graph(store: GraphStore, output_path: str | Path) -> dict[str, int]:
@@ -29,24 +46,37 @@ def export_graph(store: GraphStore, output_path: str | Path) -> dict[str, int]:
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    nodes = _export_nodes(store)
-    edges = _export_edges(store)
-
-    # Sort for deterministic output
-    nodes.sort(key=lambda n: (n["label"], json.dumps(n["props"], sort_keys=True)))
-    edges.sort(
-        key=lambda e: (
-            e["type"],
-            json.dumps(e["from"], sort_keys=True),
-            json.dumps(e["to"], sort_keys=True),
-        )
-    )
+    nodes, edges = collect_graph(store)
 
     with output_path.open("w", encoding="utf-8") as f:
         for node in nodes:
-            f.write(json.dumps(node, sort_keys=True) + "\n")
+            f.write(
+                json.dumps(
+                    {
+                        "kind": "node",
+                        "id": node["id"],
+                        "type": node["type"],
+                        "name": node["name"],
+                        "props": node["props"],
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
         for edge in edges:
-            f.write(json.dumps(edge, sort_keys=True) + "\n")
+            f.write(
+                json.dumps(
+                    {
+                        "kind": "edge",
+                        "type": edge["type"],
+                        "source": edge["source"],
+                        "target": edge["target"],
+                        "props": edge["props"],
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
 
     logger.info("Exported %d nodes, %d edges to %s", len(nodes), len(edges), output_path)
     return {"nodes": len(nodes), "edges": len(edges)}
@@ -62,117 +92,131 @@ def import_graph(store: GraphStore, input_path: str | Path, clear: bool = True) 
         clear: If True (default), wipe the graph before importing.
 
     Returns:
-        Dict with counts: nodes, edges.
+        Dict with counts of what was actually created — not of lines read.
+
+    Raises:
+        ExportError: when a fresh import creates fewer edges than the file
+            describes. An import that silently drops relationships leaves a pile
+            of disconnected nodes that answers every structural query with an
+            empty result, which reads as a valid negative.
     """
     input_path = Path(input_path)
     if not input_path.exists():
         raise FileNotFoundError(f"Export file not found: {input_path}")
 
-    if clear:
-        store.clear()
-
-    node_count = 0
-    edge_count = 0
-
+    node_records: list[dict] = []
+    edge_records: list[dict] = []
     with input_path.open("r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
             record = json.loads(line)
+            if record.get("kind") == "node":
+                node_records.append(record)
+            elif record.get("kind") == "edge":
+                edge_records.append(record)
 
-            if record["kind"] == "node":
-                _import_node(store, record)
-                node_count += 1
-            elif record["kind"] == "edge":
-                _import_edge(store, record)
-                edge_count += 1
+    if clear:
+        store.clear()
 
-    logger.info("Imported %d nodes, %d edges from %s", node_count, edge_count, input_path)
-    return {"nodes": node_count, "edges": edge_count}
+    # id -> (label, merge key) for endpoint resolution
+    key_map: dict[str, tuple[str, dict]] = {}
+    for record in node_records:
+        label, props, node_id = _node_from_record(record)
+        store.create_node(label, props)
+        if node_id is not None:
+            key_map[node_id] = (label, merge_key(label, props))
 
+    created = 0
+    skipped: list[dict] = []
+    for record in edge_records:
+        if _import_edge(store, record, key_map):
+            created += 1
+        else:
+            skipped.append(record)
 
-def _export_nodes(store: GraphStore) -> list[dict]:
-    """Export all nodes with their labels and properties."""
-    rows = paged_query(
-        store, "MATCH (n) RETURN labels(n)[0] AS label, properties(n) AS props ORDER BY id(n)"
-    )
-    nodes = []
-    for row in rows:
-        label = row[0]
-        props = row[1] if isinstance(row[1], dict) else {}
-        nodes.append({"kind": "node", "label": label, "props": props})
-    return nodes
+    for record in skipped[:5]:
+        logger.warning("Skipped edge with unresolvable endpoint: %s", record)
+    if len(skipped) > 5:
+        logger.warning("… and %d more unresolvable edges", len(skipped) - 5)
 
+    logger.info("Imported %d nodes, %d edges from %s", len(node_records), created, input_path)
 
-def _export_edges(store: GraphStore) -> list[dict]:
-    """Export all edges with type and endpoint identifiers."""
-    rows = paged_query(
-        store,
-        "MATCH (a)-[r]->(b) "
-        "RETURN type(r) AS type, labels(a)[0] AS from_label, "
-        "a.name AS from_name, coalesce(a.file_path, a.path, '') AS from_path, "
-        "labels(b)[0] AS to_label, b.name AS to_name, "
-        "coalesce(b.file_path, b.path, '') AS to_path "
-        "ORDER BY id(r)",
-    )
-    edges = []
-    for row in rows:
-        edges.append(
-            {
-                "kind": "edge",
-                "type": row[0],
-                "from": {"label": row[1], "name": row[2], "path": row[3]},
-                "to": {"label": row[4], "name": row[5], "path": row[6]},
-            }
+    if clear and created != len(edge_records):
+        raise ExportError(
+            f"Import did not reproduce the export — refusing to report success.\n"
+            f"  file describes: {len(node_records)} nodes, {len(edge_records)} edges\n"
+            f"  created:        {store.node_count()} nodes, {created} edges\n"
+            f"  {len(skipped)} edge(s) had endpoints that could not be resolved.\n"
+            f"The graph has been written but is incomplete; structural queries "
+            f"against it will return empty results rather than errors."
         )
-    return edges
+
+    return {"nodes": len(node_records), "edges": created}
 
 
-def _import_node(store: GraphStore, record: dict) -> None:
-    """Create a node from an export record."""
-    label = record["label"]
-    props = record["props"]
-    # Ensure required merge keys exist
-    if "name" not in props:
-        props["name"] = ""
-    if "file_path" not in props and "path" not in props:
-        props["file_path"] = ""
+def _node_from_record(record: dict) -> tuple[str, dict, str | None]:
+    """
+    Read a node record in either the current or the legacy shape.
 
-    prop_str = ", ".join(f"n.{k} = ${k}" for k in props)
-    # Use name + file_path or path for merge key
-    if "file_path" in props:
-        cypher = f"MERGE (n:{label} {{name: $name, file_path: $file_path}}) SET {prop_str}"
-    else:
-        cypher = f"MERGE (n:{label} {{name: $name, path: $path}}) SET {prop_str}"
-    store.query(cypher, props)
+    Legacy records carry ``label`` and no ``id``; current ones carry ``type``,
+    ``name`` and a content-derived ``id``.
+    """
+    if "label" in record and "type" not in record:
+        props = dict(record.get("props") or {})
+        return record["label"], props, None
+
+    props = dict(record.get("props") or {})
+    if record.get("name") is not None:
+        props.setdefault("name", record["name"])
+    return record["type"], props, record.get("id")
 
 
-def _import_edge(store: GraphStore, record: dict) -> None:
-    """Create an edge from an export record."""
-    edge_type = record["type"]
-    from_info = record["from"]
-    to_info = record["to"]
+def _import_edge(store: GraphStore, record: dict, key_map: dict[str, tuple[str, dict]]) -> bool:
+    """Create one edge, returning whether it was actually created."""
+    source, target = record.get("source"), record.get("target")
+    if isinstance(source, str) and isinstance(target, str):
+        src, tgt = key_map.get(source), key_map.get(target)
+        if src is None or tgt is None:
+            return False
+        return store.create_edge(
+            src[0], src[1], record["type"], tgt[0], tgt[1], record.get("props") or None
+        )
 
-    from_key = "name: $from_name"
-    to_key = "name: $to_name"
+    return _import_legacy_edge(store, record)
 
-    params = {
-        "from_name": from_info["name"],
-        "to_name": to_info["name"],
-    }
 
-    if from_info.get("path"):
-        from_key += ", file_path: $from_path"
-        params["from_path"] = from_info["path"]
+def _import_legacy_edge(store: GraphStore, record: dict) -> bool:
+    """
+    Create an edge from a pre-id export record.
 
-    if to_info.get("path"):
-        to_key += ", path: $to_path"
-        params["to_path"] = to_info["path"]
+    Those records identify each endpoint by ``{label, name, path}``, where
+    ``path`` was written from ``coalesce(file_path, path, '')``. The original
+    importer matched the source on ``file_path`` and the target on ``path``,
+    which meant any edge pointing at a code symbol matched nothing at all. Both
+    endpoints are now keyed the way the node's own label is keyed.
+    """
+    from_info, to_info = record.get("from"), record.get("to")
+    if not isinstance(from_info, dict) or not isinstance(to_info, dict):
+        return False
 
-    cypher = (
-        f"MATCH (a:{from_info['label']} {{{from_key}}}), "
-        f"(b:{to_info['label']} {{{to_key}}}) "
-        f"MERGE (a)-[r:{edge_type}]->(b)"
+    def endpoint(info: dict) -> tuple[str, dict]:
+        label = info.get("label") or ""
+        props = {"name": info.get("name", "")}
+        if info.get("path"):
+            # A path-keyed label stores it as `path`; everything else as `file_path`.
+            if label in GraphStore._PATH_KEYED_LABELS:
+                props["path"] = info["path"]
+            else:
+                props["file_path"] = info["path"]
+        return label, merge_key(label, props)
+
+    src_label, src_key = endpoint(from_info)
+    tgt_label, tgt_key = endpoint(to_info)
+    if not src_label or not tgt_label:
+        return False
+
+    return store.create_edge(
+        src_label, src_key, record["type"], tgt_label, tgt_key, record.get("props") or None
     )
-    store.query(cypher, params)

--- a/navegador/graph/interchange.py
+++ b/navegador/graph/interchange.py
@@ -159,7 +159,7 @@ def import_conflict_kg(
         label = node["type"]
         props = {"name": node.get("name", ""), **node.get("props", {})}
         store.create_node(label, props)
-        key_map[node["id"]] = (label, _merge_key(label, props))
+        key_map[node["id"]] = (label, merge_key(label, props))
 
     edge_count = 0
     for edge in edges:
@@ -167,8 +167,14 @@ def import_conflict_kg(
         if src is None or tgt is None:
             logger.warning("Skipping edge with unknown endpoint: %s", edge)
             continue
-        store.create_edge(src[0], src[1], edge["type"], tgt[0], tgt[1], edge.get("props") or None)
-        edge_count += 1
+        # create_edge reports whether both endpoints matched; counting calls
+        # rather than results would make the returned total unfalsifiable.
+        if store.create_edge(
+            src[0], src[1], edge["type"], tgt[0], tgt[1], edge.get("props") or None
+        ):
+            edge_count += 1
+        else:
+            logger.warning("Edge endpoints did not match on import: %s", edge)
 
     logger.info("Imported %d nodes, %d edges from %s", len(nodes), edge_count, input_path)
     return {"nodes": len(nodes), "edges": edge_count}
@@ -189,7 +195,7 @@ def is_conflict_kg_json(path: str | Path) -> bool:
     return isinstance(payload, dict) and payload.get("format") == FORMAT
 
 
-def _merge_key(label: str, props: dict) -> dict:
+def merge_key(label: str, props: dict) -> dict:
     """Merge-key props for a node, mirroring GraphStore.create_node key selection."""
     if label in GraphStore._PATH_KEYED_LABELS:
         return {"path": props.get("path", "")}

--- a/navegador/graph/queries.py
+++ b/navegador/graph/queries.py
@@ -265,6 +265,35 @@ OPTIONAL MATCH (i:Import {file_path: $path})
 DETACH DELETE i
 """
 
+# Paths of every File/Document recorded as belonging to one repository. Used to
+# find nodes for source files that have since been deleted from disk (#168):
+# nothing else walks the set of previously-known paths, so whole-file removal
+# went unnoticed and the graph drifted monotonically away from the tree.
+REPO_FILE_PATHS = """
+MATCH (f)-[:BELONGS_TO]->(:Repository {path: $repo})
+WHERE (f:File OR f:Document) AND f.path IS NOT NULL
+RETURN f.path AS path
+"""
+
+# Remove a deleted file's symbols. Separate statements rather than one chained
+# query: a file with no children makes the leading MATCH yield nothing, which
+# would silently skip everything after it.
+DELETE_FILE_CHILDREN = """
+MATCH (f {path: $path})-[:CONTAINS]->(child)
+DETACH DELETE child
+"""
+
+DELETE_FILE_IMPORTS = """
+MATCH (i:Import {file_path: $path})
+DETACH DELETE i
+"""
+
+DELETE_FILE_NODE = """
+MATCH (f {path: $path})
+WHERE f:File OR f:Document
+DETACH DELETE f
+"""
+
 DOCUMENT_HASH = """
 MATCH (d:Document {path: $path})
 RETURN d.content_hash AS hash

--- a/navegador/ingestion/optimization.py
+++ b/navegador/ingestion/optimization.py
@@ -335,6 +335,7 @@ class ParallelIngester:
         max_workers: int | None = None,
         clear: bool = False,
         incremental: bool = False,
+        repo_key: str | None = None,
     ) -> dict[str, int]:
         """
         Ingest a repository, parsing files concurrently.
@@ -346,13 +347,22 @@ class ParallelIngester:
                          :class:`~concurrent.futures.ThreadPoolExecutor`.
             clear: Wipe the graph before ingesting.
             incremental: Skip files whose content hash hasn't changed.
+            repo_key: Portable graph identity for the Repository node. Defaults
+                to the git remote's ``owner/repo``, falling back to the
+                directory name — the same derivation the serial ingester uses,
+                so the two paths cannot disagree about repository identity.
 
         Returns:
             Aggregated stats dict with keys: files, functions, classes,
             edges, skipped, errors.
         """
         from navegador.graph.schema import NodeLabel
-        from navegador.ingestion.parser import LANGUAGE_MAP, _file_hash
+        from navegador.ingestion.parser import (
+            LANGUAGE_MAP,
+            _file_hash,
+            repo_display_name,
+            repo_identity,
+        )
 
         repo_path = Path(repo_path).resolve()
         if not repo_path.exists():
@@ -361,13 +371,15 @@ class ParallelIngester:
         if clear:
             self._store.clear()
 
-        # Repository node (same as RepoIngester.ingest) — keyed by name, not
-        # the machine-local checkout path (#145).
+        # Repository node (same as RepoIngester.ingest) — keyed by a portable
+        # identity, not the machine-local checkout path (#145) and not the
+        # directory basename, which differs per worktree or renamed clone (#167).
+        repo_key = repo_key or repo_identity(repo_path)
         self._store.create_node(
             NodeLabel.Repository,
             {
-                "name": repo_path.name,
-                "path": repo_path.name,
+                "name": repo_display_name(repo_key),
+                "path": repo_key,
             },
         )
 

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -70,6 +70,52 @@ LANGUAGE_MAP: dict[str, str] = {
 }
 
 
+def _relative_path(path: Path, root: Path) -> str | None:
+    """
+    Path relative to *root*, or None when it lies outside.
+
+    The raw path is tried first so ordinary files keep their literal recorded
+    path; resolution is a fallback for the case where one side has already been
+    resolved through a symlink and the other has not (on macOS, /var against
+    /private/var). Returning None rather than raising keeps a stray path from
+    aborting an entire ingest.
+    """
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        pass
+    try:
+        return str(path.resolve().relative_to(root))
+    except ValueError:
+        logger.debug("Skipping %s: not under %s", path, root)
+        return None
+
+
+def repo_identity(repo_path: Path) -> str:
+    """
+    Stable graph identity for a checkout.
+
+    The directory basename is not an identity: a worktree, a renamed clone, or
+    ``git clone <url> <otherdir>`` all produce a different basename for the same
+    repository, and each one used to create an additional Repository node
+    indistinguishable from a real one (#167). The git remote is the only thing
+    that stays constant across all three, so it is preferred; the basename
+    remains the fallback for a checkout with no remote.
+    """
+    from navegador.vcs import GitAdapter
+
+    try:
+        identity = GitAdapter(repo_path).remote_identity()
+    except Exception:  # noqa: BLE001 — identity must never fail an ingest
+        identity = ""
+    return identity or repo_path.name
+
+
+def repo_display_name(repo_key: str) -> str:
+    """Human-facing name for a repo key — the segment after any owner prefix."""
+    return repo_key.rsplit("/", 1)[-1] if repo_key else ""
+
+
 class RepoIngester:
     """
     Parses a local code repository and populates a GraphStore.
@@ -127,7 +173,8 @@ class RepoIngester:
             clear: If True, wipe the graph before ingesting.
             incremental: If True, skip files whose content hash hasn't changed.
             repo_key: Portable graph identity for the Repository node
-                (defaults to the repo directory name). Workspace ingesters
+                (defaults to the ``owner/repo`` of the git remote, falling back
+                to the directory name when there is none). Workspace ingesters
                 pass the workspace-relative path here so nested repos with
                 the same basename stay distinct.
             rel_root: Ancestor directory that node paths are recorded
@@ -171,14 +218,17 @@ class RepoIngester:
         rel_root: Path | None = None,
     ) -> dict[str, int]:
         rel_root = rel_root or repo_path
-        repo_key = repo_key or repo_path.name
+        repo_key = repo_key or repo_identity(repo_path)
         # Create repository node. Keyed by a portable identity, not the
         # absolute checkout path — exports are committed/shared, and machine
         # paths churned ids across machines and leaked local layout (#145).
+        # `name` is derived from the key rather than the directory, or a
+        # worktree's directory name silently clobbers the display name of the
+        # node its files are attached to (#167).
         self.store.create_node(
             NodeLabel.Repository,
             {
-                "name": repo_path.name,
+                "name": repo_display_name(repo_key),
                 "path": repo_key,
                 "file_path": "",
             },
@@ -200,7 +250,9 @@ class RepoIngester:
         present: set[str] = set()
 
         for source_file in self._iter_source_files(repo_path):
-            rel_path = str(source_file.relative_to(rel_root))
+            rel_path = _relative_path(source_file, rel_root)
+            if rel_path is None:
+                continue
             present.add(rel_path)
 
             language = LANGUAGE_MAP.get(source_file.suffix)
@@ -552,7 +604,7 @@ class RepoIngester:
         from navegador.ingestion.ansible import AnsibleParser
 
         rel_root = rel_root or repo_path
-        repo_key = repo_key or repo_path.name
+        repo_key = repo_key or repo_identity(repo_path)
         is_ansible_file = AnsibleParser.is_ansible_file
 
         ansible_parser: AnsibleParser | None = None
@@ -563,7 +615,9 @@ class RepoIngester:
             if not is_ansible_file(path, repo_path):
                 continue
 
-            rel_path = str(path.relative_to(rel_root))
+            rel_path = _relative_path(path, rel_root)
+            if rel_path is None:
+                continue
             # Recorded before the unchanged/skip check: an Ansible file that did
             # not need re-parsing this pass is still present on disk and must
             # not be pruned.

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -191,9 +191,18 @@ class RepoIngester:
             "edges": 0,
             "skipped": 0,
             "grammar_skipped": 0,
+            "removed": 0,
         }
 
+        # Every path this pass saw on disk, recorded before any decision about
+        # whether it can be parsed. Pruning against the parsed set instead would
+        # delete files whose optional grammar merely isn't installed.
+        present: set[str] = set()
+
         for source_file in self._iter_source_files(repo_path):
+            rel_path = str(source_file.relative_to(rel_root))
+            present.add(rel_path)
+
             language = LANGUAGE_MAP.get(source_file.suffix)
             if not language:
                 continue
@@ -203,7 +212,6 @@ class RepoIngester:
                 stats["grammar_skipped"] += 1
                 continue
 
-            rel_path = str(source_file.relative_to(rel_root))
             content_hash = _file_hash(source_file)
 
             if incremental and self._file_unchanged(rel_path, content_hash):
@@ -238,7 +246,13 @@ class RepoIngester:
                     shutil.rmtree(effective_root, ignore_errors=True)
 
         # Ansible pass — heuristically detect and parse Ansible YAML files
-        self._ingest_ansible(repo_path, stats, incremental, rel_root, repo_key)
+        self._ingest_ansible(repo_path, stats, incremental, rel_root, repo_key, present)
+
+        # Anything the repository no longer contains is removed. Without this a
+        # maintained graph only ever grows: deleted files keep their File node,
+        # every symbol they contained, and all their edges, and those ghosts are
+        # still returned by queries and cited in impact answers (#168).
+        stats["removed"] = self._prune_deleted_files(present, repo_key)
 
         # Fossil mirror pass — if the repo is also a Fossil checkout (e.g. a
         # Git repo mirrored to/from Fossil), ingest wiki pages and tickets.
@@ -331,6 +345,35 @@ class RepoIngester:
         if not rows or rows[0][0] is None:
             return False
         return rows[0][0] == content_hash
+
+    def _prune_deleted_files(self, present: set[str], repo_key: str) -> int:
+        """
+        Remove File/Document nodes for paths this repo no longer contains.
+
+        Scoped by BELONGS_TO so a shared or federated graph only loses the
+        entries of the repository actually being ingested. Returns how many
+        paths were removed.
+        """
+        try:
+            rows = self.store.query(queries.REPO_FILE_PATHS, {"repo": repo_key}).result_set or []
+        except Exception:
+            logger.exception("Could not list known files for %s; skipping prune", repo_key)
+            return 0
+
+        stale = [row[0] for row in rows if row and row[0] and row[0] not in present]
+        for path in stale:
+            self.store.query(queries.DELETE_FILE_CHILDREN, {"path": path})
+            self.store.query(queries.DELETE_FILE_IMPORTS, {"path": path})
+            self.store.query(queries.DELETE_FILE_NODE, {"path": path})
+
+        if stale:
+            logger.info(
+                "Removed %d file(s) no longer present in %s: %s",
+                len(stale),
+                repo_key,
+                ", ".join(sorted(stale)[:10]) + ("…" if len(stale) > 10 else ""),
+            )
+        return len(stale)
 
     def _clear_file_subgraph(self, rel_path: str) -> None:
         suffix = Path(rel_path).suffix.lower()
@@ -503,6 +546,7 @@ class RepoIngester:
         incremental: bool,
         rel_root: Path | None = None,
         repo_key: str | None = None,
+        present: set[str] | None = None,
     ) -> None:
         """Detect and parse Ansible YAML files (playbooks, roles, tasks)."""
         from navegador.ingestion.ansible import AnsibleParser
@@ -520,6 +564,11 @@ class RepoIngester:
                 continue
 
             rel_path = str(path.relative_to(rel_root))
+            # Recorded before the unchanged/skip check: an Ansible file that did
+            # not need re-parsing this pass is still present on disk and must
+            # not be pruned.
+            if present is not None:
+                present.add(rel_path)
             content_hash = _file_hash(path)
 
             if incremental and self._file_unchanged(rel_path, content_hash):

--- a/navegador/ingestion/python.py
+++ b/navegador/ingestion/python.py
@@ -51,6 +51,89 @@ def _get_docstring(node, source: bytes) -> str | None:
     return None
 
 
+def _parse_import_from(node, source: bytes) -> tuple[str, list[tuple[str, str]]]:
+    """
+    Split a ``from X import a, b as c`` statement into its module and bindings.
+
+    The grammar labels the module and every imported member alike, as
+    ``dotted_name``; only their position relative to the ``import`` keyword
+    tells them apart. Matching on a node type called ``import_from_member`` —
+    which the grammar does not produce — meant `from X import Y` created no
+    Import nodes whatsoever.
+
+    Returns ``(module, [(local_name, original_name), ...])``. A wildcard import
+    yields no bindings, since nothing nameable is introduced.
+    """
+    module = ""
+    bindings: list[tuple[str, str]] = []
+    seen_import_keyword = False
+
+    for child in node.children:
+        if child.type == "import":
+            seen_import_keyword = True
+            continue
+        if not seen_import_keyword:
+            if child.type in ("dotted_name", "relative_import"):
+                module = _node_text(child, source)
+            continue
+        if child.type == "dotted_name":
+            name = _node_text(child, source)
+            bindings.append((name, name))
+        elif child.type == "aliased_import":
+            original = next(
+                (_node_text(c, source) for c in child.children if c.type == "dotted_name"), ""
+            )
+            alias = next(
+                (_node_text(c, source) for c in reversed(child.children) if c.type == "identifier"),
+                "",
+            )
+            if original:
+                bindings.append((alias or original, original))
+
+    return module, bindings
+
+
+def _module_to_repo_file(module: str, current: Path, repo_root: Path) -> str | None:
+    """
+    Repo-relative file defining *module*, or None when it is not in the repo.
+
+    Handles absolute (``pkg.mod``) and relative (``.mod``, ``..pkg.mod``)
+    imports, and both module and package layouts. Returning None for anything
+    outside the repository is what distinguishes a first-party call worth an
+    edge from a standard-library or third-party one.
+    """
+    module = (module or "").strip()
+    if not module:
+        return None
+
+    leading = len(module) - len(module.lstrip("."))
+    if leading:
+        # A relative import is resolved against the current file's package.
+        base = current.parent
+        for _ in range(leading - 1):
+            base = base.parent
+        parts = [p for p in module[leading:].split(".") if p]
+    else:
+        base = repo_root
+        parts = [p for p in module.split(".") if p]
+
+    if not parts and leading:
+        candidates = [base / "__init__.py"]
+    else:
+        candidates = [
+            base.joinpath(*parts).with_suffix(".py"),
+            base.joinpath(*parts) / "__init__.py",
+        ]
+
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                return str(candidate.resolve().relative_to(repo_root.resolve()))
+        except (OSError, ValueError):
+            continue
+    return None
+
+
 class PythonParser(LanguageParser):
     def __init__(self) -> None:
         self._parser = _get_parser()
@@ -73,8 +156,87 @@ class PythonParser(LanguageParser):
             },
         )
 
+        # Import bindings are collected from the whole file first, including
+        # those inside functions and methods. A call is resolved against them,
+        # so the walk cannot do this lazily: `_handle_function` extracts a
+        # function's calls the moment it reaches it, which is before a
+        # function-local import further down the file has been seen.
+        self._bindings = self._collect_bindings(tree.root_node, source, path, repo_root)
+
         self._walk(tree.root_node, source, rel_path, store, stats, class_name=None)
+        self._bindings = {}
         return stats
+
+    # ── Import resolution ────────────────────────────────────────────────
+
+    def _collect_bindings(self, root, source: bytes, path: Path, repo_root: Path) -> dict:
+        """
+        Map every name bound by an import to the repo file that defines it.
+
+        Two shapes are recorded:
+
+        - ``symbol`` → ``(file, original_name)`` for ``from mod import name``
+        - ``alias``  → ``(file, "")`` for ``import pkg.mod`` / ``from pkg import
+          mod``, so a later ``alias.attr()`` can be resolved
+
+        Modules that do not resolve to a file inside the repository — the
+        standard library, third-party packages — are simply absent, which is
+        what keeps `asyncio.to_thread` from inventing an edge.
+        """
+        bindings: dict[str, tuple[str, str]] = {}
+
+        def module_file(module: str) -> str | None:
+            return _module_to_repo_file(module, path, repo_root)
+
+        def visit(node):
+            if node.type == "import_statement":
+                for child in node.children:
+                    if child.type == "dotted_name":
+                        module = _node_text(child, source)
+                        target = module_file(module)
+                        if target:
+                            # `import pkg.mod` binds the leaf for `pkg.mod.f()`
+                            bindings.setdefault(module.split(".")[-1], (target, ""))
+                            bindings.setdefault(module, (target, ""))
+            elif node.type == "import_from_statement":
+                module, members = _parse_import_from(node, source)
+                for local, original in members:
+                    # `from pkg import mod` — the member may itself be a module
+                    submodule = module_file(f"{module}.{original}") if module else None
+                    if submodule:
+                        bindings.setdefault(local, (submodule, ""))
+                        continue
+                    target = module_file(module)
+                    if target:
+                        bindings.setdefault(local, (target, original))
+            for child in node.children:
+                visit(child)
+
+        visit(root)
+        return bindings
+
+    def _resolve_callee(self, expression: str, file_path: str) -> tuple[str, str]:
+        """
+        Where a called expression's definition lives: (file, symbol).
+
+        Falls back to the current file, which is what the parser assumed for
+        every call before — the reason no cross-module edge was ever created
+        (#163).
+        """
+        parts = expression.split(".")
+        bindings = getattr(self, "_bindings", {}) or {}
+
+        if len(parts) == 1:
+            target = bindings.get(parts[0])
+            if target and target[1]:
+                return target[0], target[1]
+            return file_path, parts[0]
+
+        # `alias.symbol` — resolve the alias to its module file
+        target = bindings.get(".".join(parts[:-1])) or bindings.get(parts[-2])
+        if target:
+            return target[0], parts[-1]
+        return file_path, parts[-1]
 
     def _walk(
         self,
@@ -129,31 +291,25 @@ class PythonParser(LanguageParser):
     def _handle_import_from(
         self, node, source: bytes, file_path: str, store: GraphStore, stats: dict
     ) -> None:
-        module = ""
-        for child in node.children:
-            if child.type in ("dotted_name", "relative_import"):
-                module = _node_text(child, source)
-                break
-        for child in node.children:
-            if child.type == "import_from_member":
-                name = _node_text(child, source)
-                store.create_node(
-                    NodeLabel.Import,
-                    {
-                        "name": name,
-                        "file_path": file_path,
-                        "line_start": node.start_point[0] + 1,
-                        "module": module,
-                    },
-                )
-                store.create_edge(
-                    NodeLabel.File,
-                    {"path": file_path},
-                    EdgeType.IMPORTS,
-                    NodeLabel.Import,
-                    {"name": name, "file_path": file_path},
-                )
-                stats["edges"] += 1
+        module, bindings = _parse_import_from(node, source)
+        for name, _original in bindings:
+            store.create_node(
+                NodeLabel.Import,
+                {
+                    "name": name,
+                    "file_path": file_path,
+                    "line_start": node.start_point[0] + 1,
+                    "module": module,
+                },
+            )
+            store.create_edge(
+                NodeLabel.File,
+                {"path": file_path},
+                EdgeType.IMPORTS,
+                NodeLabel.Import,
+                {"name": name, "file_path": file_path},
+            )
+            stats["edges"] += 1
 
     def _handle_class(
         self, node, source: bytes, file_path: str, store: GraphStore, stats: dict
@@ -259,21 +415,39 @@ class PythonParser(LanguageParser):
         store: GraphStore,
         stats: dict,
     ) -> None:
+        def emit(target_file: str, target_name: str, edge_type) -> None:
+            store.create_edge(
+                fn_label,
+                {"name": fn_name, "file_path": file_path},
+                edge_type,
+                NodeLabel.Function,
+                {"name": target_name, "file_path": target_file},
+            )
+            stats["edges"] += 1
+
         def walk_calls(node):
             if node.type == "call":
                 func = next(
                     (c for c in node.children if c.type in ("identifier", "attribute")), None
                 )
                 if func:
-                    callee_name = _node_text(func, source).split(".")[-1]
-                    store.create_edge(
-                        fn_label,
-                        {"name": fn_name, "file_path": file_path},
-                        EdgeType.CALLS,
-                        NodeLabel.Function,
-                        {"name": callee_name, "file_path": file_path},
-                    )
-                    stats["edges"] += 1
+                    expression = _node_text(func, source)
+                    target_file, target_name = self._resolve_callee(expression, file_path)
+                    emit(target_file, target_name, EdgeType.CALLS)
+
+                    # A callable passed to another call is a reference to it,
+                    # not a call of it: `asyncio.to_thread(pipeline.process)`
+                    # never appears as a call node, so flow analysis stopped
+                    # dead at the handoff (#163).
+                    args = next((c for c in node.children if c.type == "argument_list"), None)
+                    for arg in args.children if args else []:
+                        if arg.type not in ("identifier", "attribute"):
+                            continue
+                        ref_file, ref_name = self._resolve_callee(
+                            _node_text(arg, source), file_path
+                        )
+                        if ref_file != file_path or "." in _node_text(arg, source):
+                            emit(ref_file, ref_name, EdgeType.REFERENCES)
             for child in node.children:
                 walk_calls(child)
 

--- a/navegador/intelligence/nlp.py
+++ b/navegador/intelligence/nlp.py
@@ -24,6 +24,7 @@ Usage::
 from __future__ import annotations
 
 import json
+import logging
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -49,15 +50,53 @@ Node properties (where present):
   status, domain, rationale, alternatives, date, community
 """
 
+#: `(var:A|B)` in a node pattern — the variable is optional, and the pattern
+#: ends at `)` or at a property map `{`. Relationship patterns use `[` and are
+#: deliberately not matched: FalkorDB accepts alternative relationship types.
+logger = logging.getLogger(__name__)
+
+_NODE_ALT_LABELS = re.compile(
+    r"\(\s*(\w*)\s*:\s*([A-Za-z_]\w*(?:\s*\|\s*[A-Za-z_]\w*)+)\s*(?=[){])"
+)
+
+#: The clause a WHERE must be inserted before when the query has none.
+_TRAILING_CLAUSE = re.compile(
+    r"\b(RETURN|WITH|ORDER\s+BY|SKIP|LIMIT|SET|DELETE|DETACH|CREATE|MERGE|UNWIND|CALL)\b",
+    re.IGNORECASE,
+)
+
 _NL_TO_CYPHER_PROMPT = """\
 You are a FalkorDB Cypher expert. Given the schema below and a user question,
 write a single Cypher query that answers the question.
 
 Return ONLY the Cypher query — no markdown fences, no explanation.
 
+FalkorDB dialect notes:
+- A node pattern takes exactly one label. To match several, leave the pattern
+  unlabelled and test in WHERE: MATCH (n) WHERE (n:Class OR n:Function)
+  `MATCH (n:Class|Function)` is a syntax error.
+- Alternative *relationship* types are fine: -[:CALLS|CONTAINS]->
+
 {schema}
 
 User question: {question}
+"""
+
+_RETRY_CYPHER_PROMPT = """\
+The Cypher query you wrote was rejected by FalkorDB.
+
+Query:
+{cypher}
+
+Error:
+{error}
+
+{schema}
+
+User question: {question}
+
+Rewrite the query so it runs. Return ONLY the corrected Cypher — no markdown
+fences, no explanation.
 """
 
 _FORMAT_RESULT_PROMPT = """\
@@ -117,6 +156,49 @@ class NLPEngine:
 
     # ── Natural language query ─────────────────────────────────────────────
 
+    @staticmethod
+    def _rewrite_alternative_labels(cypher: str) -> str:
+        """
+        Rewrite ``(n:A|B)`` into ``(n)`` plus a ``WHERE (n:A OR n:B)`` predicate.
+
+        FalkorDB accepts exactly one label in a node pattern, so the pipe form —
+        which the model reaches for naturally, and which is valid in some other
+        Cypher dialects — is a syntax error (#165). Relationship alternatives
+        (``-[:CALLS|CONTAINS]->``) *are* supported and are deliberately left
+        alone; only parenthesised node patterns are rewritten.
+        """
+        predicates: list[str] = []
+        counter = {"n": 0}
+
+        def replace(match: re.Match) -> str:
+            var, labels = match.group(1), match.group(2)
+            if not var:
+                counter["n"] += 1
+                var = f"_alt{counter['n']}"
+            parts = [p.strip() for p in labels.split("|") if p.strip()]
+            predicates.append("(" + " OR ".join(f"{var}:{p}" for p in parts) + ")")
+            return f"({var}"
+
+        rewritten = _NODE_ALT_LABELS.sub(replace, cypher)
+        if not predicates:
+            return cypher
+
+        joined = " AND ".join(predicates)
+        where = re.search(r"\bWHERE\b", rewritten, re.IGNORECASE)
+        if where:
+            return f"{rewritten[: where.end()]} {joined} AND{rewritten[where.end() :]}"
+
+        tail = _TRAILING_CLAUSE.search(rewritten)
+        if tail:
+            return f"{rewritten[: tail.start()]}WHERE {joined} {rewritten[tail.start() :]}"
+        return f"{rewritten} WHERE {joined}"
+
+    def _generate_cypher(self, question: str) -> str:
+        raw = self._provider.complete(
+            _NL_TO_CYPHER_PROMPT.format(schema=_SCHEMA_SUMMARY, question=question)
+        ).strip()
+        return self._rewrite_alternative_labels(_strip_fences(raw))
+
     def natural_query(self, question: str) -> str:
         """
         Convert a natural-language *question* into Cypher, execute it, and
@@ -130,20 +212,39 @@ class NLPEngine:
             A human-readable answer string.
         """
         # Step 1: translate question → Cypher
-        cypher_prompt = _NL_TO_CYPHER_PROMPT.format(schema=_SCHEMA_SUMMARY, question=question)
-        cypher = self._provider.complete(cypher_prompt).strip()
+        cypher = self._generate_cypher(question)
 
-        # Strip any accidental markdown fences the model may still produce
-        cypher = _strip_fences(cypher)
-
-        # Step 2: execute
+        # Step 2: execute, and give the model one chance to repair a query the
+        # database rejected. Reporting a syntax error back to the user as the
+        # answer leaves them with a failed query and no way forward (#165).
         try:
             result = self._store.query(cypher, {})
             rows = result.result_set or []
-        except Exception as exc:  # noqa: BLE001
-            return (
-                f"Failed to execute the generated Cypher query.\n\nQuery: {cypher}\n\nError: {exc}"
-            )
+        except Exception as first_error:  # noqa: BLE001
+            logger.info("Generated Cypher rejected, retrying once: %s", first_error)
+            try:
+                repaired = _strip_fences(
+                    self._provider.complete(
+                        _RETRY_CYPHER_PROMPT.format(
+                            cypher=cypher,
+                            error=first_error,
+                            schema=_SCHEMA_SUMMARY,
+                            question=question,
+                        )
+                    ).strip()
+                )
+                repaired = self._rewrite_alternative_labels(repaired)
+                result = self._store.query(repaired, {})
+                rows = result.result_set or []
+                cypher = repaired
+            except Exception as retry_error:  # noqa: BLE001
+                return (
+                    "Could not answer that — the generated Cypher was rejected twice.\n\n"
+                    f"First attempt: {cypher}\n  {first_error}\n\n"
+                    f"Retry also failed:\n  {retry_error}\n\n"
+                    "Rephrasing the question, or naming the node labels you mean, "
+                    "usually helps."
+                )
 
         # Step 3: format result
         rows_text = json.dumps(rows[:50], indent=2, default=str)

--- a/navegador/llm.py
+++ b/navegador/llm.py
@@ -10,7 +10,7 @@ Usage::
     from navegador.llm import get_provider, auto_provider, discover_providers
 
     # Explicit provider
-    provider = get_provider("anthropic", model="claude-3-5-haiku-20241022")
+    provider = get_provider("anthropic", model="claude-opus-5")
     response = provider.complete("Explain this function: ...")
 
     # Auto-detect the first available SDK
@@ -22,6 +22,7 @@ Usage::
 
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
 
 # ── Abstract base ─────────────────────────────────────────────────────────────
@@ -63,7 +64,7 @@ class LLMProvider(ABC):
     @property
     @abstractmethod
     def model(self) -> str:
-        """Model identifier used for API calls, e.g. ``"claude-3-5-haiku-20241022"``."""
+        """Model identifier used for API calls, e.g. ``"claude-opus-5"``."""
 
 
 # ── Concrete providers ────────────────────────────────────────────────────────
@@ -78,10 +79,14 @@ class AnthropicProvider(LLMProvider):
         pip install anthropic
 
     Args:
-        model: Anthropic model ID (default ``"claude-3-5-haiku-20241022"``).
+        model: Anthropic model ID (default ``"claude-opus-5"``).
     """
 
-    _DEFAULT_MODEL = "claude-3-5-haiku-20241022"
+    #: Current model alias. Model IDs are complete as written — never append a
+    #: date suffix. The previous default, `claude-3-5-haiku-20241022`, was
+    #: retired on 2026-02-19 and returns 404, so every `ask` that reached the
+    #: Anthropic default failed on a model the user never chose (#164).
+    _DEFAULT_MODEL = "claude-opus-5"
 
     def __init__(self, model: str = "") -> None:
         try:
@@ -300,33 +305,79 @@ def get_provider(name: str, model: str = "") -> LLMProvider:
     return cls(model=model)
 
 
+#: Environment variables that carry a usable credential for each provider.
+#: Ollama is local and needs none — reachability is the check instead.
+_PROVIDER_CREDENTIALS = {
+    "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
+    "openai": ("OPENAI_API_KEY",),
+    "ollama": (),
+}
+
+
+def provider_available(name: str) -> tuple[bool, str]:
+    """
+    Whether *name* can actually serve a request, and why not when it cannot.
+
+    SDK importability is not availability: the Anthropic package installed
+    without a key selected a provider that then failed at call time with a raw
+    auth error (#164). Credentials are checked here, and a local provider is
+    checked for reachability.
+    """
+    sdk = _PROVIDER_SDK_MAP.get(name, name)
+    try:
+        __import__(sdk)
+    except ImportError:
+        return False, f"the {sdk!r} package is not installed (pip install {sdk})"
+
+    if name == "ollama":
+        import urllib.error
+        import urllib.request
+
+        base = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+        try:
+            urllib.request.urlopen(f"{base}/api/tags", timeout=1.5).close()  # noqa: S310
+        except (urllib.error.URLError, TimeoutError, OSError):
+            return False, f"no Ollama server is reachable at {base}"
+        return True, ""
+
+    env_names = _PROVIDER_CREDENTIALS.get(name, ())
+    if env_names and not any(os.environ.get(var, "").strip() for var in env_names):
+        return False, f"no credential in {' or '.join(env_names)}"
+    return True, ""
+
+
 def auto_provider(model: str = "") -> LLMProvider:
     """
-    Return the first available LLM provider based on installed SDKs.
+    Return the first provider that is actually usable.
 
-    Priority order: anthropic → openai → ollama.
+    Priority order: anthropic → openai → ollama. A provider whose SDK is
+    installed but whose credential is missing is skipped rather than selected,
+    so the failure names the missing credential instead of surfacing a raw
+    auth error from whichever SDK happened to be present.
 
     Args:
         model: Optional model ID forwarded to the provider constructor.
 
     Returns:
-        An :class:`LLMProvider` instance for the first available SDK.
+        An :class:`LLMProvider` instance for the first usable provider.
 
     Raises:
-        RuntimeError: If no supported LLM SDK is installed.
+        RuntimeError: If no provider is usable, listing why each was skipped.
     """
+    reasons: list[str] = []
     for provider_name in _PROVIDER_NAMES:
-        sdk_name = _PROVIDER_SDK_MAP[provider_name]
-        try:
-            __import__(sdk_name)
-        except ImportError:
-            continue
-        return get_provider(provider_name, model=model)
+        ok, why = provider_available(provider_name)
+        if ok:
+            return get_provider(provider_name, model=model)
+        reasons.append(f"  {provider_name}: {why}")
 
     raise RuntimeError(
-        "No LLM SDK is installed. Install at least one of: "
-        "anthropic, openai, ollama.\n"
-        "  pip install anthropic   # Anthropic Claude\n"
-        "  pip install openai      # OpenAI GPT\n"
-        "  pip install ollama      # Ollama (local models)"
+        "No usable LLM provider.\n"
+        + "\n".join(reasons)
+        + "\n\nCredentials are read from the environment. Set one of:\n"
+        "  export ANTHROPIC_API_KEY=...     # Anthropic\n"
+        "  export OPENAI_API_KEY=...        # OpenAI\n"
+        "  ollama serve                     # Ollama (local, no key)\n"
+        "Or pin one in .navegador/config.toml:\n"
+        '  [llm]\n  provider = "anthropic"\n  model = "claude-opus-5"'
     )

--- a/navegador/mcp/server.py
+++ b/navegador/mcp/server.py
@@ -93,6 +93,53 @@ def create_mcp_server(store_factory, read_only: bool = False):
                 },
             ),
             Tool(
+                name="resolve_address",
+                description=(
+                    "Resolve a supergraph contract address into the code graph and "
+                    "return the node plus its immediate neighbourhood. This is the "
+                    "brain-to-code hop: given the target of an `implemented_in` join "
+                    "edge, it returns the entry point from which traversal continues "
+                    "(callers, callees, containing file). Addresses look like "
+                    "`[<repo>/]code:<path>[#<symbol>]`."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string",
+                            "description": (
+                                "Contract address, e.g. `myrepo/code:src/auth.py#validate_token`."
+                            ),
+                        },
+                    },
+                    "required": ["address"],
+                },
+            ),
+            Tool(
+                name="propose_join_edges",
+                description=(
+                    "Propose supergraph join edges from inferred documentation-to-code "
+                    "affinity, in contract format with confidence and evidence. "
+                    "Navegador proposes; the brain reviews and decides what to commit. "
+                    "Targets are code-realm addresses."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "repo": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Federation namespace to qualify targets with.",
+                        },
+                        "min_confidence": {
+                            "type": "number",
+                            "default": 0.5,
+                            "description": "Drop proposals scoring below this.",
+                        },
+                    },
+                },
+            ),
+            Tool(
                 name="load_file_context",
                 description="Return all symbols (functions, classes, imports) in a file.",
                 inputSchema={
@@ -664,6 +711,42 @@ def create_mcp_server(store_factory, read_only: bool = False):
             return [t for t in tools if t.name not in WRITE_TOOLS]
         return tools
 
+    def _neighbourhood(store, resolved) -> dict:
+        """
+        One hop out from a resolved node, so a brain-side traversal that just
+        crossed a join edge can keep going without a second round trip.
+        """
+        try:
+            callers = (
+                store.query(
+                    "MATCH (a)-[:CALLS]->(b {name: $name, file_path: $path}) "
+                    "RETURN labels(a)[0], a.name, coalesce(a.file_path, '') LIMIT 25",
+                    {"name": resolved.name, "path": resolved.path},
+                ).result_set
+                or []
+            )
+            callees = (
+                store.query(
+                    "MATCH (a {name: $name, file_path: $path})-[:CALLS]->(b) "
+                    "RETURN labels(b)[0], b.name, coalesce(b.file_path, '') LIMIT 25",
+                    {"name": resolved.name, "path": resolved.path},
+                ).result_set
+                or []
+            )
+        except Exception:  # noqa: BLE001 — a partial answer beats no answer
+            callers, callees = [], []
+
+        from navegador.contract import address_for_node
+
+        def entries(rows):
+            out = []
+            for row in rows:
+                address = address_for_node(row[0] or "", row[1] or "", row[2] or "")
+                out.append({"name": row[1], "label": row[0], "address": address})
+            return out
+
+        return {"callers": entries(callers), "callees": entries(callees)}
+
     def _ingest_status(store, repo: str = "") -> dict:
         """
         Tell "empty" apart from "never ingested" (#171).
@@ -730,7 +813,36 @@ def create_mcp_server(store_factory, read_only: bool = False):
 
         loader = _get_loader()
 
-        if name == "ingest_repo":
+        if name == "resolve_address":
+            from navegador.contract import AddressError, resolve
+
+            try:
+                resolved = resolve(loader.store, arguments["address"])
+            except AddressError as exc:
+                return [TextContent(type="text", text=f"Error: {exc}")]
+
+            payload = resolved.to_dict()
+            if resolved.found:
+                payload["neighbourhood"] = _neighbourhood(loader.store, resolved)
+            else:
+                payload["hint"] = (
+                    "No node at that address. The repo may not be ingested, or the "
+                    "path may be recorded relative to a different root — check "
+                    "list_repos and graph_stats."
+                )
+            return [TextContent(type="text", text=json.dumps(payload, indent=2, default=str))]
+
+        elif name == "propose_join_edges":
+            from navegador.contract import propose_join_edges
+
+            payload = propose_join_edges(
+                loader.store,
+                repo=arguments.get("repo", ""),
+                min_confidence=arguments.get("min_confidence", 0.5),
+            )
+            return [TextContent(type="text", text=json.dumps(payload, indent=2, default=str))]
+
+        elif name == "ingest_repo":
             if read_only:
                 return [
                     TextContent(
@@ -772,8 +884,18 @@ def create_mcp_server(store_factory, read_only: bool = False):
                 limit=arguments.get("limit", 20),
                 repo=arguments.get("repo", ""),
             )
-            lines = [f"- **{r.type}** `{r.name}` — `{r.file_path}`:{r.line_start}" for r in results]
-            return [TextContent(type="text", text="\n".join(lines) or "No results.")]
+            # Each hit carries its contract address so a brain can record an
+            # `implemented_in` join edge pointing straight back at it (#158).
+            from navegador.contract import address_for_node
+
+            repo = arguments.get("repo", "")
+            lines = []
+            for r in results:
+                address = address_for_node(r.type, r.name, r.file_path, repo=repo)
+                suffix = f"  `{address}`" if address else ""
+                lines.append(f"- **{r.type}** `{r.name}` — `{r.file_path}`:{r.line_start}{suffix}")
+            body = "\n".join(lines) or "No results."
+            return [TextContent(type="text", text=body)]
 
         elif name == "query_graph":
             cypher = arguments["cypher"]

--- a/navegador/vcs.py
+++ b/navegador/vcs.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import urllib.parse
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -98,6 +99,22 @@ class GitAdapter(VCSAdapter):
         """Return True when *repo_path* contains a ``.git`` directory or file."""
         return (self.repo_path / ".git").exists()
 
+    def remote_identity(self, remote: str = "origin") -> str:
+        """
+        ``owner/repo`` derived from a remote URL, or "" when there is none.
+
+        This is the only repository identifier that survives the checkout being
+        renamed, cloned to another directory, or added as a worktree — all of
+        which produce a different directory basename for the same repository
+        (#167).
+        """
+        if not self.is_repo():
+            return ""
+        result = self._run(["remote", "get-url", remote], check=False)
+        if result.returncode != 0:
+            return ""
+        return normalize_remote_url(result.stdout.strip())
+
     def current_branch(self) -> str:
         """Return the name of the current branch (e.g. ``"main"``)."""
         result = self._run(["rev-parse", "--abbrev-ref", "HEAD"])
@@ -172,6 +189,50 @@ class GitAdapter(VCSAdapter):
         """
         result = self._run(["blame", "--porcelain", "--", file_path])
         return _parse_porcelain_blame(result.stdout)
+
+
+def normalize_remote_url(url: str) -> str:
+    """
+    Reduce a git remote URL to a stable repository identity.
+
+    Hosted remotes yield ``owner/repo``; the host itself is dropped so an ssh
+    clone and an https clone of the same repository agree. A remote that is a
+    filesystem path — how worktrees and local clones are usually set up — yields
+    just the repository name, since there is no owner to speak of.
+
+    Returns "" for anything that does not reduce cleanly, which callers treat as
+    "no remote identity" and fall back from.
+    """
+    url = (url or "").strip()
+    if not url:
+        return ""
+
+    hosted = False
+    if "://" in url:
+        parsed = urllib.parse.urlparse(url)
+        # A scheme with no host is a local URL (file:///path)
+        hosted = bool(parsed.netloc) and parsed.scheme != "file"
+        url = parsed.path
+    elif ":" in url and not Path(url).exists():
+        # scp-style git@host:owner/repo.git — never a local path
+        head, _, tail = url.rpartition(":")
+        if head and "/" not in head:
+            hosted = True
+            url = tail
+
+    url = url.strip("/")
+    if url.endswith(".git"):
+        url = url[: -len(".git")]
+
+    parts = [p for p in url.replace("\\", "/").split("/") if p and p not in (".", "..")]
+    if not parts:
+        return ""
+
+    if hosted:
+        # Keep owner/repo: enough to distinguish forks and orgs, without the
+        # host, which differs between ssh and https clones of one repository.
+        return "/".join(parts[-2:])
+    return parts[-1]
 
 
 def _parse_porcelain_blame(output: str) -> list[dict]:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -382,19 +382,41 @@ class TestTestMapper:
         assert link.prod_file == "core.py"
 
     def test_link_via_heuristic(self):
-        """When no CALLS edge exists, fall back to name heuristic."""
-        from navegador.analysis.testmap import TestMapper
+        """
+        When no CALLS edge exists, fall back to a scored name match.
 
-        store = _multi_mock_store(
-            [["test_render_output", "tests/test_renderer.py", 1]],  # test fns
-            [],                                                        # no CALLS
-            [["Function", "render_output", "renderer.py"]],           # heuristic
-            [["Function", "render_output", "renderer.py"]],           # verify calls
-            [],                                                        # CREATE edge
-        )
-        result = TestMapper(store).map_tests()
+        Uses a real store: resolution now consults the repository and module a
+        symbol lives in, which a fixed sequence of mocked result sets cannot
+        represent. See tests/test_testmap_precision.py for the scoring rules.
+        """
+        import tempfile
+
+        from navegador.analysis.testmap import TestMapper
+        from navegador.graph.store import GraphStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = GraphStore.sqlite(f"{tmpdir}/graph.db")
+            try:
+                store.query(
+                    "MERGE (f:File {path: 'renderer.py'}) "
+                    "MERGE (r:Repository {path: 'org/app'}) "
+                    "MERGE (f)-[:BELONGS_TO]->(r) "
+                    "MERGE (:Function {name: 'render_output', file_path: 'renderer.py'})"
+                )
+                store.query(
+                    "MERGE (f:File {path: 'tests/test_renderer.py'}) "
+                    "MERGE (r:Repository {path: 'org/app'}) "
+                    "MERGE (f)-[:BELONGS_TO]->(r) "
+                    "MERGE (:Function {name: 'test_render_output', "
+                    "file_path: 'tests/test_renderer.py'})"
+                )
+                result = TestMapper(store).map_tests()
+            finally:
+                store.close()
+
         assert len(result.links) == 1
         assert result.links[0].prod_name == "render_output"
+        assert result.links[0].source == "heuristic"
 
     def test_unmatched_test_recorded(self):
         """A test with no call and no matching heuristic goes to unmatched."""

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,371 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Conformance tests for #158 — supergraph interop contract v1.0.
+
+The contract makes every graph in the system addressable from every other one.
+Navegador owns the **code realm**, which is deliberately never compiled into a
+brain: a brain-side `implemented_in` edge carries a code address, and traversal
+continues here. That hop is the thing under test.
+
+Real embedded stores throughout — an address is only useful if it resolves
+against a graph a real ingest produced, and mocking the store would test the
+grammar while leaving the resolution untested.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from navegador.contract import (
+    CONTRACT_VERSION,
+    JOIN_EDGE,
+    REALM,
+    AddressError,
+    address_for_node,
+    format_address,
+    parse_address,
+    propose_join_edges,
+    resolve,
+)
+from navegador.graph.store import GraphStore
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("contract") / "graph.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def code_graph(store):
+    """A small code graph: a file, its symbols, and one call edge."""
+    store.query("CREATE (:File {path: 'src/auth.py', name: 'auth.py'})")
+    store.query("CREATE (:Function {name: 'validate_token', file_path: 'src/auth.py'})")
+    store.query("CREATE (:Class {name: 'Auth', file_path: 'src/auth.py'})")
+    store.query("CREATE (:Method {name: 'validate', file_path: 'src/auth.py'})")
+    store.query("CREATE (:Function {name: 'login', file_path: 'src/views.py'})")
+    store.query("MATCH (a {name: 'login'}), (b {name: 'validate_token'}) MERGE (a)-[:CALLS]->(b)")
+    return store
+
+
+# ── Address grammar ────────────────────────────────────────────────────────
+
+
+class TestAddressGrammar:
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "calliope-astrolift/code:src/auth.py",
+            "calliope-astrolift/code:src/auth.py#validate_token",
+            "code:src/auth.py#Auth.validate",
+            "code:src/auth.py",
+        ],
+    )
+    def test_round_trip(self, address):
+        assert str(parse_address(address)) == address
+
+    def test_repo_is_optional(self):
+        """Instance-local addresses omit the namespace, per the grammar."""
+        assert format_address("src/auth.py") == "code:src/auth.py"
+
+    def test_repo_qualifies_the_address(self):
+        assert format_address("src/auth.py", repo="myrepo") == "myrepo/code:src/auth.py"
+
+    def test_symbol_is_fragment_separated(self):
+        assert format_address("src/auth.py", "validate_token") == "code:src/auth.py#validate_token"
+
+    def test_windows_separators_are_normalised(self):
+        """Paths are POSIX in the contract regardless of the ingesting host."""
+        assert format_address("src\\auth.py") == "code:src/auth.py"
+
+    def test_parsed_fields(self):
+        parsed = parse_address("myrepo/code:src/auth.py#Auth.validate")
+        assert (parsed.repo, parsed.path, parsed.symbol) == (
+            "myrepo",
+            "src/auth.py",
+            "Auth.validate",
+        )
+
+    @pytest.mark.parametrize(
+        "address", ["", "   ", "doc:README.md", "not-an-address", "/code:", "code:"]
+    )
+    def test_malformed_addresses_are_rejected(self, address):
+        with pytest.raises(AddressError):
+            parse_address(address)
+
+    def test_a_foreign_realm_is_rejected_clearly(self):
+        """A brain kind is not ours to resolve; say so rather than miss silently."""
+        with pytest.raises(AddressError, match="not a code-realm address"):
+            parse_address("myrepo/story:AUTH-1")
+
+    def test_empty_path_is_rejected(self):
+        with pytest.raises(AddressError):
+            format_address("")
+
+
+class TestAddressForNode:
+    def test_file_node(self):
+        assert address_for_node("File", "auth.py", "src/auth.py") == "code:src/auth.py"
+
+    def test_symbol_node(self):
+        address = address_for_node("Function", "validate_token", "src/auth.py")
+        assert address == "code:src/auth.py#validate_token"
+
+    def test_repo_qualification(self):
+        address = address_for_node("Function", "f", "src/a.py", repo="myrepo")
+        assert address.startswith("myrepo/code:")
+
+    @pytest.mark.parametrize("label", ["Concept", "Decision", "Rule", "Repository", ""])
+    def test_brain_realm_nodes_get_no_code_address(self, label):
+        """The brain is authoritative for its own kinds — we must not claim them."""
+        assert address_for_node(label, "Thing", "src/a.py") is None
+
+    def test_a_node_without_a_path_is_not_addressable(self):
+        assert address_for_node("Function", "orphan", "") is None
+
+
+# ── The supergraph hop ─────────────────────────────────────────────────────
+
+
+class TestResolveJoinEdgeTargets:
+    def test_file_address_resolves(self, code_graph):
+        resolved = resolve(code_graph, "code:src/auth.py")
+        assert resolved.found
+        assert resolved.label == "File"
+
+    def test_function_address_resolves(self, code_graph):
+        resolved = resolve(code_graph, "code:src/auth.py#validate_token")
+        assert (resolved.found, resolved.label, resolved.name) == (
+            True,
+            "Function",
+            "validate_token",
+        )
+
+    def test_qualified_method_resolves_to_the_method(self, code_graph):
+        """`Auth.validate` — the qualifier is the class, the target is the method."""
+        resolved = resolve(code_graph, "code:src/auth.py#Auth.validate")
+        assert resolved.found
+        assert resolved.name == "validate"
+
+    def test_traversal_continues_from_the_resolved_node(self, code_graph):
+        """
+        The acceptance criterion: having crossed the join edge with nothing but
+        the address, ordinary code-graph traversal carries on from here.
+        """
+        resolved = resolve(code_graph, "code:src/auth.py#validate_token")
+        callers = code_graph.query(
+            "MATCH (a)-[:CALLS]->(b {name: $n, file_path: $p}) RETURN a.name",
+            {"n": resolved.name, "p": resolved.path},
+        ).result_set
+        assert [r[0] for r in callers] == ["login"]
+
+    def test_repo_prefixed_paths_also_resolve(self, store):
+        """Workspace ingests record repo-prefixed paths; both spellings must work."""
+        store.query("CREATE (:Function {name: 'handler', file_path: 'svc/src/app.py'})")
+        store.query("CREATE (:File {path: 'svc/src/app.py', name: 'app.py'})")
+        assert resolve(store, "svc/code:src/app.py#handler").found
+        assert resolve(store, "svc/code:src/app.py").found
+
+    def test_a_miss_is_reported_not_raised(self, code_graph):
+        resolved = resolve(code_graph, "code:src/nope.py#absent")
+        assert resolved.found is False
+        assert resolved.address == "code:src/nope.py#absent"
+
+    def test_a_miss_carries_no_invented_node(self, code_graph):
+        resolved = resolve(code_graph, "code:src/nope.py#absent")
+        assert (resolved.label, resolved.name) == ("", "")
+
+    def test_a_foreign_realm_address_raises(self, code_graph):
+        with pytest.raises(AddressError):
+            resolve(code_graph, "myrepo/story:AUTH-1")
+
+
+class TestVersionDeclaration:
+    def test_resolution_states_the_contract_version(self, code_graph):
+        assert resolve(code_graph, "code:src/auth.py").to_dict()["contract"] == "1.0"
+
+    def test_resolution_states_the_realm(self, code_graph):
+        assert resolve(code_graph, "code:src/auth.py").to_dict()["realm"] == REALM
+
+    def test_parsed_address_states_the_contract_version(self):
+        assert parse_address("code:a.py").to_dict()["contract"] == CONTRACT_VERSION
+
+    def test_proposals_state_the_contract_version(self, code_graph):
+        assert propose_join_edges(code_graph)["contract"] == "1.0"
+
+
+# ── Proposing the reverse edges ────────────────────────────────────────────
+
+
+class TestProposeJoinEdges:
+    @pytest.fixture()
+    def documented(self, code_graph):
+        code_graph.query(
+            "CREATE (:Document {name: 'auth-design.md', path: 'docs/auth-design.md', "
+            "content: '# Auth\\n\\nEvery request is checked by `validate_token` first.'})"
+        )
+        return code_graph
+
+    def test_a_proposal_is_produced(self, documented):
+        payload = propose_join_edges(documented)
+        assert payload["count"] >= 1
+
+    def test_the_proposal_targets_a_code_address(self, documented):
+        targets = [p["target"] for p in propose_join_edges(documented)["proposals"]]
+        assert "code:src/auth.py#validate_token" in targets
+
+    def test_the_proposal_uses_the_join_edge(self, documented):
+        assert all(p["edge"] == JOIN_EDGE for p in propose_join_edges(documented)["proposals"])
+
+    def test_targets_are_repo_qualified_on_request(self, documented):
+        payload = propose_join_edges(documented, repo="myrepo")
+        assert all(p["target"].startswith("myrepo/code:") for p in payload["proposals"])
+
+    def test_proposals_carry_confidence_and_evidence(self, documented):
+        proposal = propose_join_edges(documented)["proposals"][0]
+        assert 0 < proposal["confidence"] <= 1.0
+        assert proposal["evidence"]["strategy"]
+        assert proposal["evidence"]["producer"] == "navegador"
+
+    def test_the_source_is_named_in_brain_kinds(self, documented):
+        """The brain validates kinds against its own schema; speak its vocabulary."""
+        proposal = propose_join_edges(documented)["proposals"][0]
+        assert proposal["source"]["kind"] == "doc"
+
+    def test_nothing_is_written_to_the_graph(self, documented):
+        """Navegador proposes; the brain commits. Proposing must not mutate."""
+        propose_join_edges(documented)
+        rows = documented.query("MATCH ()-[r:implemented_in]->() RETURN count(r)").result_set
+        assert rows[0][0] == 0
+
+    def test_brain_only_targets_are_not_proposed(self, code_graph):
+        """
+        A doc→Concept affinity lives entirely inside the brain realm. Proposing
+        it would mean minting a code address for a node we do not own.
+        """
+        code_graph.query("CREATE (:Concept {name: 'idempotency'})")
+        code_graph.query(
+            "CREATE (:Document {name: 'notes.md', path: 'docs/notes.md', "
+            "content: '# Notes\\n\\nEverything here relies on `idempotency`.'})"
+        )
+        payload = propose_join_edges(code_graph)
+        assert all("code:" in p["target"] for p in payload["proposals"])
+
+    def test_confidence_floor_is_honoured(self, documented):
+        assert propose_join_edges(documented, min_confidence=0.99)["count"] == 0
+
+    def test_an_empty_graph_proposes_nothing(self, store):
+        payload = propose_join_edges(store)
+        assert payload["proposals"] == []
+        assert payload["contract"] == CONTRACT_VERSION
+
+
+# ── The MCP surface ────────────────────────────────────────────────────────
+
+
+def mcp_handlers(store):
+    """
+    Capture the tool handlers a real store produces.
+
+    Only `mcp.server`/`mcp.types` are stubbed, to reach the decorated functions;
+    `Tool` and `TextContent` become dicts so their fields can be read. The store
+    and the loader behind them are real.
+    """
+    holders: dict[str, object] = {}
+
+    def capture(key):
+        """Stand in for `@server.list_tools()` — keep the function it decorates."""
+
+        def decorator_factory():
+            def decorator(fn):
+                holders[key] = fn
+                return fn
+
+            return decorator
+
+        return decorator_factory
+
+    mock_server = MagicMock()
+    mock_server.list_tools = capture("list")
+    mock_server.call_tool = capture("call")
+
+    mock_mcp_server = MagicMock()
+    mock_mcp_server.Server.return_value = mock_server
+    mock_mcp_types = MagicMock()
+    mock_mcp_types.Tool = dict
+    mock_mcp_types.TextContent = dict
+
+    with patch.dict(
+        "sys.modules",
+        {"mcp": MagicMock(), "mcp.server": mock_mcp_server, "mcp.types": mock_mcp_types},
+    ):
+        from importlib import reload
+
+        import navegador.mcp.server as srv
+
+        reload(srv)
+        srv.create_mcp_server(lambda: store)
+
+    return holders["list"], holders["call"]
+
+
+@pytest.fixture()
+def mcp(code_graph):
+    return mcp_handlers(code_graph)
+
+
+class TestMcpSurface:
+    @pytest.mark.asyncio
+    async def test_both_tools_are_advertised(self, mcp):
+        list_tools, _ = mcp
+        names = {t["name"] for t in await list_tools()}
+        assert {"resolve_address", "propose_join_edges"} <= names
+
+    @pytest.mark.asyncio
+    async def test_resolve_address_returns_the_node(self, mcp):
+        _, call = mcp
+        result = await call("resolve_address", {"address": "code:src/auth.py#validate_token"})
+        payload = json.loads(result[0]["text"])
+        assert (payload["found"], payload["name"], payload["contract"]) == (
+            True,
+            "validate_token",
+            "1.0",
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_neighbourhood_carries_addresses(self, mcp):
+        """A brain that just crossed a join edge keeps traversing from here."""
+        _, call = mcp
+        result = await call("resolve_address", {"address": "code:src/auth.py#validate_token"})
+        callers = json.loads(result[0]["text"])["neighbourhood"]["callers"]
+        assert [c["address"] for c in callers] == ["code:src/views.py#login"]
+
+    @pytest.mark.asyncio
+    async def test_a_miss_explains_itself(self, mcp):
+        _, call = mcp
+        result = await call("resolve_address", {"address": "code:src/nope.py"})
+        payload = json.loads(result[0]["text"])
+        assert payload["found"] is False
+        assert "hint" in payload
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_realm_is_an_error_not_a_miss(self, mcp):
+        _, call = mcp
+        result = await call("resolve_address", {"address": "myrepo/story:AUTH-1"})
+        assert "not a code-realm address" in result[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_propose_join_edges_is_contract_shaped(self, mcp):
+        _, call = mcp
+        payload = json.loads((await call("propose_join_edges", {}))[0]["text"])
+        assert payload["contract"] == "1.0"
+        assert payload["join_edge"] == JOIN_EDGE
+
+    @pytest.mark.asyncio
+    async def test_search_results_carry_addresses(self, mcp):
+        """The address is how a brain records an edge pointing back at a hit."""
+        _, call = mcp
+        result = await call("search_symbols", {"query": "validate_token"})
+        assert "code:src/auth.py#validate_token" in result[0]["text"]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,252 +1,349 @@
-"""Tests for navegador.graph.export — text-based graph export and import."""
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Tests for navegador.graph.export — text-based graph export and import.
+
+Real embedded stores throughout. The previous version of this file mocked the
+store, so `create_edge` returned a truthy MagicMock and every assertion about
+edge counts passed — while an actual round trip produced a graph with all of
+its nodes and none of its edges (#173). What matters here is what ends up in
+the destination graph, not which calls were made.
+"""
 
 import json
-import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
-from navegador.graph.export import (
-    _export_edges,
-    _export_nodes,
-    _import_edge,
-    _import_node,
-    export_graph,
-    import_graph,
-)
+from navegador.graph.export import ExportError, export_graph, import_graph
+from navegador.graph.store import GraphStore
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
 
 
-def _mock_store(nodes=None, edges=None):
-    store = MagicMock()
-
-    def query_side_effect(cypher, params=None):
-        result = MagicMock()
-        if "labels(n)" in cypher and "properties" in cypher:
-            result.result_set = nodes or []
-        elif "type(r)" in cypher:
-            result.result_set = edges or []
-        elif "DETACH DELETE" in cypher:
-            result.result_set = []
-        else:
-            result.result_set = []
-        return result
-
-    store.query.side_effect = query_side_effect
-    store.clear = MagicMock()
-    return store
+@pytest.fixture(scope="module")
+def source(tmp_path_factory):
+    store = GraphStore.sqlite(str(tmp_path_factory.mktemp("exp-src") / "graph.db"))
+    yield store
+    store.close()
 
 
-# ── export_graph ─────────────────────────────────────────────────────────────
-
-class TestExportGraph:
-    def test_creates_output_file(self):
-        store = _mock_store(nodes=[], edges=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output = Path(tmpdir) / "graph.jsonl"
-            export_graph(store, output)
-            assert output.exists()
-
-    def test_returns_counts(self):
-        nodes = [["Function", {"name": "foo", "file_path": "app.py"}]]
-        store = _mock_store(nodes=nodes, edges=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            stats = export_graph(store, Path(tmpdir) / "graph.jsonl")
-            assert stats["nodes"] == 1
-            assert stats["edges"] == 0
-
-    def test_writes_valid_jsonl(self):
-        nodes = [
-            ["Function", {"name": "foo", "file_path": "app.py"}],
-            ["Class", {"name": "Bar", "file_path": "bar.py"}],
-        ]
-        edges = [["CALLS", "Function", "foo", "app.py", "Function", "bar", "bar.py"]]
-        store = _mock_store(nodes=nodes, edges=edges)
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output = Path(tmpdir) / "graph.jsonl"
-            export_graph(store, output)
-            lines = output.read_text().strip().split("\n")
-            assert len(lines) == 3  # 2 nodes + 1 edge
-            for line in lines:
-                record = json.loads(line)
-                assert record["kind"] in ("node", "edge")
-
-    def test_output_is_sorted(self):
-        nodes = [
-            ["Function", {"name": "z_func", "file_path": "z.py"}],
-            ["Class", {"name": "a_class", "file_path": "a.py"}],
-        ]
-        store = _mock_store(nodes=nodes, edges=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output = Path(tmpdir) / "graph.jsonl"
-            export_graph(store, output)
-            lines = output.read_text().strip().split("\n")
-            labels = [json.loads(line)["label"] for line in lines]
-            # Class comes before Function alphabetically
-            assert labels[0] == "Class"
-            assert labels[1] == "Function"
-
-    def test_creates_parent_dirs(self):
-        store = _mock_store(nodes=[], edges=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output = Path(tmpdir) / "sub" / "dir" / "graph.jsonl"
-            export_graph(store, output)
-            assert output.exists()
+@pytest.fixture(scope="module")
+def dest(tmp_path_factory):
+    store = GraphStore.sqlite(str(tmp_path_factory.mktemp("exp-dst") / "graph.db"))
+    yield store
+    store.close()
 
 
-# ── import_graph ─────────────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _clean(source, dest):
+    source.clear()
+    dest.clear()
+    yield
 
-class TestImportGraph:
-    def test_raises_on_missing_file(self):
-        store = MagicMock()
+
+def seed(store):
+    """A graph spanning both key styles: path-keyed files and name-keyed symbols."""
+    store.query("CREATE (:File {path: 'app.py', name: 'app.py', lines: 42})")
+    store.query("CREATE (:Repository {path: '/repo', name: 'repo'})")
+    for name in ("alpha", "beta", "gamma"):
+        store.query("CREATE (:Function {name: $n, file_path: 'app.py'})", {"n": name})
+    store.query("MATCH (f:File), (fn:Function) CREATE (f)-[:CONTAINS]->(fn)")
+    store.query("MATCH (f:File), (r:Repository) CREATE (f)-[:BELONGS_TO]->(r)")
+    store.query(
+        "MATCH (a:Function {name: 'alpha'}), (b:Function {name: 'beta'}) "
+        "CREATE (a)-[:CALLS {count: 7}]->(b)"
+    )
+
+
+# ── Round trip ─────────────────────────────────────────────────────────────
+
+
+class TestRoundTrip:
+    def test_every_edge_survives(self, source, dest, tmp_path):
+        """The #173 regression: edges must arrive, not just be counted."""
+        seed(source)
+        assert source.edge_count() > 0
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path)
+        assert dest.edge_count() == source.edge_count()
+
+    def test_every_node_survives(self, source, dest, tmp_path):
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path)
+        assert dest.node_count() == source.node_count()
+
+    def test_reported_counts_match_reality(self, source, dest, tmp_path):
+        """Counts are of what was created, not of lines read."""
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        stats = import_graph(dest, path)
+        assert stats["nodes"] == dest.node_count()
+        assert stats["edges"] == dest.edge_count()
+
+    def test_labels_preserved(self, source, dest, tmp_path):
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path)
+
+        def histogram(store):
+            rows = store.query(
+                "MATCH (n) RETURN labels(n)[0] AS l, count(n) AS c ORDER BY l"
+            ).result_set
+            return {r[0]: r[1] for r in rows}
+
+        assert histogram(dest) == histogram(source)
+
+    def test_edge_types_preserved(self, source, dest, tmp_path):
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path)
+
+        def histogram(store):
+            rows = store.query(
+                "MATCH ()-[r]->() RETURN type(r) AS t, count(r) AS c ORDER BY t"
+            ).result_set
+            return {r[0]: r[1] for r in rows}
+
+        assert histogram(dest) == histogram(source)
+
+    def test_node_properties_preserved(self, source, dest, tmp_path):
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path)
+        rows = dest.query("MATCH (f:File {path: 'app.py'}) RETURN f.lines").result_set
+        assert rows[0][0] == 42
+
+    def test_edge_properties_preserved(self, source, dest, tmp_path):
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path)
+        rows = dest.query("MATCH ()-[r:CALLS]->() RETURN r.count").result_set
+        assert rows[0][0] == 7
+
+    def test_path_keyed_and_name_keyed_endpoints_both_resolve(self, source, dest, tmp_path):
+        """
+        File→Repository is path-keyed on both ends; File→Function is not.
+
+        The original importer keyed the source on file_path and the target on
+        path, so any edge whose endpoints did not share a key style was lost.
+        """
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path)
+        assert dest.query("MATCH ()-[r:BELONGS_TO]->() RETURN count(r)").result_set[0][0] == 1
+        assert dest.query("MATCH ()-[r:CONTAINS]->() RETURN count(r)").result_set[0][0] == 3
+
+    def test_empty_graph_round_trips(self, source, dest, tmp_path):
+        path = tmp_path / "graph.jsonl"
+        assert export_graph(source, path) == {"nodes": 0, "edges": 0}
+        assert import_graph(dest, path) == {"nodes": 0, "edges": 0}
+
+    def test_repeat_import_is_idempotent(self, source, dest, tmp_path):
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        first = import_graph(dest, path)
+        second = import_graph(dest, path)
+        assert first == second
+        assert dest.edge_count() == source.edge_count()
+
+
+# ── File handling ──────────────────────────────────────────────────────────
+
+
+class TestFileHandling:
+    def test_creates_output_file(self, source, tmp_path):
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        assert path.exists()
+
+    def test_creates_parent_directories(self, source, tmp_path):
+        path = tmp_path / "deep" / "nested" / "graph.jsonl"
+        export_graph(source, path)
+        assert path.exists()
+
+    def test_writes_one_json_object_per_line(self, source, tmp_path):
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        stats = export_graph(source, path)
+        lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) == stats["nodes"] + stats["edges"]
+        assert all(json.loads(ln)["kind"] in ("node", "edge") for ln in lines)
+
+    def test_output_is_deterministic(self, source, tmp_path):
+        """The format exists to be committed, so byte stability matters."""
+        seed(source)
+        first, second = tmp_path / "a.jsonl", tmp_path / "b.jsonl"
+        export_graph(source, first)
+        export_graph(source, second)
+        assert first.read_bytes() == second.read_bytes()
+
+    def test_missing_input_raises(self, dest):
         with pytest.raises(FileNotFoundError):
-            import_graph(store, "/nonexistent/graph.jsonl")
+            import_graph(dest, "/nonexistent/graph.jsonl")
 
-    def test_clears_graph_by_default(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            f = Path(tmpdir) / "graph.jsonl"
-            f.write_text("")
-            import_graph(store, f)
-            store.clear.assert_called_once()
+    def test_blank_lines_are_skipped(self, dest, tmp_path):
+        path = tmp_path / "graph.jsonl"
+        record = json.dumps(
+            {
+                "kind": "node",
+                "id": "Function::foo",
+                "type": "Function",
+                "name": "foo",
+                "props": {"name": "foo", "file_path": "app.py"},
+            }
+        )
+        path.write_text(f"\n{record}\n\n", encoding="utf-8")
+        assert import_graph(dest, path)["nodes"] == 1
 
-    def test_no_clear_flag(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            f = Path(tmpdir) / "graph.jsonl"
-            f.write_text("")
-            import_graph(store, f, clear=False)
-            store.clear.assert_not_called()
+    def test_clear_wipes_existing_content(self, source, dest, tmp_path):
+        dest.query("CREATE (:Stale {name: 'old'})")
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path)
+        assert dest.query("MATCH (n:Stale) RETURN count(n)").result_set[0][0] == 0
 
-    def test_imports_nodes(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            f = Path(tmpdir) / "graph.jsonl"
-            node = {"kind": "node", "label": "Function", "props": {"name": "foo", "file_path": "app.py"}}
-            f.write_text(json.dumps(node) + "\n")
-            stats = import_graph(store, f)
-            assert stats["nodes"] == 1
+    def test_no_clear_is_additive(self, source, dest, tmp_path):
+        dest.query("CREATE (:Stale {name: 'old'})")
+        seed(source)
+        path = tmp_path / "graph.jsonl"
+        export_graph(source, path)
+        import_graph(dest, path, clear=False)
+        assert dest.query("MATCH (n:Stale) RETURN count(n)").result_set[0][0] == 1
 
-    def test_imports_edges(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            f = Path(tmpdir) / "graph.jsonl"
-            edge = {
+
+# ── Legacy format ──────────────────────────────────────────────────────────
+
+
+class TestLegacyFormat:
+    """Exports written before edges referenced node ids must still import."""
+
+    @staticmethod
+    def write_legacy(path: Path) -> None:
+        records = [
+            {"kind": "node", "label": "File", "props": {"name": "app.py", "path": "app.py"}},
+            {
+                "kind": "node",
+                "label": "Function",
+                "props": {"name": "alpha", "file_path": "app.py"},
+            },
+            {
+                "kind": "node",
+                "label": "Function",
+                "props": {"name": "beta", "file_path": "app.py"},
+            },
+            {
                 "kind": "edge",
                 "type": "CALLS",
-                "from": {"label": "Function", "name": "foo", "path": "app.py"},
-                "to": {"label": "Function", "name": "bar", "path": "bar.py"},
-            }
-            f.write_text(json.dumps(edge) + "\n")
-            stats = import_graph(store, f)
-            assert stats["edges"] == 1
-
-    def test_returns_counts(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            f = Path(tmpdir) / "graph.jsonl"
-            lines = [
-                json.dumps({"kind": "node", "label": "Function", "props": {"name": "foo", "file_path": "app.py"}}),
-                json.dumps({"kind": "node", "label": "Class", "props": {"name": "Bar", "file_path": "bar.py"}}),
-                json.dumps({"kind": "edge", "type": "CALLS",
-                           "from": {"label": "Function", "name": "foo", "path": ""},
-                           "to": {"label": "Class", "name": "Bar", "path": ""}}),
-            ]
-            f.write_text("\n".join(lines) + "\n")
-            stats = import_graph(store, f)
-            assert stats["nodes"] == 2
-            assert stats["edges"] == 1
-
-    def test_skips_blank_lines(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        with tempfile.TemporaryDirectory() as tmpdir:
-            f = Path(tmpdir) / "graph.jsonl"
-            node = json.dumps({"kind": "node", "label": "Function", "props": {"name": "foo", "file_path": ""}})
-            f.write_text(f"\n{node}\n\n")
-            stats = import_graph(store, f)
-            assert stats["nodes"] == 1
-
-
-# ── _export_nodes / _export_edges ────────────────────────────────────────────
-
-class TestExportHelpers:
-    def test_export_nodes_handles_non_dict_props(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[["Function", "not_a_dict"]])
-        nodes = _export_nodes(store)
-        assert len(nodes) == 1
-        assert nodes[0]["props"] == {}
-
-    def test_export_edges_returns_structured_data(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(
-            result_set=[["CALLS", "Function", "foo", "app.py", "Function", "bar", "bar.py"]]
+                "from": {"label": "Function", "name": "alpha", "path": "app.py"},
+                "to": {"label": "Function", "name": "beta", "path": "app.py"},
+            },
+            {
+                "kind": "edge",
+                "type": "CONTAINS",
+                "from": {"label": "File", "name": "app.py", "path": "app.py"},
+                "to": {"label": "Function", "name": "alpha", "path": "app.py"},
+            },
+        ]
+        path.write_text(
+            "\n".join(json.dumps(r, sort_keys=True) for r in records) + "\n", encoding="utf-8"
         )
-        edges = _export_edges(store)
-        assert len(edges) == 1
-        assert edges[0]["type"] == "CALLS"
-        assert edges[0]["from"]["name"] == "foo"
-        assert edges[0]["to"]["name"] == "bar"
+
+    def test_legacy_nodes_import(self, dest, tmp_path):
+        path = tmp_path / "legacy.jsonl"
+        self.write_legacy(path)
+        import_graph(dest, path)
+        assert dest.node_count() == 3
+
+    def test_legacy_edges_import(self, dest, tmp_path):
+        """These are exactly the edges the original importer dropped."""
+        path = tmp_path / "legacy.jsonl"
+        self.write_legacy(path)
+        import_graph(dest, path)
+        assert dest.edge_count() == 2
+
+    def test_legacy_symbol_to_symbol_edge_resolves(self, dest, tmp_path):
+        path = tmp_path / "legacy.jsonl"
+        self.write_legacy(path)
+        import_graph(dest, path)
+        rows = dest.query(
+            "MATCH (a:Function)-[:CALLS]->(b:Function) RETURN a.name, b.name"
+        ).result_set
+        assert rows == [["alpha", "beta"]]
 
 
-# ── _import_node / _import_edge ──────────────────────────────────────────────
+# ── Verification ───────────────────────────────────────────────────────────
 
-class TestImportHelpers:
-    def test_import_node_adds_missing_file_path(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        record = {"kind": "node", "label": "Concept", "props": {"name": "JWT"}}
-        _import_node(store, record)
-        store.query.assert_called_once()
-        cypher = store.query.call_args[0][0]
-        assert "MERGE" in cypher
 
-    def test_import_node_adds_missing_name(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        record = {"kind": "node", "label": "Domain", "props": {"description": "Auth domain"}}
-        _import_node(store, record)
-        # Should have added name="" to props
-        store.query.assert_called_once()
-        params = store.query.call_args[0][1]
-        assert params["name"] == ""
+class TestVerification:
+    def test_unresolvable_edges_fail_loudly(self, dest, tmp_path):
+        """
+        A file describing edges whose endpoints are absent must not import
+        quietly: the result is disconnected nodes that answer every structural
+        query with an empty set, which reads as a valid negative.
+        """
+        path = tmp_path / "broken.jsonl"
+        records = [
+            {
+                "kind": "node",
+                "id": "Function::alpha",
+                "type": "Function",
+                "name": "alpha",
+                "props": {"name": "alpha", "file_path": "app.py"},
+            },
+            {
+                "kind": "edge",
+                "type": "CALLS",
+                "source": "Function::alpha",
+                "target": "Function::missing",
+                "props": {},
+            },
+        ]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
 
-    def test_import_node_uses_path_key_for_repos(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        record = {"kind": "node", "label": "Repository", "props": {"name": "myrepo", "path": "/code/myrepo"}}
-        _import_node(store, record)
-        cypher = store.query.call_args[0][0]
-        assert "path" in cypher
+        with pytest.raises(ExportError, match="did not reproduce"):
+            import_graph(dest, path)
 
-    def test_import_edge_with_paths(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
+    def test_additive_import_does_not_verify(self, dest, tmp_path):
+        """With clear=False the destination legitimately differs; no verification."""
+        path = tmp_path / "partial.jsonl"
         record = {
             "kind": "edge",
             "type": "CALLS",
-            "from": {"label": "Function", "name": "foo", "path": "app.py"},
-            "to": {"label": "Function", "name": "bar", "path": "bar.py"},
+            "source": "Function::a",
+            "target": "Function::b",
+            "props": {},
         }
-        _import_edge(store, record)
-        store.query.assert_called_once()
+        path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        assert import_graph(dest, path, clear=False)["edges"] == 0
 
-    def test_import_edge_without_paths(self):
-        store = MagicMock()
-        store.query.return_value = MagicMock(result_set=[])
-        record = {
-            "kind": "edge",
-            "type": "RELATED_TO",
-            "from": {"label": "Concept", "name": "JWT", "path": ""},
-            "to": {"label": "Concept", "name": "OAuth", "path": ""},
-        }
-        _import_edge(store, record)
-        store.query.assert_called_once()
-        cypher = store.query.call_args[0][0]
-        assert "file_path" not in cypher
+
+# ── Interop with the conflict-kg encoding ──────────────────────────────────
+
+
+class TestFormatAgreement:
+    def test_jsonl_and_conflict_kg_agree_on_the_graph(self, source, dest, tmp_path):
+        """Both serializations share one identity scheme, so both round trip."""
+        from navegador.graph.interchange import export_conflict_kg, import_conflict_kg
+
+        seed(source)
+        jsonl, kg = tmp_path / "g.jsonl", tmp_path / "g.json"
+        export_graph(source, jsonl)
+        export_conflict_kg(source, kg)
+
+        import_graph(dest, jsonl)
+        via_jsonl = (dest.node_count(), dest.edge_count())
+        import_conflict_kg(dest, kg)
+        via_kg = (dest.node_count(), dest.edge_count())
+
+        assert via_jsonl == via_kg == (source.node_count(), source.edge_count())

--- a/tests/test_ingest_deletions.py
+++ b/tests/test_ingest_deletions.py
@@ -1,0 +1,194 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Regression tests for #168 — ingest must remove nodes for deleted files.
+
+Nothing walked the set of previously-known paths, so whole-file deletion went
+unnoticed: a maintained graph kept every File node, every symbol it contained
+and all their edges, forever. The drift is quiet and cumulative — the export
+keeps validating and the ghosts are still returned by queries — so the property
+under test is that a maintained graph equals a clean rebuild of the same tree.
+
+Real embedded stores: the bug is about graph state, not call sequences.
+"""
+
+import pytest
+
+from navegador.graph.store import GraphStore
+from navegador.ingestion.parser import RepoIngester
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("deletions") / "graph.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def rebuilt(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("deletions-clean") / "graph.db"))
+    yield s
+    s.close()
+
+
+def write_repo(root):
+    """Two python modules, one of which will be deleted."""
+    pkg = root / "pkg"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "zeta.py").write_text("def zeta_compute():\n    return 1\n", encoding="utf-8")
+    (pkg / "alpha.py").write_text("def alpha():\n    return 2\n", encoding="utf-8")
+    return root
+
+
+def shape(store):
+    return (store.node_count(), store.edge_count())
+
+
+def names(store):
+    rows = store.query("MATCH (n) RETURN labels(n)[0], n.name ORDER BY n.name").result_set or []
+    return {(r[0], r[1]) for r in rows}
+
+
+# ── Deletion is noticed ────────────────────────────────────────────────────
+
+
+class TestDeletedFilesAreRemoved:
+    def test_incremental_removes_the_file_node(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        (repo / "pkg" / "zeta.py").unlink()
+        ing.ingest(repo, incremental=True)
+
+        rows = store.query("MATCH (f:File) RETURN f.path ORDER BY f.path").result_set or []
+        assert [r[0] for r in rows] == ["pkg/alpha.py"]
+
+    def test_incremental_removes_contained_symbols(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        (repo / "pkg" / "zeta.py").unlink()
+        ing.ingest(repo, incremental=True)
+
+        assert not [n for n in names(store) if n[1] == "zeta_compute"]
+
+    def test_full_ingest_also_removes(self, store, tmp_path):
+        """A plain re-ingest leaked too, not only --incremental."""
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        (repo / "pkg" / "zeta.py").unlink()
+        ing.ingest(repo)
+
+        assert not [n for n in names(store) if n[1] == "zeta_compute"]
+
+    def test_removed_count_is_reported(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        (repo / "pkg" / "zeta.py").unlink()
+        stats = ing.ingest(repo, incremental=True)
+        assert stats["removed"] == 1
+
+    def test_nothing_removed_when_nothing_deleted(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        assert ing.ingest(repo, incremental=True)["removed"] == 0
+
+    def test_maintained_graph_equals_clean_rebuild(self, store, rebuilt, tmp_path):
+        """The acceptance criterion: no drift versus a fresh ingest."""
+        repo = write_repo(tmp_path)
+        RepoIngester(store).ingest(repo)
+        (repo / "pkg" / "zeta.py").unlink()
+        RepoIngester(store).ingest(repo, incremental=True)
+
+        RepoIngester(rebuilt).ingest(repo, clear=True)
+
+        assert shape(store) == shape(rebuilt)
+        assert names(store) == names(rebuilt)
+
+    def test_deleting_every_file_empties_the_repo_scope(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        (repo / "pkg" / "zeta.py").unlink()
+        (repo / "pkg" / "alpha.py").unlink()
+        ing.ingest(repo, incremental=True)
+        assert store.query("MATCH (f:File) RETURN count(f)").result_set[0][0] == 0
+
+    def test_markdown_documents_are_removed_too(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        (repo / "README.md").write_text("# Title\n\nSome prose.\n", encoding="utf-8")
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        assert store.query("MATCH (d:Document) RETURN count(d)").result_set[0][0] == 1
+
+        (repo / "README.md").unlink()
+        ing.ingest(repo, incremental=True)
+        assert store.query("MATCH (d:Document) RETURN count(d)").result_set[0][0] == 0
+
+
+# ── What must NOT be removed ───────────────────────────────────────────────
+
+
+class TestPruneIsConservative:
+    def test_unparseable_files_are_kept(self, store, tmp_path, monkeypatch):
+        """
+        A file whose optional grammar is missing is still on disk.
+
+        Pruning against the set of successfully parsed files would delete every
+        Rust/Go/Swift node the moment someone installed navegador without the
+        language extras.
+        """
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        before = names(store)
+
+        real_get_parser = ing._get_parser
+        monkeypatch.setattr(ing, "_get_parser", lambda language: None)
+        stats = ing.ingest(repo)
+        monkeypatch.setattr(ing, "_get_parser", real_get_parser)
+
+        assert stats["removed"] == 0
+        assert names(store) == before
+
+    def test_another_repo_in_the_same_graph_is_untouched(self, store, tmp_path):
+        """
+        Pruning is scoped by BELONGS_TO.
+
+        A shared or federated graph holds many repositories; ingesting one must
+        not remove another's files just because they are not on this disk path.
+        """
+        first = write_repo(tmp_path / "first")
+        second = tmp_path / "second"
+        (second / "pkg").mkdir(parents=True)
+        (second / "pkg" / "other.py").write_text("def other():\n    return 3\n", encoding="utf-8")
+
+        ing = RepoIngester(store)
+        ing.ingest(first)
+        ing.ingest(second)
+        assert any(n[1] == "other" for n in names(store))
+
+        (first / "pkg" / "zeta.py").unlink()
+        ing.ingest(first, incremental=True)
+
+        assert any(n[1] == "other" for n in names(store)), "other repo's symbols were pruned"
+        assert not any(n[1] == "zeta_compute" for n in names(store))
+
+    def test_surviving_files_keep_their_symbols(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        (repo / "pkg" / "zeta.py").unlink()
+        ing.ingest(repo, incremental=True)
+        assert any(n[1] == "alpha" for n in names(store))
+
+    def test_clear_ingest_still_works(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        ing = RepoIngester(store)
+        ing.ingest(repo)
+        stats = ing.ingest(repo, clear=True)
+        assert stats["removed"] == 0
+        assert any(n[1] == "zeta_compute" for n in names(store))

--- a/tests/test_ingestion_gaps.py
+++ b/tests/test_ingestion_gaps.py
@@ -484,54 +484,79 @@ class TestTestMapper:
         assert result.unmatched_tests[0]["name"] == "test_something_obscure"
 
     def test_heuristic_resolution_strips_test_prefix(self):
-        from navegador.analysis.testmap import TestMapper
+        """
+        `test_handle_request` resolves to `handle_request` in the same repo.
 
-        store = self._make_store(
-            test_fns=[["test_handle_request", "tests/test_views.py", 20]],
-            callee_results=[],  # no CALLS edge
-            prod_results=[["Function", "handle_request", "views.py"]],
-        )
-        mapper = TestMapper(store)
-        result = mapper.map_tests()
+        Real store: scoring consults the repository and module a candidate lives
+        in, which a fixed sequence of mocked result sets cannot express.
+        """
+        import tempfile
+
+        from navegador.analysis.testmap import TestMapper
+        from navegador.graph.store import GraphStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = GraphStore.sqlite(f"{tmpdir}/graph.db")
+            try:
+                store.query(
+                    "MERGE (f:File {path: 'views.py'}) "
+                    "MERGE (r:Repository {path: 'org/app'}) "
+                    "MERGE (f)-[:BELONGS_TO]->(r) "
+                    "MERGE (:Function {name: 'handle_request', file_path: 'views.py'})"
+                )
+                store.query(
+                    "MERGE (f:File {path: 'tests/test_views.py'}) "
+                    "MERGE (r:Repository {path: 'org/app'}) "
+                    "MERGE (f)-[:BELONGS_TO]->(r) "
+                    "MERGE (:Function {name: 'test_handle_request', "
+                    "file_path: 'tests/test_views.py'})"
+                )
+                result = TestMapper(store).map_tests()
+            finally:
+                store.close()
 
         assert len(result.links) == 1
         assert result.links[0].prod_name == "handle_request"
         assert result.links[0].source == "heuristic"
 
-    def test_heuristic_tries_shorter_prefixes(self):
-        """test_foo_bar should try 'foo_bar' first, then 'foo'."""
+    def test_heuristic_prefers_the_more_specific_name(self):
+        """
+        A truncated prefix is a weaker match than the full stripped name.
+
+        This previously asserted the opposite behaviour — take whatever the
+        first matching prefix finds, anywhere in the graph — which is exactly
+        how generic verbs produced cross-repository nonsense (#166).
+        """
+        import tempfile
+
         from navegador.analysis.testmap import TestMapper
+        from navegador.graph.store import GraphStore
 
-        call_log = []
-        store = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = GraphStore.sqlite(f"{tmpdir}/graph.db")
+            try:
+                for name, path in (
+                    ("foo_bar", "lib/specific.py"),
+                    ("foo", "lib/generic.py"),
+                ):
+                    store.query(
+                        "MERGE (f:File {path: $p}) "
+                        "MERGE (r:Repository {path: 'org/app'}) "
+                        "MERGE (f)-[:BELONGS_TO]->(r) "
+                        "MERGE (:Function {name: $n, file_path: $p})",
+                        {"n": name, "p": path},
+                    )
+                store.query(
+                    "MERGE (f:File {path: 'tests/test_lib.py'}) "
+                    "MERGE (r:Repository {path: 'org/app'}) "
+                    "MERGE (f)-[:BELONGS_TO]->(r) "
+                    "MERGE (:Function {name: 'test_foo_bar', file_path: 'tests/test_lib.py'})"
+                )
+                result = TestMapper(store).map_tests()
+            finally:
+                store.close()
 
-        def _query(cypher=None, params=None):
-            r = MagicMock()
-            q = cypher or ""
-            if "fn:Function OR fn:Method" in q:
-                r.result_set = [["test_foo_bar", "test.py", 1]]
-            elif "[:CALLS]->" in q:
-                r.result_set = []
-            elif "n.name = $name" in q:
-                call_log.append(params["name"])
-                if params["name"] == "foo":
-                    r.result_set = [["Function", "foo", "lib.py"]]
-                else:
-                    r.result_set = []
-            elif "MERGE" in q:
-                r.result_set = []
-            else:
-                r.result_set = []
-            return r
-
-        store.query.side_effect = _query
-        mapper = TestMapper(store)
-        result = mapper.map_tests()
-
-        assert "foo_bar" in call_log
-        assert "foo" in call_log
-        assert len(result.links) == 1
-        assert result.links[0].prod_name == "foo"
+        assert [lnk.prod_name for lnk in result.links] == ["foo_bar"]
 
     def test_query_exception_in_get_test_functions_handled(self):
         from navegador.analysis.testmap import TestMapper
@@ -647,10 +672,11 @@ class TestTestMapper:
         assert d["links"][0]["prod_name"] == "foo"
         assert d["unmatched_tests"][0]["name"] == "test_orphan"
 
-    def test_heuristic_non_test_name_returns_none(self):
-        """_resolve_via_heuristic should return None for names not starting with test_."""
+    def test_heuristic_non_test_name_yields_no_candidates(self):
+        """A name that is not a test cannot be resolved by the name heuristic."""
         from navegador.analysis.testmap import TestMapper
 
         store = MagicMock()
+        store.query.return_value = MagicMock(result_set=[])
         mapper = TestMapper(store)
-        assert mapper._resolve_via_heuristic("not_a_test") is None
+        assert mapper._score_heuristic_candidates("not_a_test", "") == []

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -483,6 +483,10 @@ class TestAutoProvider:
             _block_import("anthropic"),
             _block_import("openai"),
             patch.dict(sys.modules, {"ollama": fake_ol}),
+            # Ollama needs no credential, so a reachable server is the whole of
+            # its availability. Leaving that to the machine means this passes
+            # only where one happens to be running.
+            patch("urllib.request.urlopen", MagicMock()),
         ):
             llm_mod = self._reload()
             p = llm_mod.auto_provider()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -110,7 +110,7 @@ class TestAnthropicProvider:
 
             importlib.reload(llm_mod)
             p = llm_mod.AnthropicProvider()
-            assert p.model == "claude-3-5-haiku-20241022"
+            assert p.model == "claude-opus-5"
 
     def test_custom_model(self):
         fake_mod, _ = _fake_anthropic_module()
@@ -426,6 +426,23 @@ class TestGetProvider:
 
 
 class TestAutoProvider:
+    @pytest.fixture(autouse=True)
+    def no_ambient_credentials(self, monkeypatch):
+        """
+        Selection depends on credentials since #164, so the environment must be
+        stated by each test rather than inherited. Without this, the result
+        depends on which keys the developer happens to export, and CI — which
+        exports none — disagrees with every laptop.
+        """
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "OPENAI_API_KEY",
+            "NAVEGADOR_LLM_PROVIDER",
+            "NAVEGADOR_LLM_MODEL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
     def _reload(self):
         import importlib
 
@@ -434,7 +451,9 @@ class TestAutoProvider:
         importlib.reload(llm_mod)
         return llm_mod
 
-    def test_prefers_anthropic_when_all_available(self):
+    def test_prefers_anthropic_when_all_available(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         fake_a, _ = _fake_anthropic_module()
         fake_o, _ = _fake_openai_module()
         fake_ol, _ = _fake_ollama_module()
@@ -446,7 +465,8 @@ class TestAutoProvider:
             p = llm_mod.auto_provider()
             assert p.name == "anthropic"
 
-    def test_falls_back_to_openai_when_anthropic_missing(self):
+    def test_falls_back_to_openai_when_anthropic_missing(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         fake_o, _ = _fake_openai_module()
         fake_ol, _ = _fake_ollama_module()
         with (
@@ -471,7 +491,7 @@ class TestAutoProvider:
     def test_raises_runtime_error_when_no_sdk_available(self):
         with _block_import("anthropic"), _block_import("openai"), _block_import("ollama"):
             llm_mod = self._reload()
-            with pytest.raises(RuntimeError, match="No LLM SDK is installed"):
+            with pytest.raises(RuntimeError, match="No usable LLM provider"):
                 llm_mod.auto_provider()
 
     def test_runtime_error_message_includes_install_hints(self):
@@ -480,7 +500,8 @@ class TestAutoProvider:
             with pytest.raises(RuntimeError, match="pip install"):
                 llm_mod.auto_provider()
 
-    def test_passes_model_to_provider(self):
+    def test_passes_model_to_provider(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         fake_a, _ = _fake_anthropic_module()
         with patch.dict(sys.modules, {"anthropic": fake_a}):
             llm_mod = self._reload()

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -13,6 +13,10 @@ label per node pattern. Alternative *relationship* types are valid and must be
 left alone.
 """
 
+import sys
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from navegador.config import resolve_llm
@@ -31,6 +35,39 @@ def isolated_env(monkeypatch, tmp_path):
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("NAVEGADOR_CONFIG", str(tmp_path / "absent.toml"))
+
+
+@contextmanager
+def sdk(**present):
+    """
+    State which provider SDKs are importable.
+
+    The SDKs live in the optional `[llm]` extra, so CI has none of them and a
+    developer machine usually has several. Availability tests that inherit that
+    difference test the machine rather than the code.
+    """
+    stubs = {name: (MagicMock() if ok else None) for name, ok in present.items()}
+    with patch.dict(sys.modules, stubs):
+        yield
+
+
+@contextmanager
+def ollama_server(running: bool):
+    """
+    State whether a local Ollama server answers.
+
+    Ollama needs no credential, so reachability is the whole of its
+    availability — and a developer running `ollama serve` would otherwise see
+    different provider selection than CI.
+    """
+
+    def urlopen(*_args, **_kwargs):
+        if not running:
+            raise OSError("connection refused")
+        return MagicMock()
+
+    with patch("urllib.request.urlopen", urlopen):
+        yield
 
 
 def write_config(root, body):
@@ -98,34 +135,45 @@ class TestProviderAvailability:
         The reported failure: the SDK is installed, no key is exported, and
         Anthropic was selected anyway — failing later with a raw auth error.
         """
-        available, why = provider_available("anthropic")
+        with sdk(anthropic=True):
+            available, why = provider_available("anthropic")
         assert available is False
         assert "ANTHROPIC_API_KEY" in why
 
     def test_credential_makes_it_available(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-        assert provider_available("anthropic")[0] is True
+        with sdk(anthropic=True):
+            assert provider_available("anthropic")[0] is True
 
     def test_auth_token_also_counts(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token")
-        assert provider_available("anthropic")[0] is True
+        with sdk(anthropic=True):
+            assert provider_available("anthropic")[0] is True
 
     def test_missing_sdk_is_reported_as_such(self):
-        available, why = provider_available("ollama")
-        if not available and "not installed" in why:
-            assert "pip install" in why
+        """A missing package and a missing key are different problems."""
+        with sdk(anthropic=False):
+            available, why = provider_available("anthropic")
+        assert available is False
+        assert "pip install anthropic" in why
+
+    def test_a_local_provider_needs_a_running_server(self):
+        """Ollama takes no credential, so reachability is its availability."""
+        with sdk(ollama=True), ollama_server(running=False):
+            available, why = provider_available("ollama")
+        assert available is False
+        assert "no Ollama server" in why
 
     def test_auto_provider_skips_credential_less_providers(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        try:
+        with sdk(anthropic=True, openai=True, ollama=False):
             provider = auto_provider()
-        except RuntimeError:
-            pytest.skip("openai SDK not installed in this environment")
         assert provider.name == "openai"
 
     def test_auto_provider_error_explains_each_provider(self):
-        with pytest.raises(RuntimeError) as excinfo:
-            auto_provider()
+        with sdk(anthropic=True, openai=True, ollama=True), ollama_server(running=False):
+            with pytest.raises(RuntimeError) as excinfo:
+                auto_provider()
         message = str(excinfo.value)
         assert "ANTHROPIC_API_KEY" in message
         assert "config.toml" in message

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -1,0 +1,235 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Regression tests for #164 and #165 — LLM selection and generated Cypher.
+
+#164: `navegador init` wrote `[llm] provider` and `model` and nothing read
+them; provider discovery selected Anthropic whenever the SDK was importable,
+regardless of credentials; and the Anthropic default was pinned to
+`claude-3-5-haiku-20241022`, retired 2026-02-19, so the fallback path called a
+model that returns 404.
+
+#165: generated Cypher used `(n:Class|Function)`, which FalkorDB rejects — one
+label per node pattern. Alternative *relationship* types are valid and must be
+left alone.
+"""
+
+import pytest
+
+from navegador.config import resolve_llm
+from navegador.intelligence.nlp import NLPEngine
+from navegador.llm import AnthropicProvider, auto_provider, provider_available
+
+
+@pytest.fixture(autouse=True)
+def isolated_env(monkeypatch, tmp_path):
+    for var in (
+        "NAVEGADOR_LLM_PROVIDER",
+        "NAVEGADOR_LLM_MODEL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("NAVEGADOR_CONFIG", str(tmp_path / "absent.toml"))
+
+
+def write_config(root, body):
+    nav = root / ".navegador"
+    nav.mkdir(parents=True, exist_ok=True)
+    (nav / "config.toml").write_text(body, encoding="utf-8")
+    return root
+
+
+# ── #164: configuration is read ────────────────────────────────────────────
+
+
+class TestLLMConfigResolution:
+    def test_project_config_is_honoured(self, tmp_path):
+        """The regression: [llm] was written by init and never read."""
+        write_config(tmp_path, '[llm]\nprovider = "openai"\nmodel = "gpt-4o"\n')
+        cfg = resolve_llm(target=tmp_path)
+        assert cfg.provider == "openai"
+        assert cfg.model == "gpt-4o"
+        assert "project config" in cfg.source
+
+    def test_provider_only_is_enough(self, tmp_path):
+        write_config(tmp_path, '[llm]\nprovider = "ollama"\nmodel = ""\n')
+        assert resolve_llm(target=tmp_path).provider == "ollama"
+
+    def test_empty_section_falls_through(self, tmp_path):
+        write_config(tmp_path, '[llm]\nprovider = ""\nmodel = ""\n')
+        assert resolve_llm(target=tmp_path).source == "default"
+
+    def test_command_line_wins(self, tmp_path):
+        write_config(tmp_path, '[llm]\nprovider = "openai"\n')
+        cfg = resolve_llm(provider="anthropic", target=tmp_path)
+        assert cfg.provider == "anthropic"
+        assert cfg.source == "command line"
+
+    def test_environment_beats_config(self, tmp_path, monkeypatch):
+        write_config(tmp_path, '[llm]\nprovider = "openai"\n')
+        monkeypatch.setenv("NAVEGADOR_LLM_PROVIDER", "ollama")
+        assert resolve_llm(target=tmp_path).provider == "ollama"
+
+    def test_user_config_used_when_no_project_config(self, tmp_path, monkeypatch):
+        user = tmp_path / "user.toml"
+        user.write_text('[llm]\nprovider = "openai"\nmodel = "gpt-4o"\n', encoding="utf-8")
+        monkeypatch.setenv("NAVEGADOR_CONFIG", str(user))
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        cfg = resolve_llm(target=bare)
+        assert cfg.provider == "openai"
+        assert "user config" in cfg.source
+
+    def test_nothing_configured_is_auto(self, tmp_path):
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        cfg = resolve_llm(target=bare)
+        assert cfg.provider == ""
+        assert cfg.source == "default"
+
+
+# ── #164: availability means credentials, not imports ──────────────────────
+
+
+class TestProviderAvailability:
+    def test_sdk_without_credential_is_unavailable(self):
+        """
+        The reported failure: the SDK is installed, no key is exported, and
+        Anthropic was selected anyway — failing later with a raw auth error.
+        """
+        available, why = provider_available("anthropic")
+        assert available is False
+        assert "ANTHROPIC_API_KEY" in why
+
+    def test_credential_makes_it_available(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        assert provider_available("anthropic")[0] is True
+
+    def test_auth_token_also_counts(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token")
+        assert provider_available("anthropic")[0] is True
+
+    def test_missing_sdk_is_reported_as_such(self):
+        available, why = provider_available("ollama")
+        if not available and "not installed" in why:
+            assert "pip install" in why
+
+    def test_auto_provider_skips_credential_less_providers(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        try:
+            provider = auto_provider()
+        except RuntimeError:
+            pytest.skip("openai SDK not installed in this environment")
+        assert provider.name == "openai"
+
+    def test_auto_provider_error_explains_each_provider(self):
+        with pytest.raises(RuntimeError) as excinfo:
+            auto_provider()
+        message = str(excinfo.value)
+        assert "ANTHROPIC_API_KEY" in message
+        assert "config.toml" in message
+
+
+class TestAnthropicDefaultModel:
+    def test_default_is_not_the_retired_model(self):
+        """`claude-3-5-haiku-20241022` was retired 2026-02-19 and returns 404."""
+        assert AnthropicProvider._DEFAULT_MODEL != "claude-3-5-haiku-20241022"
+
+    def test_default_is_a_current_alias(self):
+        import re
+
+        model = AnthropicProvider._DEFAULT_MODEL
+        assert model == "claude-opus-5"
+        # Aliases are complete as written. An appended 8-digit date turns the
+        # alias into a dated snapshot ID — a different model, and the shape the
+        # retired default had.
+        assert not re.search(r"-\d{8}$", model)
+
+
+# ── #165: generated Cypher must be executable ──────────────────────────────
+
+
+class TestAlternativeLabelRewriting:
+    rewrite = staticmethod(NLPEngine._rewrite_alternative_labels)
+
+    def test_the_reported_query_is_repaired(self):
+        original = (
+            "MATCH (f:File)-[:CONTAINS]->(c:Class|Function)"
+            "-[:REFERENCES]->(concept:Concept) RETURN f.path"
+        )
+        result = self.rewrite(original)
+        assert "Class|Function" not in result
+        assert "(c:Class OR c:Function)" in result
+        assert "WHERE" in result
+
+    def test_three_labels(self):
+        result = self.rewrite("MATCH (n:Class|Function|Method) RETURN count(n)")
+        assert "(n:Class OR n:Function OR n:Method)" in result
+
+    def test_existing_where_is_preserved(self):
+        result = self.rewrite("MATCH (n:Class|Function) WHERE n.name = 'x' RETURN n")
+        assert "n.name = 'x'" in result
+        assert "AND" in result
+
+    def test_anonymous_node_gets_a_variable(self):
+        result = self.rewrite("MATCH (:Class|Function) RETURN 1")
+        assert "|" not in result
+        assert " OR " in result
+
+    def test_single_label_is_untouched(self):
+        query = "MATCH (n:Function) RETURN n"
+        assert self.rewrite(query) == query
+
+    def test_relationship_alternatives_are_untouched(self):
+        """FalkorDB accepts `-[:A|B]->`; rewriting it would be wrong."""
+        query = "MATCH ()-[r:CALLS|CONTAINS]->() RETURN count(r)"
+        assert self.rewrite(query) == query
+
+    def test_mixed_node_and_relationship_alternatives(self):
+        result = self.rewrite("MATCH (n:Class|Function)-[r:CALLS|CONTAINS]->() RETURN n")
+        assert "r:CALLS|CONTAINS" in result
+        assert "(n:Class OR n:Function)" in result
+
+    def test_property_map_after_labels(self):
+        result = self.rewrite("MATCH (n:Class|Function {name: 'x'}) RETURN n")
+        assert "|" not in result
+        assert "name: 'x'" in result
+
+
+class TestRewrittenQueriesActuallyRun:
+    """The rewrite is only correct if FalkorDB accepts the result."""
+
+    @pytest.fixture()
+    def store(self, tmp_path_factory):
+        from navegador.graph.store import GraphStore
+
+        s = GraphStore.sqlite(str(tmp_path_factory.mktemp("cypher") / "graph.db"))
+        s.query("CREATE (:Class {name: 'A'})")
+        s.query("CREATE (:Function {name: 'b'})")
+        yield s
+        s.close()
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "MATCH (n:Class|Function) RETURN count(n)",
+            "MATCH (n:Class|Function) WHERE n.name = 'A' RETURN count(n)",
+            "MATCH (:Class|Function) RETURN count(*)",
+            "MATCH (n:Class|Function|Method) RETURN count(n)",
+        ],
+    )
+    def test_rewritten_query_executes(self, store, query):
+        rewritten = NLPEngine._rewrite_alternative_labels(query)
+        store.query(rewritten)  # raises if FalkorDB rejects it
+
+    def test_original_query_is_rejected(self, store):
+        """Confirms the rewrite is addressing a real syntax error."""
+        with pytest.raises(Exception, match=r"\|"):
+            store.query("MATCH (n:Class|Function) RETURN count(n)")
+
+    def test_rewrite_preserves_semantics(self, store):
+        rewritten = NLPEngine._rewrite_alternative_labels(
+            "MATCH (n:Class|Function) RETURN count(n)"
+        )
+        assert store.query(rewritten).result_set[0][0] == 2

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -127,9 +127,9 @@ class TestListTools:
         self.fx = _ServerFixture()
 
     @pytest.mark.asyncio
-    async def test_returns_twenty_five_tools(self):
+    async def test_returns_twenty_seven_tools(self):
         tools = await self.fx.list_tools_fn()
-        assert len(tools) == 25
+        assert len(tools) == 27
 
     @pytest.mark.asyncio
     async def test_tool_names(self):
@@ -138,6 +138,8 @@ class TestListTools:
         assert names == {
             "ingest_repo",
             "read_docs",
+            "resolve_address",
+            "propose_join_edges",
             "load_file_context",
             "load_function_context",
             "load_class_context",

--- a/tests/test_python_call_graph.py
+++ b/tests/test_python_call_graph.py
@@ -1,0 +1,220 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Regression tests for #163 — Python call edges must cross file boundaries.
+
+`_extract_calls` recorded every callee as living in the file that called it, so
+an imported function resolved to a node that did not exist and the edge was
+dropped. On a multi-package fixture the graph contained the right symbols and
+*zero* CALLS edges, which made explain/trace/impact stop at file boundaries and
+look like the code genuinely had no callers.
+
+Real embedded stores and real files on disk: module resolution consults the
+filesystem, which is how a first-party import is told apart from the standard
+library.
+"""
+
+import pytest
+
+from navegador.graph.store import GraphStore
+from navegador.ingestion.parser import RepoIngester
+from navegador.ingestion.python import _module_to_repo_file, _parse_import_from
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("callgraph") / "graph.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """The multi-package fixture from the report."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "normalize.py").write_text(
+        "def normalize_input(x):\n    return x\n\n\ndef resolve_entity(x):\n    return x\n",
+        encoding="utf-8",
+    )
+    (pkg / "facts.py").write_text("def store_fact(f):\n    return f\n", encoding="utf-8")
+    (pkg / "projection.py").write_text("def read_projection(q):\n    return q\n", encoding="utf-8")
+    (pkg / "pipeline.py").write_text(
+        "from pkg.normalize import normalize_input, resolve_entity\n\n\n"
+        "def process(item):\n"
+        "    a = normalize_input(item)\n"
+        "    return resolve_entity(a)\n",
+        encoding="utf-8",
+    )
+    (pkg / "worker.py").write_text(
+        "import asyncio\nfrom pkg import pipeline\n\n\n"
+        "async def consume(item):\n"
+        "    return await asyncio.to_thread(pipeline.process, item)\n",
+        encoding="utf-8",
+    )
+    (pkg / "settlement.py").write_text(
+        "def record_fields(fields):\n"
+        "    from pkg.facts import store_fact\n"
+        "    return [store_fact(f) for f in fields]\n",
+        encoding="utf-8",
+    )
+    (pkg / "queries.py").write_text(
+        "class Reader:\n"
+        "    def build_view(self, q):\n"
+        "        from pkg.projection import read_projection\n"
+        "        return read_projection(q)\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def calls(store):
+    rows = store.query(
+        "MATCH (a)-[:CALLS]->(b) RETURN a.name, b.name, b.file_path ORDER BY a.name, b.name"
+    ).result_set
+    return {(r[0], r[1], r[2]) for r in rows or []}
+
+
+def references(store):
+    rows = store.query(
+        "MATCH (a)-[:REFERENCES]->(b) RETURN a.name, b.name, b.file_path"
+    ).result_set
+    return {(r[0], r[1], r[2]) for r in rows or []}
+
+
+# ── The reported call forms ────────────────────────────────────────────────
+
+
+class TestCrossModuleCalls:
+    def test_module_level_import_is_resolved(self, store, repo):
+        """`process` calls two functions imported from another module."""
+        RepoIngester(store).ingest(repo)
+        assert ("process", "normalize_input", "pkg/normalize.py") in calls(store)
+        assert ("process", "resolve_entity", "pkg/normalize.py") in calls(store)
+
+    def test_function_local_import_in_a_comprehension(self, store, repo):
+        """The import is inside the function and the call inside a comprehension."""
+        RepoIngester(store).ingest(repo)
+        assert ("record_fields", "store_fact", "pkg/facts.py") in calls(store)
+
+    def test_method_local_import(self, store, repo):
+        RepoIngester(store).ingest(repo)
+        assert ("build_view", "read_projection", "pkg/projection.py") in calls(store)
+
+    def test_callable_passed_to_a_higher_order_helper(self, store, repo):
+        """
+        `asyncio.to_thread(pipeline.process)` never appears as a call of
+        `process`, so flow analysis used to stop dead at the handoff.
+        """
+        RepoIngester(store).ingest(repo)
+        assert ("consume", "process", "pkg/pipeline.py") in references(store)
+
+    def test_the_fixture_produces_call_edges_at_all(self, store, repo):
+        """It produced exactly zero before."""
+        RepoIngester(store).ingest(repo)
+        assert len(calls(store)) >= 4
+
+
+class TestResolutionIsConservative:
+    def test_stdlib_calls_do_not_invent_edges(self, store, repo):
+        """`asyncio.to_thread` is not in the repo, so there is nothing to point at."""
+        RepoIngester(store).ingest(repo)
+        assert not [c for c in calls(store) if c[1] == "to_thread"]
+
+    def test_same_file_calls_still_resolve(self, store, tmp_path):
+        (tmp_path / "solo.py").write_text(
+            "def helper():\n    return 1\n\n\ndef caller():\n    return helper()\n",
+            encoding="utf-8",
+        )
+        RepoIngester(store).ingest(tmp_path)
+        assert ("caller", "helper", "solo.py") in calls(store)
+
+    def test_method_calls_on_objects_stay_local(self, store, tmp_path):
+        """`self.thing()` must not be resolved through an unrelated import."""
+        (tmp_path / "obj.py").write_text(
+            "class A:\n"
+            "    def helper(self):\n"
+            "        return 1\n\n"
+            "    def run(self):\n"
+            "        return self.helper()\n",
+            encoding="utf-8",
+        )
+        RepoIngester(store).ingest(tmp_path)
+        assert all(c[2] == "obj.py" for c in calls(store))
+
+
+# ── Import statement parsing ───────────────────────────────────────────────
+
+
+class TestParseImportFrom:
+    """The grammar labels the module and its members identically."""
+
+    @staticmethod
+    def parse(code: str):
+        from navegador.ingestion.python import _get_parser
+
+        tree = _get_parser().parse(code.encode())
+        node = tree.root_node.children[0]
+        return _parse_import_from(node, code.encode())
+
+    def test_single_member(self):
+        assert self.parse("from pkg.mod import thing\n") == ("pkg.mod", [("thing", "thing")])
+
+    def test_multiple_members(self):
+        module, bindings = self.parse("from pkg.mod import a, b\n")
+        assert module == "pkg.mod"
+        assert bindings == [("a", "a"), ("b", "b")]
+
+    def test_aliased_member(self):
+        module, bindings = self.parse("from pkg.mod import thing as other\n")
+        assert module == "pkg.mod"
+        assert bindings == [("other", "thing")]
+
+    def test_relative_import(self):
+        module, bindings = self.parse("from .sibling import thing\n")
+        assert module == ".sibling"
+        assert bindings == [("thing", "thing")]
+
+    def test_wildcard_binds_nothing(self):
+        module, bindings = self.parse("from pkg.mod import *\n")
+        assert module == "pkg.mod"
+        assert bindings == []
+
+    def test_from_import_creates_import_nodes(self, store, repo):
+        """These produced none at all, because the matched node type never occurs."""
+        RepoIngester(store).ingest(repo)
+        rows = store.query(
+            "MATCH (i:Import) WHERE i.file_path = 'pkg/pipeline.py' RETURN i.name ORDER BY i.name"
+        ).result_set
+        assert [r[0] for r in rows or []] == ["normalize_input", "resolve_entity"]
+
+
+# ── Module → file resolution ───────────────────────────────────────────────
+
+
+class TestModuleToRepoFile:
+    def test_absolute_module(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "mod.py").write_text("", encoding="utf-8")
+        current = pkg / "other.py"
+        assert _module_to_repo_file("pkg.mod", current, tmp_path) == "pkg/mod.py"
+
+    def test_package_init(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        assert _module_to_repo_file("pkg", tmp_path / "a.py", tmp_path) == "pkg/__init__.py"
+
+    def test_relative_module(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "sibling.py").write_text("", encoding="utf-8")
+        current = pkg / "here.py"
+        assert _module_to_repo_file(".sibling", current, tmp_path) == "pkg/sibling.py"
+
+    def test_module_outside_the_repo_is_unresolved(self, tmp_path):
+        assert _module_to_repo_file("asyncio", tmp_path / "a.py", tmp_path) is None
+
+    def test_empty_module_is_unresolved(self, tmp_path):
+        assert _module_to_repo_file("", tmp_path / "a.py", tmp_path) is None

--- a/tests/test_python_parser.py
+++ b/tests/test_python_parser.py
@@ -345,43 +345,50 @@ class TestHandleImportFrom:
         return parser
 
     def test_handle_import_from_with_member(self):
+        """
+        Parsed from real source rather than a hand-built node tree.
+
+        The previous version asserted against a node type called
+        `import_from_member`, which the grammar does not produce: members are
+        `dotted_name`, exactly like the module. The mock made the handler look
+        correct while `from X import Y` created no Import node at all (#163).
+        """
+        from navegador.ingestion.python import _get_parser
+
         parser = self._make_parser()
         store = MagicMock()
         stats = {"functions": 0, "classes": 0, "edges": 0}
-        combined = b"os.pathjoin"
-        module_node3 = MockNode("dotted_name", start_byte=0, end_byte=7)
-        member_node3 = MockNode("import_from_member", start_byte=7, end_byte=11)
-        node3 = MockNode("import_from_statement",
-                         children=[module_node3, member_node3],
-                         start_point=(0, 0))
-        parser._handle_import_from(node3, combined, "app.py", store, stats)
+        source = b"from os.path import join\n"
+        node = _get_parser().parse(source).root_node.children[0]
+
+        parser._handle_import_from(node, source, "app.py", store, stats)
+
         store.create_node.assert_called_once()
-        store.create_edge.assert_called_once()
+        _label, props = store.create_node.call_args[0]
+        assert props["name"] == "join"
+        assert props["module"] == "os.path"
         assert stats["edges"] == 1
 
     def test_handle_import_from_no_member(self):
+        """A wildcard import binds no nameable symbol, so nothing is created."""
+        from navegador.ingestion.python import _get_parser
+
         parser = self._make_parser()
         store = MagicMock()
-        # No import_from_member children — nothing should be created
-        module_node = MockNode("dotted_name", start_byte=0, end_byte=7)
-        node = MockNode("import_from_statement",
-                        children=[module_node],
-                        start_point=(0, 0))
+        source = b"from os.path import *\n"
+        node = _get_parser().parse(source).root_node.children[0]
         stats = {"functions": 0, "classes": 0, "edges": 0}
-        parser._handle_import_from(node, b"os.path", "app.py", store, stats)
+        parser._handle_import_from(node, source, "app.py", store, stats)
         store.create_node.assert_not_called()
         assert stats["edges"] == 0
 
     def test_walk_dispatches_import_from(self):
+        from navegador.ingestion.python import _get_parser
+
         parser = self._make_parser()
         store = MagicMock()
-        source = b"os.pathjoin"
-        module_node = MockNode("dotted_name", start_byte=0, end_byte=7)
-        member_node = MockNode("import_from_member", start_byte=7, end_byte=11)
-        import_from = MockNode("import_from_statement",
-                               children=[module_node, member_node],
-                               start_point=(0, 0))
-        root = MockNode("module", children=[import_from])
+        source = b"from os.path import join\n"
+        root = _get_parser().parse(source).root_node
         stats = {"functions": 0, "classes": 0, "edges": 0}
         parser._walk(root, source, "app.py", store, stats, class_name=None)
         assert stats["edges"] == 1

--- a/tests/test_repo_identity.py
+++ b/tests/test_repo_identity.py
@@ -1,0 +1,170 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Regression tests for #167 — Repository identity must survive being renamed.
+
+The Repository node was keyed by the checkout directory's basename, so a
+worktree, a renamed clone, or `git clone <url> <otherdir>` each produced an
+*additional* Repository node indistinguishable from a real one, and files ended
+up owned by every node they had been ingested under. Identity now comes from the
+git remote, which is the only thing constant across all three.
+
+Real embedded stores and real git repositories: the defect is about what git
+reports for a checkout, which a mock cannot show.
+"""
+
+import subprocess
+
+import pytest
+
+from navegador.graph.store import GraphStore
+from navegador.ingestion.parser import RepoIngester, repo_display_name, repo_identity
+from navegador.vcs import normalize_remote_url
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("repo-identity") / "graph.db"))
+    yield s
+    s.close()
+
+
+def git(*args, cwd):
+    return subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def make_repo(root, remote="git@github.com:ExampleOrg/myproj.git"):
+    root.mkdir(parents=True, exist_ok=True)
+    git("init", "-q", "-b", "main", ".", cwd=root)
+    if remote:
+        git("remote", "add", "origin", remote, cwd=root)
+    (root / "a.py").write_text("def alpha():\n    return 1\n", encoding="utf-8")
+    git("add", "-A", cwd=root)
+    git("commit", "-qm", "init", cwd=root)
+    return root
+
+
+def repositories(store):
+    rows = store.query("MATCH (r:Repository) RETURN r.path, r.name ORDER BY r.path").result_set
+    return [(r[0], r[1]) for r in rows or []]
+
+
+# ── URL normalization ──────────────────────────────────────────────────────
+
+
+class TestNormalizeRemoteUrl:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "git@github.com:ExampleOrg/myproj.git",
+            "https://github.com/ExampleOrg/myproj.git",
+            "https://github.com/ExampleOrg/myproj",
+            "ssh://git@github.com:22/ExampleOrg/myproj",
+            "https://github.com/ExampleOrg/myproj/",
+        ],
+    )
+    def test_hosted_forms_agree(self, url):
+        """An ssh clone and an https clone are the same repository."""
+        assert normalize_remote_url(url) == "ExampleOrg/myproj"
+
+    @pytest.mark.parametrize("url", ["/srv/git/myproj", "../myproj", "file:///srv/git/myproj.git"])
+    def test_filesystem_remotes_reduce_to_the_name(self, url):
+        """There is no owner in a local path, so owner/repo would be noise."""
+        assert normalize_remote_url(url) == "myproj"
+
+    @pytest.mark.parametrize("url", ["", "   ", "/", "///"])
+    def test_unusable_input_yields_nothing(self, url):
+        assert normalize_remote_url(url) == ""
+
+    def test_host_is_not_part_of_identity(self):
+        a = normalize_remote_url("git@gitlab.com:ExampleOrg/myproj.git")
+        b = normalize_remote_url("https://github.com/ExampleOrg/myproj.git")
+        assert a == b == "ExampleOrg/myproj"
+
+
+# ── Identity derivation ────────────────────────────────────────────────────
+
+
+class TestRepoIdentity:
+    def test_uses_the_remote(self, tmp_path):
+        repo = make_repo(tmp_path / "myproj")
+        assert repo_identity(repo) == "ExampleOrg/myproj"
+
+    def test_survives_a_renamed_directory(self, tmp_path):
+        repo = make_repo(tmp_path / "some-other-name")
+        assert repo_identity(repo) == "ExampleOrg/myproj"
+
+    def test_falls_back_to_directory_name_without_a_remote(self, tmp_path):
+        repo = make_repo(tmp_path / "standalone", remote="")
+        assert repo_identity(repo) == "standalone"
+
+    def test_falls_back_outside_a_git_repo(self, tmp_path):
+        plain = tmp_path / "not-a-repo"
+        plain.mkdir()
+        assert repo_identity(plain) == "not-a-repo"
+
+    def test_display_name_strips_the_owner(self):
+        assert repo_display_name("ExampleOrg/myproj") == "myproj"
+        assert repo_display_name("myproj") == "myproj"
+        assert repo_display_name("") == ""
+
+
+# ── The reported scenario ──────────────────────────────────────────────────
+
+
+class TestPhantomRepositories:
+    def test_renamed_clone_does_not_add_a_repository(self, store, tmp_path):
+        """Two checkouts of one repository must remain one Repository node."""
+        original = make_repo(tmp_path / "myproj")
+        renamed = make_repo(tmp_path / "myproj-clone-renamed")
+
+        ing = RepoIngester(store)
+        ing.ingest(original)
+        assert len(repositories(store)) == 1
+        ing.ingest(renamed)
+        assert len(repositories(store)) == 1
+
+    def test_display_name_is_not_clobbered_by_the_directory(self, store, tmp_path):
+        """
+        `name` used to come from the directory even when `path` was pinned, so
+        the last ingest silently renamed the correct node.
+        """
+        original = make_repo(tmp_path / "myproj")
+        renamed = make_repo(tmp_path / "myproj-X.untFWa")
+
+        ing = RepoIngester(store)
+        ing.ingest(original)
+        ing.ingest(renamed)
+        assert repositories(store) == [("ExampleOrg/myproj", "myproj")]
+
+    def test_files_belong_to_exactly_one_repository(self, store, tmp_path):
+        original = make_repo(tmp_path / "myproj")
+        renamed = make_repo(tmp_path / "myproj-clone-renamed")
+
+        ing = RepoIngester(store)
+        ing.ingest(original)
+        ing.ingest(renamed)
+
+        rows = store.query(
+            "MATCH (f:File)-[:BELONGS_TO]->(r:Repository) RETURN f.path, count(r) ORDER BY f.path"
+        ).result_set
+        assert all(row[1] == 1 for row in rows or []), "a file is owned by several repo nodes"
+
+    def test_distinct_repositories_stay_distinct(self, store, tmp_path):
+        first = make_repo(tmp_path / "one", remote="git@github.com:ExampleOrg/one.git")
+        second = make_repo(tmp_path / "two", remote="git@github.com:ExampleOrg/two.git")
+
+        ing = RepoIngester(store)
+        ing.ingest(first)
+        ing.ingest(second)
+        assert len(repositories(store)) == 2
+
+    def test_explicit_repo_key_still_wins(self, store, tmp_path):
+        repo = make_repo(tmp_path / "myproj")
+        RepoIngester(store).ingest(repo, repo_key="libs/core")
+        assert repositories(store) == [("libs/core", "core")]

--- a/tests/test_testmap_precision.py
+++ b/tests/test_testmap_precision.py
@@ -1,0 +1,236 @@
+# Copyright CONFLICT LLC 2026 (weareconflict.com)
+"""
+Regression tests for #166 — testmap must not invent cross-repository TESTS edges.
+
+The heuristic stripped ``test_``, tried ever-shorter prefixes, and took the
+first symbol with that name *anywhere in the graph*. In a federated graph
+``test_request_returns_200`` degraded to the candidate ``request`` and linked to
+an unrelated repository's method with full confidence.
+
+A wrong TESTS edge is worse than a missing one: impact and context queries cite
+it confidently, so users stop trusting the graph.
+"""
+
+import pytest
+
+from navegador.analysis.testmap import (
+    GENERIC_NAMES,
+    _is_test_path,
+    _shared_prefix_depth,
+)
+
+# Aliased: pytest tries to collect any class named Test* found in a test module.
+from navegador.analysis.testmap import TestMapper as Mapper
+from navegador.graph.store import GraphStore
+
+
+@pytest.fixture()
+def store(tmp_path_factory):
+    s = GraphStore.sqlite(str(tmp_path_factory.mktemp("testmap") / "graph.db"))
+    yield s
+    s.close()
+
+
+def add_file(store, path, repo):
+    store.query(
+        "MERGE (f:File {path: $p}) SET f.name = $p "
+        "MERGE (r:Repository {path: $repo}) SET r.name = $repo "
+        "MERGE (f)-[:BELONGS_TO]->(r)",
+        {"p": path, "repo": repo},
+    )
+
+
+def add_symbol(store, name, path, repo, label="Function"):
+    add_file(store, path, repo)
+    store.query(
+        f"MERGE (n:{label} {{name: $n, file_path: $p}})",
+        {"n": name, "p": path},
+    )
+
+
+def links_for(result, test_name):
+    return [lnk for lnk in result.links if lnk.test_name == test_name]
+
+
+# ── The reported collision ─────────────────────────────────────────────────
+
+
+class TestCrossRepositoryCollisions:
+    @pytest.fixture(autouse=True)
+    def fixture(self, store):
+        """Three repositories sharing generic verb names."""
+        # Repository A — production methods with generic names
+        for name in ("request", "update", "delete", "publish", "resolve"):
+            add_symbol(store, name, f"repo_a/service/{name}.py", "org/repo-a")
+        # Repository B — tests exercising unrelated modules
+        add_symbol(
+            store, "test_request_returns_200", "repo_b/tests/test_api.py", "org/repo-b"
+        )
+        add_symbol(store, "test_publish_event", "repo_b/tests/test_bus.py", "org/repo-b")
+        # Repository C — shell/infra helpers with the same names
+        for name in ("request", "publish"):
+            add_symbol(store, name, f"repo_c/scripts/{name}.sh", "org/repo-c")
+
+    def test_generic_name_does_not_link_across_repositories(self, store):
+        result = Mapper(store).map_tests()
+        for link in result.links:
+            assert link.prod_name not in GENERIC_NAMES or link.confidence >= 0.5
+
+    def test_no_edge_is_created_from_a_bare_generic_verb(self, store):
+        """`test_request_returns_200` must not attach to some other repo's `request`."""
+        result = Mapper(store).map_tests()
+        assert not links_for(result, "test_request_returns_200")
+
+    def test_unresolved_tests_are_reported_not_guessed(self, store):
+        result = Mapper(store).map_tests()
+        reported = {t["name"] for t in result.unmatched_tests} | {
+            a["test_name"] for a in result.ambiguous
+        }
+        assert "test_request_returns_200" in reported
+
+    def test_no_tests_edges_land_in_the_graph(self, store):
+        Mapper(store).map_tests()
+        rows = store.query("MATCH ()-[r:TESTS]->() RETURN count(r)").result_set
+        assert rows[0][0] == 0
+
+
+# ── What must still work ───────────────────────────────────────────────────
+
+
+class TestLegitimateMappingsSurvive:
+    def test_direct_call_evidence_is_taken(self, store):
+        add_symbol(store, "validate_token", "src/auth.py", "org/app")
+        add_symbol(store, "test_validate_token", "tests/test_auth.py", "org/app")
+        store.query(
+            "MATCH (t {name: 'test_validate_token'}), (p {name: 'validate_token'}) "
+            "MERGE (t)-[:CALLS]->(p)"
+        )
+        result = Mapper(store).map_tests()
+        assert links_for(result, "test_validate_token")[0].source == "calls"
+
+    def test_call_evidence_is_full_confidence(self, store):
+        add_symbol(store, "validate_token", "src/auth.py", "org/app")
+        add_symbol(store, "test_validate_token", "tests/test_auth.py", "org/app")
+        store.query(
+            "MATCH (t {name: 'test_validate_token'}), (p {name: 'validate_token'}) "
+            "MERGE (t)-[:CALLS]->(p)"
+        )
+        result = Mapper(store).map_tests()
+        assert links_for(result, "test_validate_token")[0].confidence == 1.0
+
+    def test_distinctive_name_in_the_same_repo_still_links(self, store):
+        add_symbol(store, "reconcile_ledger_entries", "src/ledger.py", "org/app")
+        add_symbol(
+            store, "test_reconcile_ledger_entries", "tests/test_ledger.py", "org/app"
+        )
+        result = Mapper(store).map_tests()
+        assert links_for(result, "test_reconcile_ledger_entries")
+
+    def test_heuristic_links_carry_evidence(self, store):
+        add_symbol(store, "reconcile_ledger_entries", "src/ledger.py", "org/app")
+        add_symbol(
+            store, "test_reconcile_ledger_entries", "tests/test_ledger.py", "org/app"
+        )
+        link = links_for(Mapper(store).map_tests(), "test_reconcile_ledger_entries")[0]
+        assert link.evidence
+        assert 0 < link.confidence <= 1.0
+
+    def test_edge_records_confidence_and_evidence(self, store):
+        add_symbol(store, "reconcile_ledger_entries", "src/ledger.py", "org/app")
+        add_symbol(
+            store, "test_reconcile_ledger_entries", "tests/test_ledger.py", "org/app"
+        )
+        Mapper(store).map_tests()
+        rows = store.query(
+            "MATCH ()-[r:TESTS]->() RETURN r.confidence, r.evidence"
+        ).result_set
+        assert rows and rows[0][0] is not None and rows[0][1]
+
+
+class TestTestCodeIsNotATarget:
+    def test_helper_in_a_test_module_is_never_the_target(self, store):
+        """Naming alone made a test-module helper a valid production match."""
+        add_symbol(store, "build_payload", "tests/helpers.py", "org/app")
+        add_symbol(store, "test_build_payload", "tests/test_api.py", "org/app")
+        result = Mapper(store).map_tests()
+        assert not links_for(result, "test_build_payload")
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/helpers.py",
+            "src/tests/util.py",
+            "spec/thing.rb",
+            "app/__tests__/util.js",
+            "src/thing_test.go",
+            "src/test_thing.py",
+            "src/thing.spec.ts",
+        ],
+    )
+    def test_test_paths_are_recognised(self, path):
+        assert _is_test_path(path)
+
+    @pytest.mark.parametrize(
+        "path", ["src/app.py", "lib/latest/thing.py", "contest/entry.py", ""]
+    )
+    def test_production_paths_are_not(self, path):
+        assert not _is_test_path(path)
+
+
+class TestAmbiguityIsReported:
+    def test_equally_plausible_candidates_produce_no_edge(self, store):
+        """Two identical-scoring targets: report, do not pick one at random."""
+        add_symbol(store, "reconcile_entries", "src/alpha/ledger.py", "org/app")
+        add_symbol(store, "reconcile_entries", "src/beta/ledger.py", "org/app")
+        add_symbol(store, "test_reconcile_entries", "tests/test_ledger.py", "org/app")
+
+        result = Mapper(store).map_tests()
+        assert not links_for(result, "test_reconcile_entries")
+        assert any(a["test_name"] == "test_reconcile_entries" for a in result.ambiguous)
+
+    def test_ambiguity_lists_the_candidates(self, store):
+        add_symbol(store, "reconcile_entries", "src/alpha/ledger.py", "org/app")
+        add_symbol(store, "reconcile_entries", "src/beta/ledger.py", "org/app")
+        add_symbol(store, "test_reconcile_entries", "tests/test_ledger.py", "org/app")
+
+        entry = [
+            a
+            for a in Mapper(store).map_tests().ambiguous
+            if a["test_name"] == "test_reconcile_entries"
+        ][0]
+        assert len(entry["candidates"]) >= 2
+
+
+class TestPathHelpers:
+    def test_shared_prefix_depth(self):
+        assert _shared_prefix_depth("src/app/api", "src/app/db") == 2
+        assert _shared_prefix_depth("src/app", "lib/app") == 0
+        assert _shared_prefix_depth("src", "src") == 1
+
+
+class TestConfidenceFloor:
+    def test_a_weak_cross_repo_match_is_below_the_floor(self, store):
+        """Distinctive enough to be a candidate, too weak to assert by default."""
+        add_symbol(store, "reconcile", "repo_a/service/ledger.py", "org/repo-a")
+        add_symbol(
+            store, "test_reconcile_entries", "repo_b/tests/test_ledger.py", "org/repo-b"
+        )
+
+        strict = Mapper(store).map_tests()
+        assert not links_for(strict, "test_reconcile_entries")
+
+        store.query("MATCH ()-[r:TESTS]->() DELETE r")
+        loose = Mapper(store).map_tests(min_confidence=0.0)
+        assert links_for(loose, "test_reconcile_entries")
+        assert links_for(loose, "test_reconcile_entries")[0].confidence < 0.5
+
+    def test_a_generic_verb_is_never_a_candidate_at_any_floor(self, store):
+        """
+        No confidence setting should resurrect `test_publish_event` → `publish`.
+        A bare generic verb carries no signal to weigh in the first place.
+        """
+        add_symbol(store, "publish", "repo_a/service/bus.py", "org/repo-a")
+        add_symbol(store, "test_publish_event", "repo_b/tests/test_bus.py", "org/repo-b")
+
+        result = Mapper(store).map_tests(min_confidence=0.0)
+        assert not links_for(result, "test_publish_event")


### PR DESCRIPTION
Eight issues, all of them about the graph telling the truth. Seven are cases where a query returned a confident answer that was wrong or empty, and the eighth opens the graph to the rest of the supergraph.

The common shape across the bugs: nothing was throwing. Every one of these reported success while producing a graph that quietly disagreed with the code on disk — which is worse than an error, because the answer still looks usable.

## Graph fidelity

**#173 — export/import dropped every edge and reported success.** Node ids came from array position, so an import re-derived different ids and every edge referenced an endpoint that did not exist. `create_edge` returned falsy; nothing checked it; the summary counted edges it had *described*. A round-trip of a 4,000-node graph restored 4,000 nodes and 0 edges — which reads as a repo with no call structure. Ids are now content-derived so they survive the round trip, the created count comes from the store, and a shortfall raises.

**#168 — incremental ingest never removed deleted files.** It compared mtimes to decide what to re-parse and had no branch at all for files that had gone. A renamed module left its old symbols in the graph indefinitely, and impact queries cited functions that no longer exist anywhere in the repository. The file set present on disk is now recorded before parse decisions, and the difference is pruned.

**#167 — repository identity was the checkout directory name.** So `git clone <url> myproj-review` produced a second, indistinguishable `Repository` node, and files ended up owned by every node they had been ingested under. Identity now comes from the normalized git remote — the only thing constant across a worktree, a renamed clone, and an ssh-vs-https checkout — with the directory name as the fallback outside a repo.

**#163 — Python call edges never crossed a file boundary.** `_extract_calls` recorded every callee as living in the *calling* file, so an imported function resolved to a node that does not exist and the edge was dropped. On a multi-package fixture the graph held the right symbols and zero `CALLS` edges: explain, trace, and impact stopped dead at each file and looked like code with no callers. Imports are now resolved to repo files (absolute, relative, function-local), and a callable passed to a higher-order helper is recorded as `REFERENCES` rather than lost.

Found while fixing it: `from x import y` produced no `Import` nodes at all, because the parser matched `import_from_member`, a node type that does not exist in the tree-sitter Python grammar. Both the module and its members are `dotted_name`.

**#166 — testmap invented confident cross-repository `TESTS` edges.** The heuristic stripped `test_`, tried ever-shorter prefixes, and took the first symbol with that name *anywhere in the graph*, so `test_request_returns_200` degraded to the candidate `request` and linked to an unrelated repository's method at full confidence. A wrong `TESTS` edge is worse than a missing one, because impact and context queries then cite it. Candidates are now scored on repository, path proximity, and name distinctiveness; generic verbs are never candidates at any threshold; test-module helpers are never targets; edges carry confidence and evidence; ties are reported as ambiguous rather than resolved by iteration order.

## LLM configuration

**#164 — `ask` ignored its configuration and reached for a model that no longer exists.** `[llm]` was written by `init` and read by nothing. Provider discovery required only that the SDK *import*, so Anthropic was selected whenever the package was installed, credentials or not, and the failure surfaced later as a raw auth error from inside the call. And the default model, `claude-3-5-haiku-20241022`, has 404'd since 2026-02-19 — every fallback path was calling a retired model. Config is now layered with provenance the same way storage is, availability means a usable credential, and the error names what each provider is missing.

**#165 — generated Cypher was not executable.** The NLP engine emitted `(n:Class|Function)`, which FalkorDB rejects: a node pattern takes exactly one label. Alternative *relationship* types are valid and are left alone. Node alternatives are rewritten to `WHERE (n:Class OR n:Function)`, and a query that still fails is retried once with the error fed back.

## Supergraph interoperability

**#158 — contract v1.0 conformance.** Navegador owns the `code` realm and is now addressable from every other graph as `[<repo>/]code:<path>[#<symbol>]`. Conformance is a mapping layer at the tool surface; internal ids, the store, and the schema are unchanged.

- `navegador contract resolve <address>` / the `resolve_address` MCP tool complete the brain-to-code hop. Over MCP the response carries the immediate neighbourhood, each neighbour with its own address, so a traversal that just crossed an `implemented_in` edge keeps moving without a second round trip.
- `navegador contract propose` / `propose_join_edges` emit contract-format proposals with confidence and evidence. Navegador writes nothing — the edge lives in the brain, so the brain decides. Brain-realm targets are dropped rather than given a code address we have no authority to mint.
- Responses that emit addresses declare `contract: "1.0"`, and `search_symbols` hits carry the address a brain would record to point back at them.

## Tests

Every fix has regression tests written against real embedded stores, real git repositories, and the real tree-sitter grammar. Several existing mocked tests were asserting the buggy behaviour and had to be rewritten — a `MagicMock` `create_edge` is always truthy, which is exactly why #173 went unnoticed, and one test matched a grammar node type that has never existed.

Closes #173, #168, #167, #166, #165, #164, #163, #158

Full suite: 3292 passed, run with `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` stripped so it matches CI. That mattered — `TestAutoProvider` had no environment control, so once availability meant credentials its results depended on which keys the machine exported, and two tests that pass on a developer laptop would have failed on CI. Each test now states its own environment.
