### PR TITLE
release: bump to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.5.0 — 2026-08-16
 
 ### Storage configuration
 

--- a/navegador/__init__.py
+++ b/navegador/__init__.py
@@ -2,7 +2,7 @@
 Navegador — AST + knowledge graph context engine for AI coding agents.
 """
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 __author__ = "CONFLICT LLC"
 
 from navegador.sdk import Navegador

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "navegador"
-version = "1.4.1"
+version = "1.5.0"
 description = "AST + knowledge graph context engine for AI coding agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for the 1.5.0 release: `pyproject.toml`, `navegador/__init__.py`, and the CHANGELOG `Unreleased` heading dated.

Two themes since 1.4.1:

- **Centralized native FalkorDB** (#175) — a self-installing server with no Docker, `[storage]` config actually read with layered provenance, verified migration off embedded graphs, and `doctor`/`scan` to see what is where.
- **Graph fidelity + supergraph interop** (#176) — eight issues where a query returned a confident answer that was wrong or empty, plus contract v1.0 conformance so the `code` realm is addressable from every other graph.

No code changes here beyond the three version strings.