### PR TITLE
1.6: ingest the right files, and answer the questions agents actually ask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # ripgrep is the oracle for the trigram differential test (#184), which
+      # is the strongest correctness evidence we have for lexical search: two
+      # implementations sharing no code, agreeing on real input. Without it
+      # installed those tests skip silently, and CI coverage came in a full
+      # point below local because of it.
+      #
+      # A CI test tool, not a package dependency — nothing a user installs.
+      - name: Install ripgrep
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y ripgrep
+          else
+            brew install ripgrep
+          fi
+        shell: bash
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,17 @@ jobs:
           fi
         shell: bash
 
+      # The optional grammars ship to users and, until now, no runner had them
+      # installed — so the HCL, Kotlin, Swift, PHP, C, C++, Ruby, Puppet and
+      # Bash parsers were never exercised in CI at all. Their tests skipped
+      # silently and 148 statements went uncovered, which is where the gap
+      # between local and CI coverage came from.
+      #
+      # Install what we ship, so CI tests what we ship.
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,languages,iac]"
 
       # --cov-fail-under reads the ratchet from pyproject so a local run
       # enforces the same bar as CI. Coverage was measured but never enforced

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      # --cov-fail-under reads the ratchet from pyproject so a local run
+      # enforces the same bar as CI. Coverage was measured but never enforced
+      # before this, which made the number decorative (#191).
       - name: Run tests
-        run: pytest tests/ -v --tb=short
+        run: pytest tests/ -v --tb=short --cov-report=term-missing
 
       - name: Check code style
         run: ruff check navegador/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Intelligence Layer: guide/intelligence.md
       - Python SDK: guide/sdk.md
       - Graph Queries: guide/graph-queries.md
+      - Targeting: guide/targeting.md
       - MCP Integration: guide/mcp-integration.md
       - Supergraph Contract: guide/supergraph-contract.md
       - CI/CD: guide/ci-cd.md
@@ -99,6 +100,7 @@ nav:
   - Architecture:
       - Overview: architecture/overview.md
       - Graph Schema: architecture/graph-schema.md
+      - Dependency Posture: architecture/dependencies.md
   - API Reference:
       - Python SDK: api/sdk.md
       - Ingestion: api/ingestion.md

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -4116,6 +4116,150 @@ def storage():
     """Inspect and move the graph data behind the [storage] configuration."""
 
 
+def _audit_reports(server_url: str, root: str):
+    """Audit every graph, checking against whatever checkouts we can find."""
+    from navegador.graph.audit import audit_server
+    from navegador.inventory import scan
+
+    roots = {}
+    for record in scan(root):
+        if record.effective and record.effective.graph_name:
+            roots[record.effective.graph_name] = record.root
+    return audit_server(server_url, roots)
+
+
+def _resolve_server_url(db: str) -> str:
+    from navegador.config import resolve_storage
+
+    storage_config = resolve_storage(db or None)
+    if not storage_config.is_redis:
+        raise click.ClickException(
+            "This inspects a shared server; the resolved backend is "
+            f"{storage_config.describe()}. Pass --db redis://... or configure [storage]."
+        )
+    return storage_config.redis_url
+
+
+@storage.command("audit")
+@click.option("--db", default="", help="Server to inspect. Default: resolved storage.")
+@click.option(
+    "--root",
+    default=str(Path.home() / "repos"),
+    type=click.Path(),
+    help="Tree searched for the checkouts a graph is checked against. A graph "
+    "with no checkout here is reported 'unknown', never assumed stale.",
+)
+@click.option("--json", "as_json", is_flag=True)
+def storage_audit(db: str, root: str, as_json: bool):
+    """
+    Report graphs that have stopped describing anything real.
+
+    Four verdicts matter: 'junk' (a name we would not have written), 'empty',
+    'stale' (its file paths no longer exist on disk) and 'duplicate' (another
+    graph covers the same repository). Nothing is deleted here.
+    """
+    server_url = _resolve_server_url(db)
+    reports = _audit_reports(server_url, root)
+
+    if as_json:
+        click.echo(json.dumps([r.to_dict() for r in reports], indent=2))
+        return
+
+    table = Table(title=f"Graph audit — {server_url}")
+    # Graph names are long and the interesting columns are the narrow ones, so
+    # the name truncates rather than squeezing everything else to ellipses.
+    table.add_column("Graph", style="cyan", max_width=42, overflow="ellipsis", no_wrap=True)
+    table.add_column("Verdict", width=9)
+    table.add_column("Nodes", justify="right", width=9)
+    table.add_column("Size", justify="right", width=9)
+    table.add_column("Why", style="dim", overflow="fold")
+    colours = {
+        "healthy": "green",
+        "stale": "red",
+        "junk": "red",
+        "empty": "yellow",
+        "duplicate": "yellow",
+        "unknown": "dim",
+    }
+    for report in sorted(reports, key=lambda r: -r.size_bytes):
+        verdict = report.verdict
+        table.add_row(
+            report.name,
+            f"[{colours[verdict]}]{verdict}[/{colours[verdict]}]",
+            f"{report.nodes:,}",
+            f"{report.size_bytes / 1048576:.1f} MB",
+            report.explain(),
+        )
+    console.print(table)
+
+    reclaimable = [r for r in reports if r.reclaimable]
+    if reclaimable:
+        total = sum(r.size_bytes for r in reclaimable) / 1048576
+        console.print(
+            f"\n[yellow]{len(reclaimable)} graph(s) reclaimable, {total:.1f} MB[/yellow] — "
+            "run [bold]navegador storage prune[/bold] to see what would go."
+        )
+
+
+@storage.command("prune")
+@click.option("--db", default="", help="Server to prune. Default: resolved storage.")
+@click.option("--root", default=str(Path.home() / "repos"), type=click.Path())
+@click.option(
+    "--include-stale",
+    is_flag=True,
+    help="Also delete graphs whose files no longer exist. Off by default: a "
+    "moved checkout and a deleted one look identical from here, and one of "
+    "those is recoverable by re-ingesting while the other is not.",
+)
+@click.option("--yes", is_flag=True, help="Actually delete. Without it, this is a dry run.")
+@click.option("--json", "as_json", is_flag=True)
+def storage_prune(db: str, root: str, include_stale: bool, yes: bool, as_json: bool):
+    """Delete junk and empty graphs. Dry run unless --yes is given."""
+    from navegador.graph.audit import prune as prune_graphs
+
+    server_url = _resolve_server_url(db)
+    reports = _audit_reports(server_url, root)
+    doomed = [
+        r
+        for r in reports
+        if r.verdict in {"junk", "empty"} or (include_stale and r.verdict == "stale")
+    ]
+
+    if not doomed:
+        if as_json:
+            click.echo(json.dumps({"removed": [], "dry_run": not yes}, indent=2))
+        else:
+            console.print("[green]Nothing to prune.[/green]")
+        return
+
+    reclaimed = sum(r.size_bytes for r in doomed) / 1048576
+    if not yes:
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {"would_remove": [r.to_dict() for r in doomed], "dry_run": True}, indent=2
+                )
+            )
+            return
+        console.print(f"[bold]Would delete {len(doomed)} graph(s), {reclaimed:.1f} MB:[/bold]")
+        for report in sorted(doomed, key=lambda r: -r.size_bytes):
+            console.print(f"  {report.name}  [dim]{report.explain()}[/dim]")
+        stale_held = [r for r in reports if r.verdict == "stale" and not include_stale]
+        if stale_held:
+            console.print(
+                f"\n[dim]{len(stale_held)} stale graph(s) held back; "
+                "--include-stale to delete them too.[/dim]"
+            )
+        console.print("\nRe-run with [bold]--yes[/bold] to delete.")
+        return
+
+    removed = prune_graphs(server_url, doomed, include_stale=include_stale)
+    if as_json:
+        click.echo(json.dumps({"removed": removed, "dry_run": False}, indent=2))
+    else:
+        console.print(f"[green]Deleted {len(removed)} graph(s), {reclaimed:.1f} MB.[/green]")
+
+
 @storage.command("migrate")
 @click.option("--target", default=".", type=click.Path(), help="Project to migrate.")
 @click.option("--to", "dest_url", default="", help="Destination server URL.")

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -6,15 +6,18 @@ Navegador CLI — the single interface to your project's knowledge graph.
   UNIVERSAL: explain, search (spans both layers), stats
 """
 
-import asyncio
 import json
 import logging
 from pathlib import Path
 
 import click
 from rich.console import Console
-from rich.markdown import Markdown
 from rich.table import Table
+
+# asyncio and rich.markdown are imported where they are used, not here. They
+# cost ~95ms of the ~137ms it took to import this module, and every CLI
+# invocation paid it — including the agent hooks, which shell out per call
+# (#190). Only the MCP server needs asyncio; only `manual` renders markdown.
 
 console = Console()
 # Progress narration goes to stderr so that --json output on stdout stays
@@ -1835,6 +1838,8 @@ def mcp(db: str, read_only: bool, federate: tuple[str, ...]):
     mode = "read-only" if read_only else "read-write"
     federated = f", federated over {len(federate)} repos" if federate else ""
     console.print(f"[green]Navegador MCP server running[/green] (stdio, {mode}{federated})")
+
+    import asyncio
 
     async def _run():
         async with stdio_server() as (read_stream, write_stream):
@@ -4619,6 +4624,8 @@ def manual(page: str, query: str, list_only: bool, raw: bool, as_json: bool):
             elif raw:
                 click.echo(doc.read())
             else:
+                from rich.markdown import Markdown
+
                 console.print(Markdown(doc.read()))
             return
 

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -4126,6 +4126,91 @@ def storage():
     """Inspect and move the graph data behind the [storage] configuration."""
 
 
+@main.command("locate")
+@click.argument("intent")
+@click.option("--db", default="", help="Graph to search. Default: resolved storage.")
+@click.option("--target", default=".", type=click.Path())
+@click.option("-n", "--limit", default=10)
+@click.option("--json", "as_json", is_flag=True)
+def locate(intent: str, db: str, target: str, limit: int, as_json: bool):
+    """
+    Where to look for INTENT, ranked, with the reason for each place.
+
+    Returns places to look, not an answer. Exact text matches, symbol names,
+    documents and semantic similarity are fused on rank, so the top result is
+    where several kinds of evidence agree.
+    """
+    from navegador.targeting import Targeting
+
+    store = _get_store(db, target=target)
+    candidates = Targeting(store).locate(intent, limit=limit)
+
+    if as_json:
+        click.echo(json.dumps([c.to_dict() for c in candidates], indent=2))
+        return
+    if not candidates:
+        console.print("[dim]Nothing found. Has this repository been ingested?[/dim]")
+        return
+
+    table = Table(title=f"Where to look — {intent}")
+    table.add_column("Where", style="cyan", overflow="fold")
+    table.add_column("Score", justify="right", width=7)
+    table.add_column("Why", style="dim", overflow="fold")
+    for candidate in candidates:
+        where = candidate.path + (f":{candidate.line}" if candidate.line else "")
+        table.add_row(where, f"{candidate.score:.4f}", "; ".join(candidate.reasons)[:90])
+    console.print(table)
+
+
+@main.command("scope")
+@click.argument("symbol")
+@click.option("--db", default="", help="Graph to search. Default: resolved storage.")
+@click.option("--target", default=".", type=click.Path())
+@click.option("--depth", default=2, help="How far to follow calls, references and imports.")
+@click.option("--pattern", default="", help="Search within the scope instead of listing it.")
+@click.option("-n", "--limit", default=50)
+@click.option("--json", "as_json", is_flag=True)
+def scope(symbol: str, db: str, target: str, depth: int, pattern: str, limit: int, as_json: bool):
+    """
+    Files reachable from SYMBOL — the set worth searching.
+
+    With --pattern, searches only those files. This is the reduction a flat
+    text index cannot compute: it follows calls, references and imports.
+    """
+    from navegador.targeting import Targeting
+
+    store = _get_store(db, target=target)
+    targeting = Targeting(store)
+    paths = targeting.scope_for(symbol, depth=depth)
+
+    if pattern:
+        matches = targeting.search_within(symbol, pattern, depth=depth, limit=limit)
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {"symbol": symbol, "files": paths, "matches": [m.to_dict() for m in matches]},
+                    indent=2,
+                )
+            )
+            return
+        console.print(f"[dim]{len(paths)} file(s) in scope[/dim]")
+        for match in matches:
+            console.print(
+                f"[cyan]{match.path}[/cyan]:[green]{match.line}[/green]: {match.text.strip()}"
+            )
+        return
+
+    if as_json:
+        click.echo(json.dumps({"symbol": symbol, "files": paths}, indent=2))
+        return
+    if not paths:
+        console.print(f"[dim]No scope found for {symbol}.[/dim]")
+        return
+    console.print(f"[bold]{len(paths)} file(s) reachable from {symbol}:[/bold]")
+    for path in paths:
+        console.print(f"  {path}")
+
+
 @main.command("grep")
 @click.argument("pattern")
 @click.option("--db", default="", help="Graph to search. Default: resolved storage.")

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -257,6 +257,14 @@ def init(
     "paths or single path components; a repo-root .navignore is honored too.",
 )
 @click.option(
+    "--no-content",
+    "no_content",
+    is_flag=True,
+    help="Do not keep file text in the content store. Content is addressed by "
+    "hash, so unchanged files and vendored copies cost nothing to keep — but "
+    "without it lexical search has no corpus to match against.",
+)
+@click.option(
     "--no-gitignore",
     "no_gitignore",
     is_flag=True,
@@ -277,6 +285,7 @@ def ingest(
     monorepo: bool,
     repo_key: str,
     excludes: tuple[str, ...],
+    no_content: bool,
     no_gitignore: bool,
 ):
     """Ingest a repository's code into the graph (AST + call graph)."""
@@ -308,6 +317,7 @@ def ingest(
         redact=redact,
         exclude=list(excludes),
         respect_gitignore=not no_gitignore,
+        store_content=not no_content,
     )
 
     if watch:

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -253,6 +253,15 @@ def init(
     help="Exclude paths matching GLOB (repeatable). Matches repo-relative "
     "paths or single path components; a repo-root .navignore is honored too.",
 )
+@click.option(
+    "--no-gitignore",
+    "no_gitignore",
+    is_flag=True,
+    help="Index files git ignores. By default a git checkout contributes only "
+    "the files git tracks or would show as untracked, which is the same set "
+    "ripgrep walks — without this, build output lands in the graph and agents "
+    "are handed generated code as if it were source.",
+)
 def ingest(
     repo_path: str,
     db: str,
@@ -265,6 +274,7 @@ def ingest(
     monorepo: bool,
     repo_key: str,
     excludes: tuple[str, ...],
+    no_gitignore: bool,
 ):
     """Ingest a repository's code into the graph (AST + call graph)."""
     if monorepo:
@@ -290,7 +300,12 @@ def ingest(
     from navegador.ingestion import RepoIngester
 
     store = _get_store(db, target=repo_path)
-    ingester = RepoIngester(store, redact=redact, exclude=list(excludes))
+    ingester = RepoIngester(
+        store,
+        redact=redact,
+        exclude=list(excludes),
+        respect_gitignore=not no_gitignore,
+    )
 
     if watch:
         console.print(f"[bold]Watching[/bold] {repo_path} (interval={interval}s, Ctrl-C to stop)")

--- a/navegador/cli/commands.py
+++ b/navegador/cli/commands.py
@@ -4126,6 +4126,59 @@ def storage():
     """Inspect and move the graph data behind the [storage] configuration."""
 
 
+@main.command("grep")
+@click.argument("pattern")
+@click.option("--db", default="", help="Graph to search. Default: resolved storage.")
+@click.option("--target", default=".", type=click.Path(), help="Project the graph belongs to.")
+@click.option("-e", "--regex", is_flag=True, help="Treat PATTERN as a regular expression.")
+@click.option("-i", "--ignore-case", is_flag=True)
+@click.option("-n", "--limit", default=100, help="Maximum matches.")
+@click.option(
+    "--reindex", is_flag=True, help="Index any stored content not yet in the trigram index."
+)
+@click.option("--json", "as_json", is_flag=True)
+def grep(
+    pattern: str,
+    db: str,
+    target: str,
+    regex: bool,
+    ignore_case: bool,
+    limit: int,
+    reindex: bool,
+    as_json: bool,
+):
+    """
+    Exact substring or regex search over indexed content.
+
+    Trigrams narrow the candidate set inside the database and the real pattern
+    then matches against stored text, so results are exact — verified against
+    ripgrep on this package's own source. Cost scales with the number of
+    matches rather than the size of the corpus, so a miss is nearly free.
+    """
+    from navegador.graph.trigram import TrigramIndex
+
+    store = _get_store(db, target=target)
+    index = TrigramIndex(store)
+    if reindex:
+        index.index_graph()
+
+    matches = index.search(pattern, is_regex=regex, limit=limit, ignore_case=ignore_case)
+
+    if as_json:
+        click.echo(json.dumps([m.to_dict() for m in matches], indent=2))
+        return
+
+    if not matches:
+        console.print(
+            "[dim]No matches. If content has not been indexed yet, run with --reindex.[/dim]"
+        )
+        return
+    for match in matches:
+        console.print(
+            f"[cyan]{match.path}[/cyan]:[green]{match.line}[/green]: {match.text.strip()}"
+        )
+
+
 def _audit_reports(server_url: str, root: str):
     """Audit every graph, checking against whatever checkouts we can find."""
     from navegador.graph.audit import audit_server

--- a/navegador/docs/architecture/dependencies.md
+++ b/navegador/docs/architecture/dependencies.md
@@ -1,0 +1,71 @@
+# Dependency posture
+
+**`pip install navegador` is the whole installation.**
+
+Navegador must not require you to install, pin, audit and track a collection of
+other open-source tools. Every capability either works with what is already in
+the box, or degrades gracefully when an optional input is absent.
+
+## Why
+
+The tool exists to reduce the work of understanding a system. A context engine
+that itself demands seven external binaries — each with its own release
+cadence, provenance story and supply-chain exposure — has moved that cost
+rather than removed it.
+
+Lightness is a feature, not an accident of being early.
+
+## What this rules in
+
+Capabilities built on what is already present cost nothing new and are
+preferred:
+
+| capability | built on |
+|---|---|
+| vector search | FalkorDB's native vector index |
+| full-text search | FalkorDB's full-text index |
+| trigram search | Redis sets, on the server already running |
+| content store | stdlib `zlib` |
+| parsing | tree-sitter grammars, already the parsing layer |
+
+Notably, the vector and full-text indexes were sitting unused on the server for
+some time before anything queried them. Checking what the platform already does
+is the first step, not the last resort.
+
+## What this rules out
+
+**Embedded language servers.** Thirteen languages means thirteen runtimes, each
+stateful, slow to warm and often measured in gigabytes of memory. That directly
+contradicts being a compact shared index. An LSP is also workspace-scoped, with
+no concept of the many sibling repositories that are the interesting case.
+
+**Shelling out to external search binaries.** No Zoekt, no ripgrep as a
+load-bearing component. The trigram index is built in-house specifically
+because integrating a battle-tested Go binary would mean shipping a Go binary.
+
+That decision is worth being explicit about, since "just use the existing tool"
+is usually right: the build cost of a trigram index is real and unchanged, but
+the dependency cost is what tipped it.
+
+**Anything that turns an optional capability into a hard requirement.**
+
+## The optional-input pattern
+
+Where an external artifact genuinely adds value, consume it if present and
+degrade if not — never generate it, never require it.
+
+Precise call edges are the reference case. A SCIP or LSIF index gives
+compiler-grade name resolution that tree-sitter cannot, and if one exists
+navegador should use it. But navegador will not invoke an indexer, vendor one,
+or add one to its dependencies. If you want precise edges, you generate the
+index with your own toolchain, on your own terms; without it, edges fall back
+to import heuristics and are marked `inferred` so the difference is visible.
+
+## Applying it
+
+The review question on any new work: **does this add something the user has to
+track?**
+
+If yes, it needs an explicit justification or an optional-input design. If a
+feature can only be built by taking on a dependency, that is a real trade to
+discuss — not a detail to slip into `pyproject.toml`.

--- a/navegador/docs/guide/targeting.md
+++ b/navegador/docs/guide/targeting.md
@@ -1,0 +1,143 @@
+# Targeting
+
+Navegador's job for an agent is not to answer questions about your code. It is
+to say **where to look**, so the agent stops searching and starts reading.
+
+## Why this shape
+
+Grep is not the problem. Once an agent knows where to point it, grep is fast
+and precise. Telemetry across 151 real agent sessions and 25 projects found
+that agents already scope **96.5%** of their searches to a named file, an
+explicit file list, or a subdirectory. Only 3.4% sweep a whole tree.
+
+What costs is the turns spent working out *where*:
+
+| | median |
+|---|---:|
+| tool calls per session | 206 |
+| filesystem reads per session | 35 |
+| turns before touching the file that gets edited | 13 |
+| reads that re-open a file already read this session | 32% |
+
+Each of those turns is inference latency and context window. So the unit of
+waste is a turn, not a byte, and these tools are built to reduce turns.
+
+They return places and reasons. They never synthesise an answer — being handed
+six files and told why beats being handed a paragraph you have to trust.
+
+## `locate` — where should I look?
+
+```bash
+navegador locate "rate limiting"
+```
+
+Ranked candidates, each stating why it surfaced. Four sources are queried
+independently and fused:
+
+| source | what it contributes |
+|---|---|
+| exact | the literal appears at this line |
+| symbol | a function, method or class with a matching name |
+| prose | this file's comments, string literals or identifiers are about it |
+| vector | semantically similar, when an LLM provider is configured |
+
+Fusion is by **reciprocal rank**, not by adding scores — a trigram hit, a
+cosine distance and a graph traversal are not on comparable scales. Each source
+votes by position, so a place two sources agree on outranks one that only the
+strongest source found.
+
+A source that is unavailable contributes nothing and the rest still answer.
+
+## `scope` — what is worth searching?
+
+```bash
+navegador scope validate_token
+navegador scope validate_token --pattern "token"
+```
+
+The set of files reachable from a symbol through calls, references and imports.
+
+**This is the reduction no flat text index can compute.** A text index finds
+every file that mentions "token"; the graph knows which files are actually
+connected to the one you are changing. On this repository,
+`scope required_trigrams` returns 2 files out of 264.
+
+With `--pattern`, the search runs only inside that scope. An unknown symbol
+returns nothing rather than falling back to the whole repository — silently
+widening would make every scoped search a full search.
+
+Hand the file list to any tool you like:
+
+```bash
+rg "token" $(navegador scope validate_token --json | jq -r '.files[]')
+```
+
+## `grep` — exact text, cheaply
+
+```bash
+navegador grep "token expired"
+navegador grep "def _\w+_store" --regex
+```
+
+Substring and regular-expression search over indexed content, returning file,
+line number and the matching line.
+
+Results are **exact**. Trigrams choose which files to look at; the real pattern
+is then matched against stored text, so the index may over-select but never
+under-select. This is verified by a differential test against ripgrep on
+navegador's own source — eight patterns including regexes, zero disagreements.
+
+The property that matters is how cost scales. Measured on a 263-file corpus
+against warm ripgrep:
+
+| pattern | candidate files | navegador | ripgrep |
+|---|---:|---:|---:|
+| `content_hash` | 16 | 7.2 ms | 11.5 ms |
+| `GRAPH.LIST` | 4 | 1.9 ms | 12.6 ms |
+| `queryNodes` | 1 | 1.0 ms | 12.2 ms |
+| no match | 0 | **0.1 ms** | 13.2 ms |
+
+Navegador's cost scales with the number of matches; grep's scales with the size
+of the corpus. A search that finds nothing is nearly free, where grep pays a
+full scan every time.
+
+## `neighbourhood` — what surrounds this?
+
+```bash
+navegador explain validate_token
+```
+
+Callers, callees, tests and defining file in one call — what would otherwise
+take several turns to assemble.
+
+Call edges carry a `resolution` property:
+
+- `inferred` — matched by import heuristics. tree-sitter is syntax only: it has
+  no name resolution and no types, so `foo.bar()` cannot be proven to reach
+  `Baz.bar`. Usually right, not guaranteed.
+- `resolved` — reserved for compiler-accurate edges.
+
+A uniformly confident graph cannot tell you which parts to trust. This one can.
+
+## Over MCP
+
+Agents get the same surface as tools: `locate`, `scope_for`, `neighbourhood`
+and `grep_code`. All read-only.
+
+`scope_for` accepts an optional `pattern`, so an agent can narrow and search in
+a single call rather than two round trips.
+
+## Requirements
+
+Targeting needs content stored at ingest time, which is the default:
+
+```bash
+navegador ingest .            # stores content and prose
+navegador ingest . --no-content   # opts out; grep and locate lose their corpus
+```
+
+Content is addressed by hash, so unchanged files and vendored copies cost
+nothing to keep, and re-ingesting an unchanged repository stores zero blobs.
+
+If a repository was ingested before content storage existed, re-ingest it —
+`navegador grep` will say so when it finds no corpus.

--- a/navegador/graph/audit.py
+++ b/navegador/graph/audit.py
@@ -1,0 +1,253 @@
+"""
+Find graphs on a shared server that have stopped describing anything real.
+
+Once every project shares one server (1.5.0), the graph list accumulates and
+nothing notices when an entry goes bad. An audit of a live server holding 41
+graphs found all three failure modes at once: a 47 MB graph whose 15,291 file
+paths had **none** still resolving on disk, the same repository indexed under
+three different names, and nine empty graphs named ``1)`` through ``9)`` left
+behind by shell output being fed back in as arguments.
+
+None of these break a query. They quietly answer the wrong question, or waste
+memory that a shared server is supposed to be conserving (#181).
+
+A graph is only judged where there is ground truth: resolution is measured
+against a checkout on disk, and a graph with no known checkout is reported as
+``unknown`` rather than guessed at. Nothing is deleted without being named
+first.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# A graph name we would never have written. `1)` and `telemetry{9)}` come from
+# redis-cli's numbered list output being pasted back in as an argument.
+JUNK_NAME = re.compile(r"^\d+\)$|[)\}\{]|^\s*$")
+
+# Below this share of file paths resolving on disk, the graph is describing a
+# checkout that no longer exists. Not zero: a little drift is normal as files
+# are deleted between ingests, and calling that stale would be false alarm.
+STALE_RESOLUTION = 0.05
+
+# An empty falkordblite snapshot is a few hundred bytes.
+EMPTY_NODES = 0
+
+
+@dataclass
+class GraphAudit:
+    """One graph on the server and what is wrong with it, if anything."""
+
+    name: str
+    nodes: int = 0
+    edges: int = 0
+    size_bytes: int = 0
+    files_total: int = 0
+    files_resolved: int = 0
+    root: Path | None = None
+    repositories: list[str] = field(default_factory=list)
+    duplicate_of: str | None = None
+
+    @property
+    def resolution(self) -> float | None:
+        """Share of file paths that still exist, or None without a checkout."""
+        if self.root is None or self.files_total == 0:
+            return None
+        return self.files_resolved / self.files_total
+
+    @property
+    def verdict(self) -> str:
+        if JUNK_NAME.search(self.name):
+            return "junk"
+        if self.nodes <= EMPTY_NODES:
+            return "empty"
+        if self.duplicate_of:
+            return "duplicate"
+        share = self.resolution
+        if share is None:
+            return "unknown"
+        if share <= STALE_RESOLUTION:
+            return "stale"
+        return "healthy"
+
+    @property
+    def reclaimable(self) -> bool:
+        """Safe to delete without losing anything a re-ingest could not rebuild."""
+        return self.verdict in {"junk", "empty", "stale"}
+
+    def explain(self) -> str:
+        if self.verdict == "junk":
+            return "name is not one we would have written; likely shell output fed back in"
+        if self.verdict == "empty":
+            return "no nodes"
+        if self.verdict == "duplicate":
+            return f"same repository as {self.duplicate_of}"
+        if self.verdict == "stale":
+            resolved = f"{self.files_resolved}/{self.files_total}"
+            return f"only {resolved} file paths still exist on disk"
+        if self.verdict == "unknown":
+            return "no checkout found to check against"
+        return "ok"
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "verdict": self.verdict,
+            "explanation": self.explain(),
+            "nodes": self.nodes,
+            "edges": self.edges,
+            "size_bytes": self.size_bytes,
+            "files_total": self.files_total,
+            "files_resolved": self.files_resolved,
+            "resolution": self.resolution,
+            "root": str(self.root) if self.root else None,
+            "duplicate_of": self.duplicate_of,
+            "reclaimable": self.reclaimable,
+        }
+
+
+def graph_size_bytes(connection, name: str) -> int:
+    """
+    Byte length of the serialised graph.
+
+    ``MEMORY USAGE`` returns a useless 48 bytes for a graph key because Redis
+    cannot size a module type, so DUMP is the only honest measure available
+    without vendor-specific commands.
+    """
+    try:
+        blob = connection.dump(name)
+    except Exception:
+        return 0
+    return len(blob) if blob else 0
+
+
+def _counts(graph) -> tuple[int, int]:
+    nodes = graph.ro_query("MATCH (n) RETURN count(n)").result_set
+    edges = graph.ro_query("MATCH ()-[r]->() RETURN count(r)").result_set
+    return (
+        int(nodes[0][0]) if nodes else 0,
+        int(edges[0][0]) if edges else 0,
+    )
+
+
+def _file_paths(graph, limit: int) -> list[str]:
+    rows = graph.ro_query(f"MATCH (f:File) RETURN f.path LIMIT {int(limit)}").result_set
+    return [row[0] for row in (rows or []) if row and row[0]]
+
+
+def _repositories(graph) -> list[str]:
+    rows = graph.ro_query("MATCH (r:Repository) RETURN r.name").result_set
+    return sorted({row[0] for row in (rows or []) if row and row[0]})
+
+
+def audit_graph(
+    db,
+    connection,
+    name: str,
+    root: Path | None = None,
+    sample: int = 2000,
+) -> GraphAudit:
+    """
+    Inspect one graph, checking its file paths against *root* when given.
+
+    Only a sample of paths is checked: resolution is a ratio, and stat-ing
+    50,000 files to learn what 2,000 already say is a waste of a scan.
+    """
+    report = GraphAudit(name=name, root=root)
+    if JUNK_NAME.search(name):
+        # Do not query a junk key; it may not even be a graph.
+        report.size_bytes = graph_size_bytes(connection, name)
+        return report
+
+    graph = db.select_graph(name)
+    try:
+        report.nodes, report.edges = _counts(graph)
+    except Exception:
+        return report
+    report.size_bytes = graph_size_bytes(connection, name)
+    if report.nodes == 0:
+        return report
+
+    report.repositories = _repositories(graph)
+    if root is None:
+        return report
+
+    paths = _file_paths(graph, sample)
+    report.files_total = len(paths)
+    report.files_resolved = sum(1 for p in paths if (root / p).exists())
+    return report
+
+
+def mark_duplicates(reports: list[GraphAudit]) -> None:
+    """
+    Flag graphs describing a repository another graph already covers.
+
+    Reported, never merged: two graphs of one repository may differ by ingest
+    settings or age, and picking a winner is the operator's call. The larger
+    graph keeps its identity and the smaller is flagged.
+    """
+    by_repo: dict[str, GraphAudit] = {}
+    # Node count decides, name breaks ties, so the same server always yields
+    # the same answer rather than depending on dict ordering.
+    for report in sorted(reports, key=lambda r: (-r.nodes, r.name)):
+        if report.verdict in {"junk", "empty"} or not report.repositories:
+            continue
+        key = "|".join(report.repositories)
+        if key in by_repo:
+            report.duplicate_of = by_repo[key].name
+        else:
+            by_repo[key] = report
+
+
+def audit_server(url: str, roots: dict[str, Path] | None = None) -> list[GraphAudit]:
+    """
+    Audit every graph on the server at *url*.
+
+    *roots* maps graph name to the checkout it describes — normally built from
+    ``navegador scan``. A graph absent from the mapping is reported as
+    ``unknown`` rather than assumed stale, because a graph we cannot check is
+    not the same as a graph we know is wrong.
+    """
+    import falkordb
+    import redis as redis_lib
+
+    db = falkordb.FalkorDB.from_url(url)
+    connection = redis_lib.from_url(url)
+    roots = roots or {}
+
+    # GRAPH.LIST returns bytes on a connection that is not decoding responses,
+    # and str() on bytes yields "b'name'" — which matches no graph, so every
+    # lookup misses and every graph is reported empty. The connection stays
+    # undecoded because DUMP must return raw bytes to be measured.
+    names = [
+        n.decode() if isinstance(n, bytes) else str(n)
+        for n in connection.execute_command("GRAPH.LIST")
+    ]
+    reports = [audit_graph(db, connection, name, roots.get(name)) for name in sorted(names)]
+    mark_duplicates(reports)
+    return reports
+
+
+def prune(url: str, reports: list[GraphAudit], include_stale: bool = False) -> list[str]:
+    """
+    Delete the graphs named in *reports* that are safe to remove.
+
+    Junk and empty graphs go without ceremony. Stale ones only when asked
+    explicitly: "the checkout moved" and "the checkout is gone" look identical
+    from here, and one of those is recoverable by re-ingesting while the other
+    throws away the only copy.
+    """
+    import redis as redis_lib
+
+    connection = redis_lib.from_url(url)
+    removed = []
+    for report in reports:
+        if report.verdict in {"junk", "empty"} or (include_stale and report.verdict == "stale"):
+            try:
+                connection.delete(report.name)
+                removed.append(report.name)
+            except Exception:
+                continue
+    return removed

--- a/navegador/graph/audit.py
+++ b/navegador/graph/audit.py
@@ -230,7 +230,9 @@ def audit_server(url: str, roots: dict[str, Path] | None = None) -> list[GraphAu
     return reports
 
 
-def prune(url: str, reports: list[GraphAudit], include_stale: bool = False) -> list[str]:
+def prune(
+    target: str | object, reports: list[GraphAudit], include_stale: bool = False
+) -> list[str]:
     """
     Delete the graphs named in *reports* that are safe to remove.
 
@@ -238,10 +240,17 @@ def prune(url: str, reports: list[GraphAudit], include_stale: bool = False) -> l
     explicitly: "the checkout moved" and "the checkout is gone" look identical
     from here, and one of those is recoverable by re-ingesting while the other
     throws away the only copy.
-    """
-    import redis as redis_lib
 
-    connection = redis_lib.from_url(url)
+    *target* is a server URL or an existing Redis connection. Accepting a
+    connection is what lets this be tested against an embedded store, which is
+    a real Redis over a unix socket and has no ``redis://`` URL to pass.
+    """
+    if isinstance(target, str):
+        import redis as redis_lib
+
+        connection = redis_lib.from_url(target)
+    else:
+        connection = target
     removed = []
     for report in reports:
         if report.verdict in {"junk", "empty"} or (include_stale and report.verdict == "stale"):

--- a/navegador/graph/content.py
+++ b/navegador/graph/content.py
@@ -44,6 +44,33 @@ GRAPH_BLOBS = "nav:graph:{graph}:blobs"
 LEVEL = 6
 
 
+ZLIB = b"\x01"  # payload is zlib-compressed
+RAW = b"\x00"  # payload is stored as-is
+
+
+def _encode(text: str) -> bytes:
+    """
+    Compress, unless compressing makes it bigger.
+
+    zlib adds a header and a checksum, so on a short file the "compressed"
+    form is larger than the original — a 81-byte fixture came back as 93.
+    A one-byte tag says which form the payload is in, which costs less than
+    ever storing the worse of the two.
+    """
+    encoded = text.encode("utf-8")
+    squeezed = zlib.compress(encoded, LEVEL)
+    if len(squeezed) < len(encoded):
+        return ZLIB + squeezed
+    return RAW + encoded
+
+
+def _decode(blob: bytes) -> str:
+    tag, payload = blob[:1], blob[1:]
+    if tag == ZLIB:
+        payload = zlib.decompress(payload)
+    return payload.decode("utf-8", errors="replace")
+
+
 def _binary_connection(connection):
     """
     A sibling connection that does not decode responses.
@@ -115,7 +142,7 @@ class ContentStore:
         self._conn.sadd(GRAPH_BLOBS.format(graph=self._graph), sha)
         if self._conn.exists(key):
             return False
-        self._conn.set(key, zlib.compress(text.encode("utf-8"), LEVEL))
+        self._conn.set(key, _encode(text))
         return True
 
     # ── Read ──────────────────────────────────────────────────────────────
@@ -124,7 +151,7 @@ class ContentStore:
         blob = self._conn.get(BLOB.format(sha=sha))
         if blob is None:
             return None
-        return zlib.decompress(blob).decode("utf-8", errors="replace")
+        return _decode(blob)
 
     def lines(self, sha: str) -> list[str]:
         text = self.get(sha)
@@ -217,5 +244,5 @@ class ContentStore:
                 continue
             stats.blobs += 1
             stats.compressed_bytes += len(blob)
-            stats.original_bytes += len(zlib.decompress(blob))
+            stats.original_bytes += len(_decode(blob).encode("utf-8"))
         return stats

--- a/navegador/graph/content.py
+++ b/navegador/graph/content.py
@@ -1,0 +1,221 @@
+"""
+Content-addressed source storage beside the graph (#183).
+
+The graph keeps structure and throws the text away: ``File`` nodes carry a
+path, a language, a line count and a ``content_hash``, and symbol nodes carry
+line ranges. Nothing carries the source. There is therefore nothing to match a
+literal against and nothing to return a line from, which is what lexical
+search needs (#184, #185).
+
+Content lives in Redis beside the graph rather than inside it. A graph
+database is the wrong shape for a blob store, and keeping it out means graph
+size, ``DUMP`` output and traversal cost are unchanged by this.
+
+Two properties come free from addressing by ``content_hash``, which ingest
+already computes:
+
+**Dedup.** A vendored copy, a fork and the same file in three workspaces are
+one blob. On this machine several codebases are indexed two and three times
+under different graph names; identical files across them cost storage once.
+
+**Incremental.** An unchanged file has an unchanged hash, so re-ingesting a
+repository writes nothing.
+
+Compression is stdlib ``zlib``. Source compresses well and a compression
+dependency is not worth a supply-chain entry (#189).
+"""
+
+from __future__ import annotations
+
+import zlib
+from dataclasses import dataclass
+
+# Compressed source, keyed by content hash.
+BLOB = "nav:blob:{sha}"
+# Graphs referencing a blob. A set, not a counter: re-ingesting the same
+# repository must not inflate the count, and a counter cannot survive a graph
+# being deleted without also being decremented, which nothing guarantees.
+BLOB_REFS = "nav:blob:{sha}:refs"
+# Reverse index, so releasing a graph does not mean scanning every blob.
+GRAPH_BLOBS = "nav:graph:{graph}:blobs"
+
+# zlib level 6. Level 9 buys a few percent for substantially more CPU on a
+# path that runs once per changed file during ingest.
+LEVEL = 6
+
+
+def _binary_connection(connection):
+    """
+    A sibling connection that does not decode responses.
+
+    The graph client connects with ``decode_responses=True`` because Cypher
+    results are text. Compressed bytes read back through it raise
+    UnicodeDecodeError on the first byte that is not valid UTF-8, so this
+    reuses the same socket settings with decoding turned off rather than
+    base64-ing the payload and paying a third more storage to avoid it.
+    """
+    import redis as redis_lib
+
+    kwargs = dict(getattr(connection.connection_pool, "connection_kwargs", {}))
+    if not kwargs.get("decode_responses"):
+        return connection
+    kwargs["decode_responses"] = False
+    # A unix socket pool keys on `path`; a TCP pool on host/port.
+    if "path" in kwargs:
+        return redis_lib.Redis(unix_socket_path=kwargs.pop("path"), **kwargs)
+    return redis_lib.Redis(**kwargs)
+
+
+@dataclass
+class ContentStats:
+    blobs: int = 0
+    compressed_bytes: int = 0
+    original_bytes: int = 0
+
+    @property
+    def ratio(self) -> float:
+        if not self.compressed_bytes:
+            return 0.0
+        return self.original_bytes / self.compressed_bytes
+
+    def to_dict(self) -> dict:
+        return {
+            "blobs": self.blobs,
+            "compressed_bytes": self.compressed_bytes,
+            "original_bytes": self.original_bytes,
+            "ratio": round(self.ratio, 2),
+        }
+
+
+class ContentStore:
+    """
+    Source text addressed by content hash, reference-counted per graph.
+
+    Args:
+        store: A :class:`~navegador.graph.GraphStore`; its Redis connection is
+            reused so content lands on the same server as the graph.
+        graph: Owning graph name. Defaults to the store's own.
+    """
+
+    def __init__(self, store, graph: str | None = None) -> None:
+        self._conn = _binary_connection(store._client.connection)
+        self._graph = graph or store.graph_name
+
+    # ── Write ─────────────────────────────────────────────────────────────
+
+    def put(self, sha: str, text: str) -> bool:
+        """
+        Store *text* under *sha* and record this graph as a referrer.
+
+        Returns True when the blob was newly written, False when it already
+        existed — the dedup and incremental cases, which are the common ones.
+        """
+        key = BLOB.format(sha=sha)
+        self._conn.sadd(BLOB_REFS.format(sha=sha), self._graph)
+        self._conn.sadd(GRAPH_BLOBS.format(graph=self._graph), sha)
+        if self._conn.exists(key):
+            return False
+        self._conn.set(key, zlib.compress(text.encode("utf-8"), LEVEL))
+        return True
+
+    # ── Read ──────────────────────────────────────────────────────────────
+
+    def get(self, sha: str) -> str | None:
+        blob = self._conn.get(BLOB.format(sha=sha))
+        if blob is None:
+            return None
+        return zlib.decompress(blob).decode("utf-8", errors="replace")
+
+    def lines(self, sha: str) -> list[str]:
+        text = self.get(sha)
+        return text.splitlines() if text is not None else []
+
+    def line_at(self, sha: str, byte_offset: int) -> tuple[int, str] | None:
+        """
+        The 1-indexed line containing *byte_offset*, and its text.
+
+        The offset is a **byte** offset into the UTF-8 encoding, because that
+        is what a byte-oriented matcher produces. Passing a Python string
+        index instead is silently wrong on any file containing non-ASCII: on
+        this module's own source, 187 non-ASCII characters put the two 374
+        bytes apart and the answer nine lines off. It is the obvious mistake,
+        so the parameter is named for the unit.
+
+        Line offsets are computed here rather than stored alongside the blob:
+        resolving an offset already requires the content, and the scan that
+        decompresses it counts newlines in the same pass. A stored offset
+        table would be a second thing to keep in sync for no saved work.
+        """
+        text = self.get(sha)
+        if text is None or byte_offset < 0:
+            return None
+        encoded = text.encode("utf-8")
+        if byte_offset >= len(encoded):
+            return None
+        number = encoded[:byte_offset].count(b"\n") + 1
+        lines = text.splitlines()
+        if number > len(lines):
+            return None
+        return number, lines[number - 1]
+
+    def byte_offset_of(self, sha: str, needle: str) -> int | None:
+        """
+        Byte offset of the first occurrence of *needle*, for callers holding
+        a string rather than a byte position. Saves them the encode dance
+        that :meth:`line_at` documents.
+        """
+        text = self.get(sha)
+        if text is None:
+            return None
+        index = text.find(needle)
+        if index < 0:
+            return None
+        return len(text[:index].encode("utf-8"))
+
+    def exists(self, sha: str) -> bool:
+        return bool(self._conn.exists(BLOB.format(sha=sha)))
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    def release(self, graph: str | None = None) -> int:
+        """
+        Drop *graph*'s claim on its blobs, deleting those nobody else wants.
+
+        Called when a graph is pruned. Without it a deleted graph would leave
+        its content resident forever; with naive deletion instead, pruning one
+        of two graphs sharing a vendored file would take the file out from
+        under the other.
+
+        Returns the number of blobs actually deleted.
+        """
+        name = graph or self._graph
+        index = GRAPH_BLOBS.format(graph=name)
+        shas = [s.decode() if isinstance(s, bytes) else s for s in self._conn.smembers(index)]
+        deleted = 0
+        for sha in shas:
+            refs = BLOB_REFS.format(sha=sha)
+            self._conn.srem(refs, name)
+            if self._conn.scard(refs) == 0:
+                self._conn.delete(BLOB.format(sha=sha), refs)
+                deleted += 1
+        self._conn.delete(index)
+        return deleted
+
+    def stats(self) -> ContentStats:
+        """
+        Size of this graph's content, reported separately from the graph.
+
+        Original size is derived by decompressing, so this is a reporting
+        call rather than something to put on a hot path.
+        """
+        index = GRAPH_BLOBS.format(graph=self._graph)
+        shas = [s.decode() if isinstance(s, bytes) else s for s in self._conn.smembers(index)]
+        stats = ContentStats()
+        for sha in shas:
+            blob = self._conn.get(BLOB.format(sha=sha))
+            if blob is None:
+                continue
+            stats.blobs += 1
+            stats.compressed_bytes += len(blob)
+            stats.original_bytes += len(zlib.decompress(blob))
+        return stats

--- a/navegador/graph/content.py
+++ b/navegador/graph/content.py
@@ -83,13 +83,32 @@ def _binary_connection(connection):
     """
     import redis as redis_lib
 
-    kwargs = dict(getattr(connection.connection_pool, "connection_kwargs", {}))
-    if not kwargs.get("decode_responses"):
+    pool_kwargs = dict(getattr(connection.connection_pool, "connection_kwargs", {}))
+    if not pool_kwargs.get("decode_responses"):
         return connection
+
+    # Only the parameters that identify and secure the connection. A pool
+    # carries internals that Redis.__init__ rejects outright — copying them
+    # wholesale raised TypeError on maint_notifications_pool_handler against a
+    # real server, while working fine against the embedded unix socket.
+    allowed = (
+        "host",
+        "port",
+        "db",
+        "username",
+        "password",
+        "socket_timeout",
+        "socket_connect_timeout",
+        "ssl",
+        "ssl_certfile",
+        "ssl_keyfile",
+        "ssl_ca_certs",
+    )
+    kwargs = {k: v for k, v in pool_kwargs.items() if k in allowed}
     kwargs["decode_responses"] = False
     # A unix socket pool keys on `path`; a TCP pool on host/port.
-    if "path" in kwargs:
-        return redis_lib.Redis(unix_socket_path=kwargs.pop("path"), **kwargs)
+    if "path" in pool_kwargs:
+        return redis_lib.Redis(unix_socket_path=pool_kwargs["path"], **kwargs)
     return redis_lib.Redis(**kwargs)
 
 

--- a/navegador/graph/prose.py
+++ b/navegador/graph/prose.py
@@ -1,0 +1,166 @@
+"""
+Index the text parsing throws away (#185).
+
+An AST keeps structure and discards most of what people actually search for.
+The name of a function survives; the error message it raises does not, nor the
+comment explaining why it exists, nor the SQL, URLs and feature flags sitting
+in its string literals. Those are the things an agent has in hand when it goes
+looking — a user pastes an error, not a symbol name.
+
+This extracts three kinds of text per file and indexes them with FalkorDB's
+full-text index, which is already on the server and was unused:
+
+**Literals** — error messages, log lines, SQL, URLs. The single biggest search
+target and previously invisible.
+
+**Comments** — kept apart from docstrings, because a comment usually records
+why something is the way it is, which is the question docstrings answer least.
+
+**Identifiers, split on camelCase and snake_case** — so ``getUserById`` is
+reachable from "user id". Cheap, and it closes most of the distance between
+how code is written and how people ask about it.
+
+Why not fold this into the trigram index: different jobs. Trigrams answer
+"this exact string appears here" — precise, unranked, no notion of aboutness.
+Full text answers "these files are about this" — tokenised and ranked, and
+useful when the agent does not know the exact spelling. Targeting fuses both.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# One node per file holding its extracted prose. A separate label keeps the
+# full-text index off File, whose properties are queried structurally on hot
+# paths and should not carry a large text blob.
+LABEL = "FileText"
+
+# Quoted strings, including triple-quoted. Non-greedy, and escapes are skipped
+# so an embedded quote does not end the match early.
+_LITERAL = re.compile(
+    r'"""(.*?)"""' r"|'''(.*?)'''" r'|"((?:[^"\\]|\\.)*)"' r"|'((?:[^'\\]|\\.)*)'",
+    re.DOTALL,
+)
+# Line comments across the languages parsed here: #, //, --.
+_COMMENT = re.compile(r"(?:^|\s)(?:#|//|--)\s?(.*)$", re.MULTILINE)
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+# camelCase and PascalCase boundaries.
+_CAMEL = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+# Extracted text is truncated per file. A minified bundle or a vendored blob
+# would otherwise put a megabyte of noise into one property and swamp ranking.
+MAX_CHARS = 20_000
+
+
+def split_identifier(name: str) -> list[str]:
+    """
+    ``getUserById`` -> ["get", "user", "by", "id"]; ``parse_import`` -> both parts.
+
+    The original is kept as well: an agent searching the exact symbol name
+    should still find it.
+    """
+    parts: list[str] = []
+    for chunk in name.split("_"):
+        if not chunk:
+            continue
+        parts.extend(p for p in _CAMEL.split(chunk) if p)
+    lowered = [p.lower() for p in parts if len(p) > 1]
+    return sorted(set(lowered + [name.lower()]))
+
+
+@dataclass
+class Extracted:
+    literals: str = ""
+    comments: str = ""
+    identifiers: str = ""
+
+    @property
+    def empty(self) -> bool:
+        return not (self.literals or self.comments or self.identifiers)
+
+
+def extract(source: str) -> Extracted:
+    """Pull literals, comments and split identifiers out of *source*."""
+    literals: list[str] = []
+    for match in _LITERAL.finditer(source):
+        value = next((g for g in match.groups() if g), "")
+        value = value.strip()
+        # A one-word string is usually a dict key or a flag, not prose worth
+        # ranking; keeping them buries the error messages under noise.
+        if len(value) > 3 and " " in value:
+            literals.append(value)
+
+    comments = [m.group(1).strip() for m in _COMMENT.finditer(source) if m.group(1).strip()]
+
+    words: set[str] = set()
+    for match in _IDENTIFIER.finditer(source):
+        words.update(split_identifier(match.group(0)))
+
+    return Extracted(
+        literals=" ".join(literals)[:MAX_CHARS],
+        comments=" ".join(comments)[:MAX_CHARS],
+        identifiers=" ".join(sorted(words))[:MAX_CHARS],
+    )
+
+
+class ProseIndex:
+    """Full-text search over the literals, comments and identifiers of a graph."""
+
+    def __init__(self, store) -> None:
+        self._store = store
+
+    def ensure_index(self) -> None:
+        """
+        Create the full-text index, ignoring "already indexed".
+
+        There is no IF NOT EXISTS form, so the second call raises and there is
+        nothing useful to do but continue.
+        """
+        try:
+            self._store.query(
+                f"CALL db.idx.fulltext.createNodeIndex('{LABEL}', "
+                "'literals', 'comments', 'identifiers')"
+            )
+        except Exception:
+            pass
+
+    def index_file(self, path: str, source: str) -> bool:
+        """Attach extracted text to *path*. Returns False when there was none."""
+        extracted = extract(source)
+        if extracted.empty:
+            return False
+        self.ensure_index()
+        self._store.query(
+            f"MERGE (t:{LABEL} {{path: $path}}) "
+            "SET t.literals = $literals, t.comments = $comments, "
+            "t.identifiers = $identifiers",
+            {
+                "path": path,
+                "literals": extracted.literals,
+                "comments": extracted.comments,
+                "identifiers": extracted.identifiers,
+            },
+        )
+        return True
+
+    def search(self, query: str, limit: int = 20) -> list[dict]:
+        """
+        Files whose prose matches *query*, ranked.
+
+        Returns an empty list rather than raising when nothing has been
+        indexed yet — no index is an absence of answer, not an error.
+        """
+        try:
+            rows = self._store.query(
+                f"CALL db.idx.fulltext.queryNodes('{LABEL}', $query) YIELD node, score "
+                "RETURN node.path, score ORDER BY score DESC LIMIT $limit",
+                {"query": query, "limit": int(limit)},
+            ).result_set
+        except Exception:
+            return []
+        return [{"path": row[0], "score": float(row[1])} for row in rows or [] if row and row[0]]
+
+    def stats(self) -> dict:
+        rows = self._store.query(f"MATCH (t:{LABEL}) RETURN count(t)").result_set
+        return {"indexed_files": int(rows[0][0]) if rows else 0}

--- a/navegador/graph/queries.py
+++ b/navegador/graph/queries.py
@@ -294,6 +294,14 @@ WHERE f:File OR f:Document
 DETACH DELETE f
 """
 
+# Extracted literals, comments and identifiers for a file (#185). Keyed by
+# path like File is, and equally stale once the file is gone — leaving it
+# behind made an incrementally maintained graph diverge from a clean rebuild.
+DELETE_FILE_TEXT = """
+MATCH (t:FileText {path: $path})
+DETACH DELETE t
+"""
+
 DOCUMENT_HASH = """
 MATCH (d:Document {path: $path})
 RETURN d.content_hash AS hash

--- a/navegador/graph/trigram.py
+++ b/navegador/graph/trigram.py
@@ -1,0 +1,327 @@
+"""
+Trigram index for substring and regex search (#184).
+
+The graph answers structural questions well and exact-text questions not at
+all, yet agents search for literals constantly — an error message, a feature
+flag, a magic constant, an env var, a TODO. A graph cannot answer those, and
+embeddings answer them badly because vectors are weak on exact tokens.
+
+This is the Zoekt design adapted to Redis, so it lives on the same shared
+server as the graph and adds no external dependency (#189).
+
+**Trigrams narrow; they never decide.** A query is reduced to the trigrams it
+must contain, those postings are intersected to a candidate set, and each
+candidate is then matched with the real pattern against its stored content.
+The index is therefore allowed to over-select but never to under-select, and
+results are exact rather than approximate.
+
+**Scoping is free.** Postings hold blob ids and so does the per-graph blob
+index, so restricting a search to one repository — or to the files reachable
+from a symbol (#186) — is another set in the same intersection rather than a
+filter applied afterwards. That is the reduction no flat index can compute,
+and the reason this belongs inside navegador rather than shelling out to
+ripgrep.
+
+Postings are keyed by content hash, so the dedup and incremental properties
+of the content store carry over: a vendored copy indexed twice costs one set
+of postings, and re-indexing unchanged content is a no-op.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from navegador.graph.content import GRAPH_BLOBS, ContentStore, _binary_connection
+
+# trigram -> set of blob ids. Ids rather than hashes: a 64-character hex digest
+# in every posting would dwarf the content it points at, while small integers
+# let Redis hold the set in its compact intset encoding.
+POSTING = "nav:tri:{tri}"
+# Two-way mapping between content hash and blob id.
+BLOB_ID = "nav:blobid:{sha}"
+BLOB_SHA = "nav:blobsha:{bid}"
+BLOB_SEQ = "nav:blobseq"
+# Blobs already indexed, so re-indexing is a cheap no-op.
+INDEXED = "nav:tri:indexed"
+# Blob *ids* this graph holds, maintained at index time. Postings hold ids and
+# the content store's index holds hashes, so without this every search rebuilt
+# the mapping with one round trip per blob — a fixed 22ms floor on a 262-file
+# corpus, paid even by a search matching nothing.
+GRAPH_IDS = "nav:tri:ids:{graph}"
+
+# Below this a pattern has no trigram to narrow with and the scope is scanned.
+MIN_TRIGRAM = 3
+
+# Characters that make a run of text something other than a literal.
+_META = set(".^$*+?{}[]()|\\")
+# A literal run followed by one of these is optional or repeated, so it is not
+# guaranteed to appear: `ab?` does not require "ab".
+_QUANTIFIERS = set("?*{")
+
+
+@dataclass
+class Match:
+    """One matching line, with enough provenance to act on."""
+
+    path: str
+    line: int
+    text: str
+    sha: str
+
+    def to_dict(self) -> dict:
+        return {"path": self.path, "line": self.line, "text": self.text, "sha": self.sha}
+
+
+def trigrams(text: str) -> set[str]:
+    """Distinct lowercased 3-character windows."""
+    lowered = text.lower()
+    return {lowered[i : i + 3] for i in range(len(lowered) - 2)}
+
+
+def required_trigrams(pattern: str, is_regex: bool) -> set[str]:
+    """
+    Trigrams every match must contain, or an empty set when none can be proven.
+
+    Over-requiring here causes false negatives, which is the one failure a
+    search index may not have: the caller would be told a string does not
+    appear when it does. So a run only counts when it is unconditionally
+    present — not inside a group or character class, and not followed by a
+    quantifier that could make it vanish.
+
+    An empty result is not failure. It means "no narrowing available", and the
+    caller scans the scope instead — slower, still exact.
+    """
+    if not is_regex:
+        return trigrams(pattern) if len(pattern) >= MIN_TRIGRAM else set()
+
+    # Alternation anywhere means no single run is guaranteed: `foo|bar` must
+    # contain neither "foo" nor "bar" specifically.
+    if "|" in pattern.replace("\\|", ""):
+        return set()
+
+    runs: list[str] = []
+    current: list[str] = []
+    depth = 0
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "\\":
+            current = []  # an escape may be a class like \d; stop the run
+            index += 2
+            continue
+        if char in "([":
+            depth += 1
+            current = []
+        elif char in ")]":
+            depth = max(0, depth - 1)
+            current = []
+        elif char in _META:
+            # A quantifier makes the character before it optional, so that
+            # character cannot be part of a required run.
+            if char in _QUANTIFIERS and current:
+                current.pop()
+            if len(current) >= MIN_TRIGRAM:
+                runs.append("".join(current))
+            current = []
+        elif depth == 0:
+            current.append(char)
+        index += 1
+
+    if len(current) >= MIN_TRIGRAM:
+        runs.append("".join(current))
+
+    required: set[str] = set()
+    for run in runs:
+        required |= trigrams(run)
+    return required
+
+
+class TrigramIndex:
+    """
+    Substring and regex search over stored content, narrowed by trigrams.
+
+    Args:
+        store: A :class:`~navegador.graph.GraphStore`.
+        graph: Owning graph name. Defaults to the store's own.
+    """
+
+    def __init__(self, store, graph: str | None = None) -> None:
+        self._store = store
+        self._conn = _binary_connection(store._client.connection)
+        self._graph = graph or store.graph_name
+        self._content = ContentStore(store, graph=self._graph)
+
+    # ── Blob identity ─────────────────────────────────────────────────────
+
+    def _blob_id(self, sha: str, create: bool = False) -> int | None:
+        existing = self._conn.get(BLOB_ID.format(sha=sha))
+        if existing is not None:
+            return int(existing)
+        if not create:
+            return None
+        new_id = int(self._conn.incr(BLOB_SEQ))
+        self._conn.set(BLOB_ID.format(sha=sha), new_id)
+        self._conn.set(BLOB_SHA.format(bid=new_id), sha)
+        return new_id
+
+    def _sha_for(self, blob_id: int) -> str | None:
+        raw = self._conn.get(BLOB_SHA.format(bid=int(blob_id)))
+        return raw.decode() if isinstance(raw, bytes) else raw
+
+    # ── Index ─────────────────────────────────────────────────────────────
+
+    def index_blob(self, sha: str, text: str) -> bool:
+        """
+        Add one blob's trigrams. Returns False when it was already indexed.
+
+        Content-addressed, so the same file appearing in three repositories is
+        indexed once and re-ingesting an unchanged repository does nothing.
+        """
+        blob_id = self._blob_id(sha, create=True)
+        # Recorded even when the blob was indexed by another graph: postings
+        # are shared, but which graph holds the blob is per graph.
+        self._conn.sadd(GRAPH_IDS.format(graph=self._graph), blob_id)
+        if self._conn.sismember(INDEXED, sha):
+            return False
+        grams = trigrams(text)
+        if grams:
+            pipe = self._conn.pipeline(transaction=False)
+            for gram in grams:
+                pipe.sadd(POSTING.format(tri=gram), blob_id)
+            pipe.sadd(INDEXED, sha)
+            pipe.execute()
+        else:
+            self._conn.sadd(INDEXED, sha)
+        return True
+
+    def index_graph(self, limit: int | None = None) -> int:
+        """Index every blob this graph holds. Returns the number newly indexed."""
+        shas = [
+            s.decode() if isinstance(s, bytes) else s
+            for s in self._conn.smembers(GRAPH_BLOBS.format(graph=self._graph))
+        ]
+        indexed = 0
+        for sha in shas:
+            if limit is not None and indexed >= limit:
+                break
+            text = self._content.get(sha)
+            if text is None:
+                continue
+            if self.index_blob(sha, text):
+                indexed += 1
+        return indexed
+
+    # ── Search ────────────────────────────────────────────────────────────
+
+    def _candidate_ids(self, required: set[str], scope_key: str) -> list[int]:
+        """
+        Blob ids that hold every required trigram and are in scope.
+
+        The scope set joins the intersection rather than filtering after it,
+        so a search restricted to one repository never materialises the other
+        repositories' candidates at all.
+        """
+        keys = [POSTING.format(tri=g) for g in sorted(required)]
+        raw = self._conn.sinter([scope_key, *keys]) if keys else self._conn.smembers(scope_key)
+        return [int(v) for v in raw]
+
+    def _scope_key(self, scope: set[str] | None) -> tuple[str, bool]:
+        """
+        A Redis key holding the blob ids to search, and whether it is temporary.
+
+        The unscoped case is the common one and must cost nothing: it returns
+        the persistent per-graph id set maintained at index time. Building it
+        per search instead meant one round trip per blob before any matching
+        began, which dominated every query regardless of how few matched.
+
+        A caller-supplied scope still materialises a short-lived key, since
+        the set is different every time.
+        """
+        if scope is None:
+            return GRAPH_IDS.format(graph=self._graph), False
+
+        ids = [i for i in (self._blob_id(s) for s in scope) if i is not None]
+        key = f"nav:tri:scope:{self._graph}:{id(self)}"
+        self._conn.delete(key)
+        if ids:
+            self._conn.sadd(key, *ids)
+            self._conn.expire(key, 60)
+        return key, True
+
+    def search(
+        self,
+        pattern: str,
+        is_regex: bool = False,
+        scope: set[str] | None = None,
+        limit: int = 100,
+        ignore_case: bool = False,
+    ) -> list[Match]:
+        """
+        Lines matching *pattern*, with file and line number.
+
+        Args:
+            pattern: Literal substring, or a regular expression when
+                *is_regex* is set.
+            scope: Content hashes to search within. None means this graph.
+            limit: Maximum matches returned.
+            ignore_case: Case-insensitive matching.
+
+        Results are exact: trigrams only choose which blobs to look at, and
+        every returned line was matched with the real pattern.
+        """
+        try:
+            flags = re.IGNORECASE if ignore_case else 0
+            matcher = re.compile(pattern if is_regex else re.escape(pattern), flags)
+        except re.error:
+            return []
+
+        scope_key, temporary = self._scope_key(scope)
+        try:
+            candidates = self._candidate_ids(required_trigrams(pattern, is_regex), scope_key)
+            shas = [s for s in (self._sha_for(i) for i in candidates) if s]
+            paths = self._paths_for(shas)
+
+            matches: list[Match] = []
+            for sha in shas:
+                text = self._content.get(sha)
+                if text is None:
+                    continue
+                hit_lines = [
+                    (number, line)
+                    for number, line in enumerate(text.splitlines(), start=1)
+                    if matcher.search(line)
+                ]
+                if not hit_lines:
+                    continue
+                for path in paths.get(sha, [""]):
+                    for number, line in hit_lines:
+                        matches.append(Match(path=path, line=number, text=line, sha=sha))
+                        if len(matches) >= limit:
+                            return sorted(matches, key=lambda m: (m.path, m.line))
+            return sorted(matches, key=lambda m: (m.path, m.line))
+        finally:
+            if temporary:
+                self._conn.delete(scope_key)
+
+    def _paths_for(self, shas: list[str]) -> dict[str, list[str]]:
+        """
+        Map content hashes back to the paths holding them, via the graph.
+
+        One hash can map to several paths — that is dedup working, not an
+        error, and every one of them is a real place the line appears.
+        """
+        if not shas:
+            return {}
+        result = self._store.query(
+            "MATCH (f:File) WHERE f.content_hash IN $shas RETURN f.content_hash, f.path",
+            {"shas": list(shas)},
+        ).result_set
+        paths: dict[str, list[str]] = {}
+        for row in result or []:
+            paths.setdefault(row[0], []).append(row[1])
+        return paths
+
+    def stats(self) -> dict:
+        indexed = self._conn.scard(INDEXED)
+        return {"indexed_blobs": int(indexed)}

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -148,6 +148,7 @@ class RepoIngester:
         # files and vendored copies cost nothing.
         self.store_content = store_content
         self._content_store = None
+        self._prose_index = None
         # When True (default), a git checkout contributes only the files git
         # does not ignore. Without this the walk pruned on a fixed directory
         # list and indexed any build output whose directory name happened to
@@ -255,6 +256,7 @@ class RepoIngester:
             "grammar_skipped": 0,
             "removed": 0,
             "content_stored": 0,
+            "prose_indexed": 0,
         }
 
         # Every path this pass saw on disk, recorded before any decision about
@@ -299,6 +301,8 @@ class RepoIngester:
                 stats["edges"] += 1
                 if self._store_content(source_file, content_hash):
                     stats["content_stored"] += 1
+                if self._index_prose(rel_path, source_file):
+                    stats["prose_indexed"] += 1
                 if stats["files"] % 1000 == 0:
                     logger.info(
                         "Ingest progress %s: %d files parsed", repo_path.name, stats["files"]
@@ -440,6 +444,28 @@ class RepoIngester:
         if self._detector is not None:
             text = self._detector.redact(text)
         return content.put(content_hash, text)
+
+    def _index_prose(self, rel_path: str, source_file: Path) -> bool:
+        """
+        Index the literals, comments and identifiers parsing discards (#185).
+
+        Separate from content storage because the two answer different
+        questions: content backs exact matching, this backs ranked "what is
+        about this" search.
+        """
+        if not self.store_content:
+            return False
+        if self._prose_index is None:
+            from navegador.graph.prose import ProseIndex
+
+            self._prose_index = ProseIndex(self.store)
+        try:
+            text = source_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return False
+        if self._detector is not None:
+            text = self._detector.redact(text)
+        return self._prose_index.index_file(rel_path, text)
 
     def _file_unchanged(self, rel_path: str, content_hash: str) -> bool:
         suffix = Path(rel_path).suffix.lower()

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -498,6 +498,11 @@ class RepoIngester:
             self.store.query(queries.DELETE_FILE_CHILDREN, {"path": path})
             self.store.query(queries.DELETE_FILE_IMPORTS, {"path": path})
             self.store.query(queries.DELETE_FILE_NODE, {"path": path})
+            # The prose node is keyed by path like File is, and is just as
+            # stale once the file is gone. Missing it reintroduced #168 for a
+            # node type introduced after that fix: an incrementally maintained
+            # graph stopped matching a clean rebuild.
+            self.store.query(queries.DELETE_FILE_TEXT, {"path": path})
 
         if stale:
             logger.info(

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -139,9 +139,15 @@ class RepoIngester:
         exclude: list[str] | None = None,
         include_nested_repos: bool = False,
         respect_gitignore: bool = True,
+        store_content: bool = True,
     ) -> None:
         self.store = store
         self.redact = redact
+        # Keep each file's text in the content store so lexical search has
+        # something to match against (#183). Content-addressed, so unchanged
+        # files and vendored copies cost nothing.
+        self.store_content = store_content
+        self._content_store = None
         # When True (default), a git checkout contributes only the files git
         # does not ignore. Without this the walk pruned on a fixed directory
         # list and indexed any build output whose directory name happened to
@@ -248,6 +254,7 @@ class RepoIngester:
             "skipped": 0,
             "grammar_skipped": 0,
             "removed": 0,
+            "content_stored": 0,
         }
 
         # Every path this pass saw on disk, recorded before any decision about
@@ -290,6 +297,8 @@ class RepoIngester:
                 self._store_file_hash(rel_path, content_hash)
                 self._link_file_to_repo(rel_path, repo_key)
                 stats["edges"] += 1
+                if self._store_content(source_file, content_hash):
+                    stats["content_stored"] += 1
                 if stats["files"] % 1000 == 0:
                     logger.info(
                         "Ingest progress %s: %d files parsed", repo_path.name, stats["files"]
@@ -391,6 +400,46 @@ class RepoIngester:
 
     # Extensions handled by MarkdownParser — these produce Document nodes, not File nodes.
     _DOCUMENT_EXTENSIONS = frozenset({".md", ".markdown"})
+
+    @property
+    def _content(self):
+        """
+        Lazily opened content store, or None when content is not being kept.
+
+        Opened once per ingester rather than per file: it holds a Redis
+        connection, and building one for each of 50,000 files would dominate
+        the ingest.
+        """
+        if not self.store_content:
+            return None
+        if self._content_store is None:
+            from navegador.graph.content import ContentStore
+
+            self._content_store = ContentStore(self.store)
+        return self._content_store
+
+    def _store_content(self, source_file: Path, content_hash: str) -> bool:
+        """
+        Keep the file's text so lexical search has something to match against.
+
+        Returns True only when the blob was newly written; an unchanged file
+        or one already stored by another repository returns False, which is
+        what makes re-ingest and vendored copies free.
+
+        Redaction is deliberately honoured here: if content is being redacted
+        for the graph, storing the unredacted original beside it would put the
+        secret back on the server through another door.
+        """
+        content = self._content
+        if content is None:
+            return False
+        try:
+            text = source_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return False
+        if self._detector is not None:
+            text = self._detector.redact(text)
+        return content.put(content_hash, text)
 
     def _file_unchanged(self, rel_path: str, content_hash: str) -> bool:
         suffix = Path(rel_path).suffix.lower()

--- a/navegador/ingestion/parser.py
+++ b/navegador/ingestion/parser.py
@@ -138,9 +138,15 @@ class RepoIngester:
         redact: bool = False,
         exclude: list[str] | None = None,
         include_nested_repos: bool = False,
+        respect_gitignore: bool = True,
     ) -> None:
         self.store = store
         self.redact = redact
+        # When True (default), a git checkout contributes only the files git
+        # does not ignore. Without this the walk pruned on a fixed directory
+        # list and indexed any build output whose directory name happened to
+        # fall outside it (#180).
+        self.respect_gitignore = respect_gitignore
         # Glob patterns excluded from the walk, merged with the repo's
         # .navignore. Matching directories are pruned before descent.
         self.exclude = list(exclude or [])
@@ -529,6 +535,7 @@ class RepoIngester:
         directories the same way (#130).
         """
         patterns = self._exclusion_patterns(repo_path)
+        visible_files, visible_dirs = self._git_visible(repo_path)
         for dirpath, dirnames, filenames in os.walk(repo_path):
             current = Path(dirpath)
             kept = []
@@ -536,6 +543,10 @@ class RepoIngester:
                 if d in self._SKIP_DIRS:
                     continue
                 child = current / d
+                # Prune ignored directories rather than filtering their files
+                # afterwards, so a large ignored tree is never descended into.
+                if visible_dirs is not None and child not in visible_dirs:
+                    continue
                 if patterns and self._matches_exclusion(
                     child.relative_to(repo_path).as_posix(), patterns
                 ):
@@ -548,12 +559,48 @@ class RepoIngester:
             dirnames[:] = kept
             for fname in filenames:
                 path = current / fname
+                if visible_files is not None and path not in visible_files:
+                    continue
                 if patterns and self._matches_exclusion(
                     path.relative_to(repo_path).as_posix(), patterns
                 ):
                     continue
                 if path.is_file():  # excludes broken symlinks, FIFOs, sockets
                     yield path
+
+    def _git_visible(self, repo_path: Path) -> tuple[set[Path] | None, set[Path] | None]:
+        """
+        The files git does not ignore, plus every directory leading to one.
+
+        Returns ``(None, None)`` when the answer is "no opinion" — gitignore
+        respect is off, the path is not a git checkout, or git returned
+        nothing — and the caller then walks everything as before.
+
+        The directory set exists so ignored trees can be pruned during the
+        walk instead of being descended into and filtered file by file; a
+        repository with 54k files of ignored build output should cost nothing
+        to skip.
+        """
+        if not self.respect_gitignore:
+            return None, None
+        from navegador.vcs import GitAdapter
+
+        adapter = GitAdapter(repo_path)
+        if not adapter.is_repo():
+            return None, None
+        relative = adapter.visible_files()
+        if not relative:
+            return None, None
+        files = {repo_path / rel for rel in relative}
+        directories: set[Path] = set()
+        for path in files:
+            for parent in path.parents:
+                if parent in directories:
+                    break  # this chain is already recorded
+                if parent == repo_path:
+                    break
+                directories.add(parent)
+        return files, directories
 
     def _exclusion_patterns(self, repo_path: Path) -> list[str]:
         """Explicit exclude patterns plus the repo's .navignore entries."""

--- a/navegador/ingestion/python.py
+++ b/navegador/ingestion/python.py
@@ -422,6 +422,13 @@ class PythonParser(LanguageParser):
                 edge_type,
                 NodeLabel.Function,
                 {"name": target_name, "file_path": target_file},
+                # tree-sitter is syntax only: it has no name resolution and no
+                # types, so `foo.bar()` cannot be resolved to Baz.bar. The
+                # callee here was matched by import heuristics and is usually
+                # but not always right (#163, #166). Recording that lets a
+                # caller tell a fact from a good guess, and leaves room for
+                # compiler-accurate edges to be marked `resolved` (#188).
+                {"resolution": "inferred"},
             )
             stats["edges"] += 1
 

--- a/navegador/intelligence/search.py
+++ b/navegador/intelligence/search.py
@@ -1,187 +1,230 @@
 """
-SemanticSearch — embedding-based similarity search over the navegador graph.
+SemanticSearch — vector similarity over the navegador graph.
 
-Embeds function/class docstrings via an LLMProvider, stores the embedding
-vectors as JSON in a node property (``embedding``), and retrieves the top-k
-most similar nodes to a natural-language query using cosine similarity.
+Embeds the text attached to a node and retrieves the nearest matches for a
+natural-language query using FalkorDB's native vector index.
+
+The previous implementation stored embeddings as JSON strings and, on every
+query, fetched **every** embedded node together with its full vector, parsed
+each one, and computed cosine similarity in a Python loop. At 100k nodes and
+1536 dimensions that is on the order of a gigabyte crossing the wire per
+query, and the cost grew with the graph — reintroducing exactly the full-scan
+problem this project exists to remove, and multiplying it by every agent
+sharing the server (#182).
+
+Now the k-nearest search happens inside the database against an index, so
+query cost is independent of graph size and no vector is transferred except
+the query's own.
 
 Usage::
 
-    from navegador.graph import GraphStore
+    from navegador.config import get_store
     from navegador.llm import get_provider
     from navegador.intelligence.search import SemanticSearch
 
-    store = GraphStore.sqlite(".navegador/graph.db")
-    provider = get_provider("openai")
-    ss = SemanticSearch(store, provider)
-
-    # Build / refresh the index (idempotent — re-embeds all nodes)
-    ss.index()
-
-    # Query
-    results = ss.search("function that validates JWT tokens", limit=5)
-    for r in results:
-        print(r["name"], r["score"])
+    ss = SemanticSearch(get_store(target="."), get_provider("openai"))
+    ss.index()                       # incremental; unchanged text is skipped
+    ss.search("validates JWT tokens", limit=5)
 """
 
 from __future__ import annotations
 
-import json
-import math
+import hashlib
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from navegador.graph.store import GraphStore
     from navegador.llm import LLMProvider
 
+logger = logging.getLogger(__name__)
 
-# Cypher to fetch all embeddable nodes (those with a docstring or description)
-_EMBEDDABLE_NODES = """
-MATCH (n)
-WHERE (n:Function OR n:Class OR n:Method OR n:Concept OR n:Rule OR n:Decision)
-  AND (n.docstring IS NOT NULL OR n.description IS NOT NULL)
-RETURN
-    labels(n)[0] AS type,
-    n.name AS name,
-    coalesce(n.file_path, '') AS file_path,
-    coalesce(n.docstring, n.description, '') AS text
-LIMIT $limit
-"""
+# A FalkorDB node pattern takes exactly one label, and a vector index is
+# created per label, so both the index and the query fan out across these.
+EMBEDDABLE_LABELS = ("Function", "Method", "Class", "Concept", "Rule", "Decision")
 
-# Cypher to fetch nodes that already have a stored embedding
-_NODES_WITH_EMBEDDINGS = """
-MATCH (n)
-WHERE n.embedding IS NOT NULL
-RETURN
-    labels(n)[0] AS type,
-    n.name AS name,
-    coalesce(n.file_path, '') AS file_path,
-    coalesce(n.docstring, n.description, '') AS text,
-    n.embedding AS embedding
-"""
+# Nodes whose embedded text is unchanged are skipped on re-index. The hash is
+# of the text actually embedded rather than File.content_hash, because symbol
+# nodes carry no content hash and a file can change without changing a given
+# function's signature or docstring.
+_EMBED_HASH = "embedding_hash"
 
-# Upsert the embedding property on a matched node
-_SET_EMBEDDING = """
-MATCH (n)
-WHERE n.name = $name AND ($file_path = '' OR n.file_path = $file_path)
-SET n.embedding = $embedding
-"""
+
+def _text_for(row: dict) -> str:
+    """
+    The text embedded for a node.
+
+    Previously only nodes with a docstring or description were embeddable,
+    which made most real functions invisible to semantic search. The name and
+    signature carry real meaning on their own — `parse_import_statement` is
+    findable from "handle imports" without a word of prose.
+    """
+    parts = [row.get("name") or ""]
+    if row.get("class_name"):
+        parts.append(f"in {row['class_name']}")
+    if row.get("file_path"):
+        parts.append(row["file_path"].replace("/", " ").replace("_", " "))
+    if row.get("text"):
+        parts.append(row["text"])
+    return " — ".join(p for p in parts if p).strip()
 
 
 class SemanticSearch:
     """
-    Embedding-based semantic search over the navegador graph.
-
-    Embeddings are stored as a JSON string (serialised ``list[float]``) in the
-    ``embedding`` property of each node so they survive graph restarts without
-    any external vector store.
+    Vector search over the graph, backed by FalkorDB's native vector index.
 
     Args:
-        store: A :class:`~navegador.graph.GraphStore` instance.
-        provider: An :class:`~navegador.llm.LLMProvider` that implements
-            :meth:`embed`.
+        store: A :class:`~navegador.graph.GraphStore`.
+        provider: An :class:`~navegador.llm.LLMProvider` implementing ``embed``.
     """
 
     def __init__(self, store: "GraphStore", provider: "LLMProvider") -> None:
         self._store = store
         self._provider = provider
 
-    # ── Index ─────────────────────────────────────────────────────────────────
+    # ── Index ─────────────────────────────────────────────────────────────
 
-    def index(self, limit: int = 1000) -> int:
+    def _ensure_index(self, label: str, dimension: int) -> None:
         """
-        Embed all function/class/concept docstrings and store on the nodes.
+        Create the vector index for *label*, ignoring "already indexed".
+
+        FalkorDB has no CREATE VECTOR INDEX IF NOT EXISTS, so the second call
+        raises and there is nothing to do about it but carry on.
+        """
+        try:
+            self._store.query(
+                f"CREATE VECTOR INDEX FOR (n:{label}) ON (n.embedding) "
+                f"OPTIONS {{dimension:{int(dimension)}, similarityFunction:'cosine'}}"
+            )
+        except Exception as exc:  # noqa: BLE001 — the only failure worth acting on is a new one
+            if "already" not in str(exc).lower():
+                logger.debug("vector index for %s: %s", label, exc)
+
+    def index(self, limit: int | None = None, batch: int = 256) -> int:
+        """
+        Embed node text and store it as a native vector.
+
+        Incremental: a node whose embedded text has not changed since last
+        time is skipped, so re-indexing an unchanged repository costs nothing
+        and does not re-pay the embedding bill.
 
         Args:
-            limit: Maximum number of nodes to index in one pass.
+            limit: Stop after this many nodes. None means all of them — the
+                old default silently truncated at 1000, leaving a partially
+                indexed graph that looked complete.
+            batch: Nodes per write round trip.
 
         Returns:
-            The number of nodes that were (re-)embedded.
+            Number of nodes newly embedded.
         """
-        result = self._store.query(_EMBEDDABLE_NODES, {"limit": limit})
-        rows = result.result_set or []
-        indexed = 0
-        for row in rows:
-            node_type, name, file_path, text = row[0], row[1], row[2], row[3]
-            if not text:
-                continue
-            label = f"[{node_type}] {name}: {text}"
-            vector = self._provider.embed(label)
-            self._store.query(
-                _SET_EMBEDDING,
-                {
-                    "name": name,
-                    "file_path": file_path,
-                    "embedding": json.dumps(vector),
-                },
-            )
-            indexed += 1
-        return indexed
+        embedded = 0
+        dimension: int | None = None
 
-    # ── Search ────────────────────────────────────────────────────────────────
+        for label in EMBEDDABLE_LABELS:
+            rows = self._store.query(
+                f"MATCH (n:{label}) "
+                "RETURN id(n), n.name, coalesce(n.file_path,''), "
+                "coalesce(n.docstring, n.description, ''), "
+                f"coalesce(n.class_name,''), n.{_EMBED_HASH}"
+            ).result_set
+            pending: list[tuple[int, list[float], str]] = []
+
+            for row in rows or []:
+                if limit is not None and embedded >= limit:
+                    break
+                node_id, name, file_path, text, class_name, stored_hash = row
+                if not name:
+                    continue
+                content = _text_for(
+                    {
+                        "name": name,
+                        "file_path": file_path,
+                        "text": text,
+                        "class_name": class_name,
+                    }
+                )
+                if not content:
+                    continue
+                digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                if stored_hash == digest:
+                    continue  # unchanged since last index
+
+                vector = self._provider.embed(content)
+                if not vector:
+                    continue
+                if dimension is None:
+                    dimension = len(vector)
+                    for lbl in EMBEDDABLE_LABELS:
+                        self._ensure_index(lbl, dimension)
+                pending.append((int(node_id), vector, digest))
+                embedded += 1
+                if len(pending) >= batch:
+                    self._write(pending)
+                    pending = []
+
+            if pending:
+                self._write(pending)
+
+        return embedded
+
+    def _write(self, pending: list[tuple[int, list[float], str]]) -> None:
+        """
+        Attach vectors to nodes by internal id.
+
+        The previous version matched on name plus optional file_path, which is
+        ambiguous for an overloaded method or a module-level function sharing
+        a name with one — it could write the embedding to the wrong node, or
+        to several.
+        """
+        for node_id, vector, digest in pending:
+            literal = ",".join(f"{v:.7g}" for v in vector)
+            self._store.query(
+                f"MATCH (n) WHERE id(n) = {node_id} "
+                f"SET n.embedding = vecf32([{literal}]), n.{_EMBED_HASH} = $digest",
+                {"digest": digest},
+            )
+
+    # ── Search ────────────────────────────────────────────────────────────
 
     def search(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
         """
-        Embed *query* and return the *limit* most similar indexed nodes.
+        Return the *limit* nodes nearest to *query*.
 
-        Each result dict has keys: ``type``, ``name``, ``file_path``,
-        ``text``, ``score`` (cosine similarity, 0–1).
-
-        Args:
-            query: Natural-language search query.
-            limit: Maximum number of results to return.
-
-        Returns:
-            List of result dicts sorted by descending similarity score.
+        Each result has ``type``, ``name``, ``file_path``, ``text`` and
+        ``score`` — cosine similarity in 0..1, converted from the distance the
+        index returns so that higher remains better for callers.
         """
-        query_vec = self._provider.embed(query)
+        vector = self._provider.embed(query)
+        if not vector:
+            return []
+        literal = ",".join(f"{v:.7g}" for v in vector)
 
-        result = self._store.query(_NODES_WITH_EMBEDDINGS, {})
-        rows = result.result_set or []
-
-        scored: list[dict[str, Any]] = []
-        for row in rows:
-            node_type, name, file_path, text, emb_json = (row[0], row[1], row[2], row[3], row[4])
-            if not emb_json:
-                continue
+        results: list[dict[str, Any]] = []
+        for label in EMBEDDABLE_LABELS:
             try:
-                node_vec: list[float] = json.loads(emb_json)
-            except (json.JSONDecodeError, TypeError):
+                rows = self._store.query(
+                    f"CALL db.idx.vector.queryNodes('{label}', 'embedding', {int(limit)}, "
+                    f"vecf32([{literal}])) YIELD node, score "
+                    "RETURN labels(node)[0], node.name, coalesce(node.file_path,''), "
+                    "coalesce(node.docstring, node.description, ''), score"
+                ).result_set
+            except Exception as exc:  # noqa: BLE001
+                # No index for this label yet — nothing has been embedded for
+                # it. Not an error; the other labels still answer.
+                logger.debug("vector query on %s: %s", label, exc)
                 continue
-            score = self._cosine_similarity(query_vec, node_vec)
-            scored.append(
-                {
-                    "type": node_type,
-                    "name": name,
-                    "file_path": file_path,
-                    "text": text,
-                    "score": score,
-                }
-            )
 
-        scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+            for row in rows or []:
+                node_type, name, file_path, text, distance = row
+                results.append(
+                    {
+                        "type": node_type,
+                        "name": name,
+                        "file_path": file_path,
+                        "text": text,
+                        "score": max(0.0, 1.0 - float(distance)),
+                    }
+                )
 
-    # ── Internals ─────────────────────────────────────────────────────────────
-
-    @staticmethod
-    def _cosine_similarity(a: list[float], b: list[float]) -> float:
-        """
-        Compute the cosine similarity between two vectors.
-
-        Args:
-            a: First embedding vector.
-            b: Second embedding vector.
-
-        Returns:
-            Cosine similarity in the range ``[-1, 1]``.  Returns ``0.0`` if
-            either vector is the zero vector or the lengths differ.
-        """
-        if len(a) != len(b):
-            return 0.0
-        dot = sum(x * y for x, y in zip(a, b))
-        mag_a = math.sqrt(sum(x * x for x in a))
-        mag_b = math.sqrt(sum(x * x for x in b))
-        if mag_a == 0.0 or mag_b == 0.0:
-            return 0.0
-        return dot / (mag_a * mag_b)
+        results.sort(key=lambda r: r["score"], reverse=True)
+        return results[:limit]

--- a/navegador/mcp/server.py
+++ b/navegador/mcp/server.py
@@ -706,6 +706,85 @@ def create_mcp_server(store_factory, read_only: bool = False):
                     "required": ["lens"],
                 },
             ),
+            Tool(
+                name="locate",
+                description=(
+                    "Find where to look for something, ranked, with the reason each "
+                    "place surfaced. Fuses exact text matches, symbol names, "
+                    "documents and semantic similarity. Returns places to look, not "
+                    "an answer — use it to pick a target in one call instead of "
+                    "several rounds of searching, then read or grep precisely."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "intent": {
+                            "type": "string",
+                            "description": "What you are looking for, in words or as a literal.",
+                        },
+                        "limit": {"type": "integer", "default": 10},
+                    },
+                    "required": ["intent"],
+                },
+            ),
+            Tool(
+                name="scope_for",
+                description=(
+                    "The set of files reachable from a symbol, for narrowing a "
+                    "search before running it. Pass `pattern` to search only within "
+                    "that scope and get back matching lines with file and line "
+                    "number. This is the reduction a flat text index cannot compute: "
+                    "it follows calls, references and imports through the graph."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "symbol": {"type": "string", "description": "Function, method or class."},
+                        "pattern": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Optional; search within the scope instead of "
+                            "just listing it.",
+                        },
+                        "depth": {"type": "integer", "default": 2},
+                        "limit": {"type": "integer", "default": 50},
+                    },
+                    "required": ["symbol"],
+                },
+            ),
+            Tool(
+                name="neighbourhood",
+                description=(
+                    "Callers, callees, tests and defining file for a symbol, in one "
+                    "call. Saves the several turns it otherwise takes to assemble "
+                    "the same picture."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {"symbol": {"type": "string"}},
+                    "required": ["symbol"],
+                },
+            ),
+            Tool(
+                name="grep_code",
+                description=(
+                    "Exact substring or regular-expression search over indexed "
+                    "content, returning file, line number and the matching line. "
+                    "Results are exact — verified against ripgrep — and cost scales "
+                    "with the number of matches rather than the size of the "
+                    "codebase, so a search that matches nothing is nearly free."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "pattern": {"type": "string"},
+                        "regex": {"type": "boolean", "default": False},
+                        "ignore_case": {"type": "boolean", "default": False},
+                        "limit": {"type": "integer", "default": 50},
+                    },
+                    "required": ["pattern"],
+                },
+            ),
         ]
         if read_only:
             return [t for t in tools if t.name not in WRITE_TOOLS]
@@ -812,6 +891,71 @@ def create_mcp_server(store_factory, read_only: bool = False):
                 return [TextContent(type="text", text=f"Error: {exc}")]
 
         loader = _get_loader()
+
+        if name == "locate":
+            from navegador.targeting import Targeting
+
+            candidates = Targeting(loader.store).locate(
+                arguments["intent"], limit=int(arguments.get("limit", 10))
+            )
+            payload = {
+                "intent": arguments["intent"],
+                "candidates": [c.to_dict() for c in candidates],
+                "note": (
+                    "These are places to look, not an answer. Read or grep the "
+                    "top candidates rather than trusting the ranking."
+                ),
+            }
+            return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+
+        if name == "scope_for":
+            from navegador.targeting import Targeting
+
+            targeting = Targeting(loader.store)
+            symbol = arguments["symbol"]
+            depth = int(arguments.get("depth", 2))
+            paths = targeting.scope_for(symbol, depth=depth)
+            payload: dict = {"symbol": symbol, "depth": depth, "files": paths}
+
+            pattern = arguments.get("pattern") or ""
+            if pattern:
+                matches = targeting.search_within(
+                    symbol, pattern, depth=depth, limit=int(arguments.get("limit", 50))
+                )
+                payload["pattern"] = pattern
+                payload["matches"] = [m.to_dict() for m in matches]
+            elif paths:
+                payload["hint"] = (
+                    "Pass `pattern` to search only these files, or hand them to a "
+                    "grep as an explicit file list."
+                )
+            return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+
+        if name == "neighbourhood":
+            from navegador.targeting import Targeting
+
+            payload = Targeting(loader.store).neighbourhood(arguments["symbol"])
+            return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+
+        if name == "grep_code":
+            from navegador.graph.trigram import TrigramIndex
+
+            matches = TrigramIndex(loader.store).search(
+                arguments["pattern"],
+                is_regex=bool(arguments.get("regex", False)),
+                ignore_case=bool(arguments.get("ignore_case", False)),
+                limit=int(arguments.get("limit", 50)),
+            )
+            payload = {
+                "pattern": arguments["pattern"],
+                "matches": [m.to_dict() for m in matches],
+            }
+            if not matches:
+                payload["hint"] = (
+                    "No matches. If this repository was ingested before content "
+                    "storage existed, re-ingest it so there is a corpus to search."
+                )
+            return [TextContent(type="text", text=json.dumps(payload, indent=2))]
 
         if name == "resolve_address":
             from navegador.contract import AddressError, resolve

--- a/navegador/targeting.py
+++ b/navegador/targeting.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 # How much a hit from each source contributes before rank fusion. Exact text
 # is weighted hardest: if a literal appears somewhere, that is a fact, whereas
 # vector similarity is a guess and structure is context.
-WEIGHTS = {"exact": 1.0, "symbol": 0.9, "vector": 0.6, "structure": 0.4}
+WEIGHTS = {"exact": 1.0, "symbol": 0.9, "prose": 0.7, "vector": 0.6, "structure": 0.4}
 
 # Reciprocal rank fusion constant. 60 is the value from the original TREC work
 # and is not sensitive enough to be worth tuning here.
@@ -125,6 +125,7 @@ class Targeting:
         ranked = {
             "exact": self._exact(intent, limit),
             "symbol": self._symbols(intent, limit),
+            "prose": self._prose(intent, limit),
             "structure": self._documents(intent, limit),
         }
         if self._provider is not None:
@@ -180,6 +181,25 @@ class Targeting:
                     seen.add(candidate.key())
                     found.append(candidate)
         return found[:limit]
+
+    def _prose(self, intent: str, limit: int) -> list[Candidate]:
+        """
+        Files whose literals, comments or identifiers are about the intent.
+
+        This is what answers a pasted error message or a phrase like "rate
+        limiting" that appears in a comment but in no symbol name (#185).
+        """
+        try:
+            from navegador.graph.prose import ProseIndex
+
+            hits = ProseIndex(self._store).search(intent, limit=limit)
+        except Exception:
+            return []
+        return [
+            Candidate(path=h["path"], reasons=["text in this file is about that"])
+            for h in hits
+            if h.get("path")
+        ]
 
     def _documents(self, intent: str, limit: int) -> list[Candidate]:
         """Documents mentioning the intent — decisions and prose are context."""

--- a/navegador/targeting.py
+++ b/navegador/targeting.py
@@ -294,17 +294,31 @@ class Targeting:
 
         def names(cypher: str) -> list[dict]:
             rows = self._store.query(cypher, {"symbol": symbol}).result_set
-            return [{"name": row[0], "path": row[1] or ""} for row in rows or [] if row and row[0]]
+            entries = []
+            for row in rows or []:
+                if not row or not row[0]:
+                    continue
+                entry = {"name": row[0], "path": row[1] or ""}
+                # Whether the edge was resolved or guessed. tree-sitter has no
+                # name resolution, so a call edge comes from import heuristics
+                # that are usually right; an agent should be able to tell that
+                # apart from a fact (#188).
+                if len(row) > 2 and row[2]:
+                    entry["resolution"] = row[2]
+                entries.append(entry)
+            return entries
 
         base = "MATCH (n) WHERE (n:Function OR n:Method OR n:Class) AND n.name = $symbol "
         return {
             "symbol": symbol,
             "defined_in": names(base + "RETURN n.name, coalesce(n.file_path,'') LIMIT 5"),
             "callers": names(
-                base + "MATCH (c)-[:CALLS]->(n) RETURN c.name, coalesce(c.file_path,'') LIMIT 25"
+                base + "MATCH (c)-[r:CALLS]->(n) "
+                "RETURN c.name, coalesce(c.file_path,''), coalesce(r.resolution,'') LIMIT 25"
             ),
             "callees": names(
-                base + "MATCH (n)-[:CALLS]->(c) RETURN c.name, coalesce(c.file_path,'') LIMIT 25"
+                base + "MATCH (n)-[r:CALLS]->(c) "
+                "RETURN c.name, coalesce(c.file_path,''), coalesce(r.resolution,'') LIMIT 25"
             ),
             "tests": names(
                 base + "MATCH (t)-[:TESTS]->(n) RETURN t.name, coalesce(t.file_path,'') LIMIT 25"

--- a/navegador/targeting.py
+++ b/navegador/targeting.py
@@ -1,0 +1,292 @@
+"""
+Tell an agent where to look. Do not tell it what the answer is (#186).
+
+Grep is not the problem. Once an agent knows where to point it, grep is fast
+and precise, and telemetry from 151 real sessions says agents already scope
+96.5% of their searches to a named file, file list or subdirectory. Only 3.4%
+sweep a whole tree.
+
+What costs is the turns spent working out *where* — 206 tool calls in a median
+session, 32% of file reads re-opening something already read. Each of those
+turns is inference latency and context window, not disk. So the unit of waste
+is a turn, and the number to move is turns-to-first-correct-target, which the
+frozen baseline in ``scripts/baselines/`` puts at 13.
+
+Hence three tools that return a **scope**, not an answer:
+
+``locate``
+    Ranked places to look, each with the reason it surfaced. Fuses exact
+    matches from the trigram index, vector similarity, and graph structure.
+
+``scope_for``
+    The file set reachable from a symbol, shaped to hand straight to ripgrep.
+    This is the search-space reduction no flat index can compute, and it is
+    the whole argument for doing this inside a graph.
+
+``neighbourhood``
+    What the agent would otherwise spend three more turns learning: callers,
+    callees, tests, and the file a symbol lives in.
+
+None of them write, and none of them synthesise an answer. Being handed six
+files and a reason beats being handed a paragraph the agent has to trust.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# How much a hit from each source contributes before rank fusion. Exact text
+# is weighted hardest: if a literal appears somewhere, that is a fact, whereas
+# vector similarity is a guess and structure is context.
+WEIGHTS = {"exact": 1.0, "symbol": 0.9, "vector": 0.6, "structure": 0.4}
+
+# Reciprocal rank fusion constant. 60 is the value from the original TREC work
+# and is not sensitive enough to be worth tuning here.
+RRF_K = 60
+
+
+@dataclass
+class Candidate:
+    """One place worth looking, and why."""
+
+    path: str
+    line: int = 0
+    symbol: str = ""
+    score: float = 0.0
+    reasons: list[str] = field(default_factory=list)
+
+    def key(self) -> tuple[str, int]:
+        return (self.path, self.line)
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "line": self.line,
+            "symbol": self.symbol,
+            "score": round(self.score, 4),
+            "reasons": self.reasons,
+        }
+
+
+def _fuse(ranked: dict[str, list[Candidate]]) -> list[Candidate]:
+    """
+    Reciprocal rank fusion across sources.
+
+    Scores from a trigram index, a vector index and a graph traversal are not
+    on comparable scales, so they cannot simply be added. Fusing on *rank*
+    sidesteps that: each source votes by position, weighted by how much its
+    kind of evidence is worth.
+    """
+    merged: dict[tuple[str, int], Candidate] = {}
+    for source, candidates in ranked.items():
+        weight = WEIGHTS.get(source, 0.5)
+        for position, candidate in enumerate(candidates):
+            existing = merged.get(candidate.key())
+            if existing is None:
+                existing = Candidate(
+                    path=candidate.path, line=candidate.line, symbol=candidate.symbol
+                )
+                merged[candidate.key()] = existing
+            existing.score += weight / (RRF_K + position + 1)
+            for reason in candidate.reasons:
+                if reason not in existing.reasons:
+                    existing.reasons.append(reason)
+            if candidate.symbol and not existing.symbol:
+                existing.symbol = candidate.symbol
+    return sorted(merged.values(), key=lambda c: (-c.score, c.path, c.line))
+
+
+class Targeting:
+    """
+    Where-to-look queries over one graph.
+
+    Args:
+        store: A :class:`~navegador.graph.GraphStore`.
+        provider: Optional LLM provider for vector search. Without one the
+            other sources still answer — semantic similarity is an
+            improvement, not a requirement.
+    """
+
+    def __init__(self, store, provider=None) -> None:
+        self._store = store
+        self._provider = provider
+
+    # ── locate ────────────────────────────────────────────────────────────
+
+    def locate(self, intent: str, limit: int = 10) -> list[Candidate]:
+        """
+        Ranked places to look for *intent*, each with a stated reason.
+
+        Sources are queried independently and fused on rank. A source that
+        fails or is unavailable contributes nothing and the rest still answer,
+        because a targeting tool that returns nothing is worse than one that
+        returns a partial list.
+        """
+        ranked = {
+            "exact": self._exact(intent, limit),
+            "symbol": self._symbols(intent, limit),
+            "structure": self._documents(intent, limit),
+        }
+        if self._provider is not None:
+            ranked["vector"] = self._vector(intent, limit)
+        return _fuse(ranked)[:limit]
+
+    def _exact(self, intent: str, limit: int) -> list[Candidate]:
+        """Literal occurrences. The strongest evidence: it is either there or not."""
+        try:
+            from navegador.graph.trigram import TrigramIndex
+
+            matches = TrigramIndex(self._store).search(intent, limit=limit)
+        except Exception:
+            return []
+        return [
+            Candidate(
+                path=m.path,
+                line=m.line,
+                score=1.0,
+                reasons=[f"text appears here: {m.text.strip()[:80]}"],
+            )
+            for m in matches
+        ]
+
+    def _symbols(self, intent: str, limit: int) -> list[Candidate]:
+        """
+        Symbols whose name resembles the intent.
+
+        Matching on the whole intent rarely hits, so each word is tried; an
+        agent asking about "rate limiting" is looking for `rate_limit`.
+        """
+        words = [w for w in intent.replace("_", " ").split() if len(w) > 2]
+        if not words:
+            return []
+        found: list[Candidate] = []
+        seen: set[tuple[str, int]] = set()
+        for word in words[:4]:
+            rows = self._store.query(
+                "MATCH (n) WHERE (n:Function OR n:Method OR n:Class) "
+                "AND toLower(n.name) CONTAINS toLower($word) "
+                "RETURN n.name, coalesce(n.file_path,''), coalesce(n.line_start,0), labels(n)[0] "
+                "LIMIT $limit",
+                {"word": word, "limit": limit},
+            ).result_set
+            for name, path, line, label in rows or []:
+                candidate = Candidate(
+                    path=path,
+                    line=int(line or 0),
+                    symbol=name,
+                    reasons=[f"{label.lower()} named {name}"],
+                )
+                if candidate.key() not in seen:
+                    seen.add(candidate.key())
+                    found.append(candidate)
+        return found[:limit]
+
+    def _documents(self, intent: str, limit: int) -> list[Candidate]:
+        """Documents mentioning the intent — decisions and prose are context."""
+        rows = self._store.query(
+            "MATCH (d:Document) WHERE toLower(coalesce(d.title,'')) CONTAINS toLower($intent) "
+            "RETURN coalesce(d.path,''), coalesce(d.title,'') LIMIT $limit",
+            {"intent": intent, "limit": limit},
+        ).result_set
+        return [Candidate(path=path, reasons=[f"document: {title}"]) for path, title in rows or []]
+
+    def _vector(self, intent: str, limit: int) -> list[Candidate]:
+        try:
+            from navegador.intelligence.search import SemanticSearch
+
+            hits = SemanticSearch(self._store, self._provider).search(intent, limit=limit)
+        except Exception:
+            return []
+        return [
+            Candidate(
+                path=h.get("file_path", ""),
+                symbol=h.get("name", ""),
+                reasons=[f"semantically similar ({h.get('score', 0):.2f})"],
+            )
+            for h in hits
+            if h.get("file_path")
+        ]
+
+    # ── scope_for ─────────────────────────────────────────────────────────
+
+    def scope_for(self, symbol: str, depth: int = 2) -> list[str]:
+        """
+        Files reachable from *symbol*, for handing straight to a grep.
+
+        Depth is inlined rather than parameterised because FalkorDB rejects a
+        parameterised variable-length bound — the bug behind traversals
+        silently returning nothing in 1.2.0.
+
+        Returns paths, sorted, with the symbol's own file first if present.
+        """
+        depth = max(1, min(int(depth), 5))
+        rows = self._store.query(
+            "MATCH (n) WHERE (n:Function OR n:Method OR n:Class) AND n.name = $symbol "
+            f"MATCH (n)-[:CALLS|REFERENCES|IMPORTS*1..{depth}]-(m) "
+            "RETURN DISTINCT coalesce(m.file_path, '') ",
+            {"symbol": symbol},
+        ).result_set
+        paths = {row[0] for row in rows or [] if row and row[0]}
+
+        own = self._store.query(
+            "MATCH (n) WHERE (n:Function OR n:Method OR n:Class) AND n.name = $symbol "
+            "RETURN DISTINCT coalesce(n.file_path,'')",
+            {"symbol": symbol},
+        ).result_set
+        home = {row[0] for row in own or [] if row and row[0]}
+        return sorted(home) + sorted(paths - home)
+
+    def hashes_for_paths(self, paths: list[str]) -> set[str]:
+        """
+        Content hashes for *paths*, so a scope can be handed to the trigram
+        index — which addresses blobs by hash, not path.
+        """
+        if not paths:
+            return set()
+        rows = self._store.query(
+            "MATCH (f:File) WHERE f.path IN $paths RETURN f.content_hash",
+            {"paths": list(paths)},
+        ).result_set
+        return {row[0] for row in rows or [] if row and row[0]}
+
+    def search_within(self, symbol: str, pattern: str, depth: int = 2, limit: int = 50):
+        """
+        Search only what *symbol* reaches. The reduction, end to end.
+
+        An empty scope returns nothing rather than falling back to the whole
+        repository: "no results in this scope" is a real answer, and silently
+        widening it would make the scope meaningless.
+        """
+        from navegador.graph.trigram import TrigramIndex
+
+        scope = self.hashes_for_paths(self.scope_for(symbol, depth=depth))
+        return TrigramIndex(self._store).search(pattern, scope=scope, limit=limit)
+
+    # ── neighbourhood ─────────────────────────────────────────────────────
+
+    def neighbourhood(self, symbol: str) -> dict:
+        """
+        Callers, callees, tests and home file for *symbol*.
+
+        Everything an agent would otherwise spend several turns rediscovering,
+        in one answer.
+        """
+
+        def names(cypher: str) -> list[dict]:
+            rows = self._store.query(cypher, {"symbol": symbol}).result_set
+            return [{"name": row[0], "path": row[1] or ""} for row in rows or [] if row and row[0]]
+
+        base = "MATCH (n) WHERE (n:Function OR n:Method OR n:Class) AND n.name = $symbol "
+        return {
+            "symbol": symbol,
+            "defined_in": names(base + "RETURN n.name, coalesce(n.file_path,'') LIMIT 5"),
+            "callers": names(
+                base + "MATCH (c)-[:CALLS]->(n) RETURN c.name, coalesce(c.file_path,'') LIMIT 25"
+            ),
+            "callees": names(
+                base + "MATCH (n)-[:CALLS]->(c) RETURN c.name, coalesce(c.file_path,'') LIMIT 25"
+            ),
+            "tests": names(
+                base + "MATCH (t)-[:TESTS]->(n) RETURN t.name, coalesce(t.file_path,'') LIMIT 25"
+            ),
+        }

--- a/navegador/vcs.py
+++ b/navegador/vcs.py
@@ -120,6 +120,30 @@ class GitAdapter(VCSAdapter):
         result = self._run(["rev-parse", "--abbrev-ref", "HEAD"])
         return result.stdout.strip()
 
+    def visible_files(self) -> list[str]:
+        """
+        Repo-relative paths of every file git does not ignore.
+
+        ``ls-files --cached --others --exclude-standard`` is tracked files plus
+        untracked ones that survive the exclude rules, which is exactly the set
+        a tool like ripgrep walks. Using git as the oracle rather than matching
+        ``.gitignore`` ourselves keeps nested ignore files, negation patterns,
+        anchoring, ``core.excludesFile`` and ``.git/info/exclude`` correct for
+        free — all of which a hand-rolled matcher gets subtly wrong (#180).
+
+        Returns an empty list outside a git repository, which callers read as
+        "no opinion" and fall back to walking everything.
+        """
+        if not self.is_repo():
+            return []
+        result = self._run(
+            ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        return [p for p in result.stdout.split("\0") if p]
+
     def changed_files(self, since: str = "") -> list[str]:
         """
         Return file paths that differ from *since* (or from HEAD when empty).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,3 +142,13 @@ addopts = "--cov=navegador"
 filterwarnings = [
     "ignore::ResourceWarning",
 ]
+
+[tool.coverage.report]
+# A ratchet, not a target. Coverage was measured but never enforced, so the
+# number drifted freely; it sat at 94% while all eight of the 1.5 fidelity
+# bugs shipped inside covered lines. Raising the bar would not have caught
+# any of them — see tests/test_no_store_mocks.py for the rule that would.
+#
+# Set one point below the measured value so an unrelated change does not
+# fail on noise. Raise it when coverage rises on its own; never lower it.
+fail_under = 93

--- a/scripts/baselines/retrieval-2026-08-16.json
+++ b/scripts/baselines/retrieval-2026-08-16.json
@@ -1,0 +1,65 @@
+{
+  "sample": {
+    "sessions": 133,
+    "projects": 22,
+    "tool_calls": 57972,
+    "idle_threshold_s": 120.0
+  },
+  "orientation_turns": {
+    "n": 1477,
+    "mean": 8.16,
+    "p25": 2,
+    "p50": 5,
+    "p75": 10,
+    "p90": 19
+  },
+  "turns_to_first_target": {
+    "n": 5016,
+    "mean": 25.44,
+    "p25": 5,
+    "p50": 13.0,
+    "p75": 32,
+    "p90": 62
+  },
+  "reread_ratio": {
+    "n": 124,
+    "mean": 1.27,
+    "p25": 1.0,
+    "p50": 1.17,
+    "p75": 1.41,
+    "p90": 1.64
+  },
+  "fs_reads_per_active_minute": {
+    "n": 133,
+    "mean": 0.52,
+    "p25": 0.25,
+    "p50": 0.45,
+    "p75": 0.7,
+    "p90": 0.99
+  },
+  "tool_calls_per_session": {
+    "n": 133,
+    "mean": 435.88,
+    "p25": 76,
+    "p50": 206,
+    "p75": 524,
+    "p90": 1045
+  },
+  "scope_mix_pct": {
+    "file list": 49.0,
+    "single file": 43.1,
+    "subdirectory": 4.4,
+    "whole tree": 3.4,
+    "glob": 0.1
+  },
+  "top_tools": {
+    "Bash": 40752,
+    "Edit": 6713,
+    "Read": 2817,
+    "Write": 1818,
+    "mcp__claude-in-chrome__computer": 977,
+    "TaskUpdate": 925,
+    "TaskCreate": 553,
+    "mcp__claude-in-chrome__navigate": 395
+  }
+}

--- a/scripts/retrieval_telemetry.py
+++ b/scripts/retrieval_telemetry.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+Measure how much work an agent spends finding things (#187).
+
+Navegador's thesis is that agents waste effort locating code, not reading it —
+so the metric that matters is turns spent orienting, not bytes scanned. This
+script freezes a baseline from real agent transcripts so the claim can be
+tested after the targeting tools land, rather than asserted.
+
+Usage::
+
+    python scripts/retrieval_telemetry.py                     # human table
+    python scripts/retrieval_telemetry.py --json out.json     # machine readable
+    python scripts/retrieval_telemetry.py --baseline old.json # compare
+
+Transcripts are Claude Code session logs: one JSON object per line under
+``~/.claude/projects/<project>/<session>.jsonl``. Nothing here is specific to
+navegador's own repo — point it at any project directory.
+
+Two measurement decisions carry the whole report, and both are deliberate:
+
+**Active time, not wall time.** Sessions are resumed across days, so wall
+duration says more about the human's calendar than the agent's behaviour.
+Active time sums the gaps between consecutive events that are shorter than
+``--idle-threshold``. The median inter-event gap inside active time is a few
+seconds, so the default of 120s is far above the working cadence and cuts
+only genuine human-away pauses.
+
+**A pipe is not a disk read.** ``Grep``/``Glob`` tool calls are almost never
+used in practice — filesystem search goes through ``Bash``. But a large share
+of Bash calls are ``git log | grep ...``, which filters another command's
+stdout and never touches the filesystem. Counting every command containing
+"grep" roughly triples the apparent read rate. Only a search binary in the
+*first* pipeline position is counted as a read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import statistics
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+# Commands that read the filesystem when they lead a pipeline.
+SEARCH_COMMANDS = {"grep", "rg", "find", "fd", "cat", "ls", "head", "tail", "awk", "sed"}
+# Tools that read the filesystem directly.
+READ_TOOLS = {"Read", "Grep", "Glob"}
+# Tools that represent productive work rather than orientation.
+WRITE_TOOLS = {"Edit", "Write", "NotebookEdit"}
+
+
+def parse_timestamp(raw: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def leading_command(command: str) -> str | None:
+    """
+    The binary in the first pipeline position, or None if unparseable.
+
+    ``git log | grep x`` returns "git": the grep filters stdout and never
+    touches disk, so counting it as a read overstates retrieval badly.
+    """
+    first = command.split("|")[0].strip()
+    if not first:
+        return None
+    try:
+        tokens = shlex.split(first)
+    except ValueError:
+        return None  # unbalanced quotes; caller falls back
+    for token in tokens:
+        if "=" in token and not token.startswith("-"):
+            continue  # leading VAR=value assignments
+        return Path(token).name
+    return None
+
+
+def bash_paths(command: str) -> list[str]:
+    """Non-flag arguments of the leading command, used for scope analysis."""
+    first = command.split("|")[0].strip()
+    try:
+        tokens = shlex.split(first)
+    except ValueError:
+        return []
+    return [t for t in tokens[2:] if not t.startswith("-")]
+
+
+class ToolCall:
+    __slots__ = ("name", "input", "timestamp", "is_read", "is_write", "paths")
+
+    def __init__(self, name: str, tool_input: dict, timestamp: datetime | None) -> None:
+        self.name = name
+        self.input = tool_input if isinstance(tool_input, dict) else {}
+        self.timestamp = timestamp
+        self.is_write = name in WRITE_TOOLS
+        self.is_read, self.paths = self._classify()
+
+    def _classify(self) -> tuple[bool, list[str]]:
+        if self.name in READ_TOOLS:
+            target = self.input.get("file_path") or self.input.get("path") or ""
+            return True, [target] if target else []
+        if self.name == "Bash":
+            command = self.input.get("command", "")
+            lead = leading_command(command)
+            if lead in SEARCH_COMMANDS:
+                # sed -i rewrites a file; it is a write wearing a read's clothes
+                if lead == "sed" and "-i" in command.split():
+                    return False, []
+                return True, bash_paths(command)
+        return False, []
+
+    def touches(self, path: str) -> bool:
+        """
+        True when this call refers to *path* as a file, not merely as a place.
+
+        Substring matching is wrong here: ``grep -r foo src/`` would "touch"
+        every file under src/, so a broad sweep would score as having found
+        the target immediately and the metric would flatter any agent that
+        greps widely. A candidate only counts when it looks like a file
+        reference and resolves to the same one.
+        """
+        target = path.strip()
+        if not target:
+            return False
+        for candidate in self.paths:
+            if not candidate or not Path(candidate).suffix:
+                continue  # a directory or a search pattern, not a file
+            if candidate == target or target.endswith(candidate) or candidate.endswith(target):
+                return True
+        return False
+
+
+class Session:
+    """One transcript, reduced to the calls and the episode boundaries."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.project = path.parent.name
+        self.calls: list[ToolCall] = []
+        self.timestamps: list[datetime] = []
+        # Index into self.calls where each user turn began.
+        self.episode_starts: list[int] = []
+        self._load()
+
+    def _load(self) -> None:
+        with self.path.open(encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                stamp = parse_timestamp(event.get("timestamp", ""))
+                if stamp is not None:
+                    self.timestamps.append(stamp)
+                message = event.get("message")
+                if not isinstance(message, dict):
+                    continue
+                if event.get("type") == "user" and message.get("role") == "user":
+                    content = message.get("content")
+                    # A tool_result also arrives as a user message; only a real
+                    # human turn starts a new episode.
+                    if isinstance(content, str) or (
+                        isinstance(content, list)
+                        and not any(
+                            isinstance(p, dict) and p.get("type") == "tool_result" for p in content
+                        )
+                    ):
+                        self.episode_starts.append(len(self.calls))
+                for part in message.get("content") or []:
+                    if isinstance(part, dict) and part.get("type") == "tool_use":
+                        self.calls.append(
+                            ToolCall(part.get("name", "?"), part.get("input", {}), stamp)
+                        )
+
+    def active_minutes(self, idle_threshold: float) -> float:
+        stamps = sorted(self.timestamps)
+        total = 0.0
+        for earlier, later in zip(stamps, stamps[1:]):
+            gap = (later - earlier).total_seconds()
+            if 0 <= gap < idle_threshold:
+                total += gap
+        return total / 60.0
+
+    def episodes(self) -> list[list[ToolCall]]:
+        if not self.calls:
+            return []
+        bounds = sorted(set(self.episode_starts + [0, len(self.calls)]))
+        return [self.calls[a:b] for a, b in zip(bounds, bounds[1:]) if b > a]
+
+    # ── Thesis metrics ────────────────────────────────────────────────────
+
+    def orientation_turns(self) -> list[int]:
+        """
+        Calls made before the first edit in each episode.
+
+        The agent is looking rather than changing anything. If targeting works,
+        this is the number that falls.
+        """
+        out = []
+        for episode in self.episodes():
+            for index, call in enumerate(episode):
+                if call.is_write:
+                    out.append(index)
+                    break
+        return out
+
+    def turns_to_first_target(self) -> list[int]:
+        """
+        Calls before first touching a file the episode goes on to edit.
+
+        Orientation turns can be gamed by an agent that edits early and badly.
+        This asks a sharper question: how long until it laid hands on the file
+        that actually mattered? Only files that were edited count, so reading
+        for legitimate context is not scored as waste.
+        """
+        out = []
+        for episode in self.episodes():
+            edited = {
+                call.input.get("file_path", "")
+                for call in episode
+                if call.is_write and call.input.get("file_path")
+            }
+            for target in edited:
+                for index, call in enumerate(episode):
+                    if call.touches(target) or call.input.get("file_path") == target:
+                        out.append(index)
+                        break
+        return out
+
+    def reread_ratio(self) -> float | None:
+        """Reads divided by distinct files read; 1.0 means nothing re-opened."""
+        files = [
+            call.input.get("file_path")
+            for call in self.calls
+            if call.name == "Read" and call.input.get("file_path")
+        ]
+        if not files:
+            return None
+        return len(files) / len(set(files))
+
+    def scope_mix(self) -> Counter:
+        """How narrowly searches are aimed — the 2026-08 baseline was 94.6% scoped."""
+        mix: Counter = Counter()
+        for call in self.calls:
+            if not call.is_read:
+                continue
+            if call.name == "Read":
+                mix["single file"] += 1
+            elif not call.paths or call.paths == ["."]:
+                mix["whole tree"] += 1
+            elif len(call.paths) > 1:
+                mix["file list"] += 1
+            elif any(ch in call.paths[0] for ch in "*?["):
+                mix["glob"] += 1
+            elif Path(call.paths[0]).suffix:
+                mix["single file"] += 1
+            else:
+                mix["subdirectory"] += 1
+        return mix
+
+
+def percentiles(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {}
+    ordered = sorted(values)
+
+    def at(q: float) -> float:
+        return ordered[min(int(q * len(ordered)), len(ordered) - 1)]
+
+    return {
+        "n": len(ordered),
+        "mean": round(statistics.fmean(ordered), 2),
+        "p25": round(at(0.25), 2),
+        "p50": round(statistics.median(ordered), 2),
+        "p75": round(at(0.75), 2),
+        "p90": round(at(0.90), 2),
+    }
+
+
+def collect(root: Path, min_calls: int, idle: float) -> tuple[list[Session], dict]:
+    sessions = []
+    for path in sorted(root.glob("*/*.jsonl")):
+        if "subagents" in path.parts:
+            continue  # no independent session semantics
+        try:
+            session = Session(path)
+        except OSError:
+            continue
+        if len(session.calls) >= min_calls and session.active_minutes(idle) >= 1:
+            sessions.append(session)
+
+    orientation: list[float] = []
+    to_target: list[float] = []
+    rereads: list[float] = []
+    read_rate: list[float] = []
+    calls_per_session: list[float] = []
+    tools: Counter = Counter()
+    scope: Counter = Counter()
+
+    for session in sessions:
+        minutes = session.active_minutes(idle)
+        reads = sum(1 for c in session.calls if c.is_read)
+        orientation.extend(session.orientation_turns())
+        to_target.extend(session.turns_to_first_target())
+        ratio = session.reread_ratio()
+        if ratio is not None:
+            rereads.append(ratio)
+        if minutes > 0:
+            read_rate.append(reads / minutes)
+        calls_per_session.append(len(session.calls))
+        tools.update(c.name for c in session.calls)
+        scope.update(session.scope_mix())
+
+    total_scope = sum(scope.values()) or 1
+    return sessions, {
+        "sample": {
+            "sessions": len(sessions),
+            "projects": len({s.project for s in sessions}),
+            "tool_calls": sum(len(s.calls) for s in sessions),
+            "idle_threshold_s": idle,
+        },
+        "orientation_turns": percentiles(orientation),
+        "turns_to_first_target": percentiles(to_target),
+        "reread_ratio": percentiles(rereads),
+        "fs_reads_per_active_minute": percentiles(read_rate),
+        "tool_calls_per_session": percentiles(calls_per_session),
+        "scope_mix_pct": {k: round(100 * v / total_scope, 1) for k, v in scope.most_common()},
+        "top_tools": dict(tools.most_common(8)),
+    }
+
+
+def render(report: dict, baseline: dict | None) -> str:
+    lines = []
+    sample = report["sample"]
+    lines.append(
+        f"{sample['sessions']} sessions across {sample['projects']} projects, "
+        f"{sample['tool_calls']:,} tool calls "
+        f"(idle threshold {sample['idle_threshold_s']:.0f}s)"
+    )
+    lines.append("")
+    header = f"{'metric':<32}{'p25':>9}{'p50':>9}{'p75':>9}{'p90':>9}"
+    if baseline:
+        header += f"{'p50 was':>11}{'delta':>9}"
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for key in (
+        "turns_to_first_target",
+        "orientation_turns",
+        "reread_ratio",
+        "fs_reads_per_active_minute",
+        "tool_calls_per_session",
+    ):
+        stats = report.get(key)
+        if not stats:
+            continue
+        row = f"{key:<32}{stats['p25']:>9}{stats['p50']:>9}{stats['p75']:>9}{stats['p90']:>9}"
+        if baseline and (was := baseline.get(key, {}).get("p50")) is not None:
+            delta = stats["p50"] - was
+            row += f"{was:>11}{delta:>+9.2f}"
+        lines.append(row)
+
+    lines.append("")
+    lines.append(
+        "search scope:  " + "  ".join(f"{k} {v}%" for k, v in report["scope_mix_pct"].items())
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    parser.add_argument(
+        "--transcripts",
+        type=Path,
+        default=Path.home() / ".claude" / "projects",
+        help="Directory of <project>/<session>.jsonl transcripts",
+    )
+    parser.add_argument("--json", type=Path, help="Write the report as JSON")
+    parser.add_argument("--baseline", type=Path, help="Earlier JSON report to compare against")
+    parser.add_argument("--min-calls", type=int, default=10, help="Ignore trivial sessions")
+    parser.add_argument(
+        "--idle-threshold",
+        type=float,
+        default=120.0,
+        help="Gaps longer than this are the human being away, not the agent working",
+    )
+    args = parser.parse_args()
+
+    if not args.transcripts.is_dir():
+        parser.error(f"no transcripts at {args.transcripts}")
+
+    _, report = collect(args.transcripts, args.min_calls, args.idle_threshold)
+    if not report["sample"]["sessions"]:
+        print("No sessions matched.")
+        return 1
+
+    baseline = json.loads(args.baseline.read_text()) if args.baseline else None
+    print(render(report, baseline))
+
+    if args.json:
+        args.json.write_text(json.dumps(report, indent=2))
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_startup.py
+++ b/tests/test_cli_startup.py
@@ -1,0 +1,87 @@
+"""
+The CLI does not import what it does not need (#190).
+
+Importing ``navegador.cli.commands`` cost ~137ms, of which ~95ms was
+``rich.markdown`` (which drags in markdown_it and pygments) and ``asyncio``.
+Only ``manual`` renders markdown and only the MCP server needs asyncio, but
+every invocation paid for both — including the agent hooks, which shell out
+once per call against a graph query that takes 0.45ms.
+
+These tests pin the cost down. They are worth more than a benchmark because
+they fail deterministically the moment someone adds a convenient top-level
+import, rather than slowly getting worse.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+# Modules no command should pull in merely by being importable. Each is either
+# expensive on its own or drags in a large tree.
+FORBIDDEN_AT_IMPORT = [
+    "rich.markdown",
+    "markdown_it",
+    "pygments",
+    "asyncio",
+]
+
+
+def import_and_report(module: str, probes: list[str]) -> dict[str, bool]:
+    """Import *module* in a clean interpreter and report which probes loaded."""
+    code = (
+        f"import importlib, json, sys;"
+        f"importlib.import_module({module!r});"
+        f"print(json.dumps({{p: p in sys.modules for p in {probes!r}}}))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    import json
+
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestExpensiveImportsAreDeferred:
+    @pytest.mark.parametrize("module", FORBIDDEN_AT_IMPORT)
+    def test_not_imported_by_the_cli_module(self, module):
+        loaded = import_and_report("navegador.cli.commands", FORBIDDEN_AT_IMPORT)
+        assert not loaded[module], (
+            f"{module} is imported at CLI module load. It was moved into the "
+            f"function that needs it in #190; a top-level import puts ~95ms "
+            f"back onto every invocation."
+        )
+
+    def test_the_cheap_ones_are_still_eager(self):
+        """
+        click and rich.console are needed by essentially every command, so
+        deferring them would trade startup cost for scattered import lines
+        and no benefit. This documents where the line sits.
+        """
+        loaded = import_and_report("navegador.cli.commands", ["click", "rich.console"])
+        assert loaded["click"]
+        assert loaded["rich.console"]
+
+
+class TestStillWorks:
+    """Deferring an import must not break the feature that needs it."""
+
+    def test_manual_renders_markdown(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from navegador.cli.commands import main; main()",
+                "manual",
+                "getting-started/quickstart",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Quick Start" in result.stdout
+
+    def test_mcp_command_resolves(self):
+        from navegador.cli.commands import main
+
+        assert main.commands.get("mcp") is not None

--- a/tests/test_cli_targeting.py
+++ b/tests/test_cli_targeting.py
@@ -1,0 +1,166 @@
+"""
+CLI surface for targeting and lexical search (#184, #186).
+
+These commands are the thing a person actually touches, and none of them were
+covered by a CLI-level test — the modules underneath were. That gap is worth
+closing on its own terms: a working `TrigramIndex` behind a command that
+crashes on a flag is still a broken feature, and the two connection bugs found
+in this milestone only appeared at the boundary between layers.
+
+Every test drives a real embedded store through a real ingest.
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from navegador.cli.commands import main
+
+
+def flat(result) -> str:
+    """Rich wraps output at the terminal width; join it before matching."""
+    return " ".join(result.output.split())
+
+
+@pytest.fixture
+def project(tmp_path):
+    """An ingested repo, with its db path, ready for --db."""
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "auth.py").write_text(
+        "def validate_token(token):\n"
+        "    return check_signature(token)\n"
+        "\n"
+        "def check_signature(token):\n"
+        "    raise ValueError('token signature invalid')\n"
+    )
+    (root / "src" / "api.py").write_text(
+        "from src.auth import validate_token\n"
+        "\n"
+        "def handle_request(request):\n"
+        "    return validate_token(request.token)\n"
+    )
+    db = str(tmp_path / "g.db")
+    result = CliRunner().invoke(main, ["ingest", str(root), "--db", db])
+    assert result.exit_code == 0, result.output
+    return db, root
+
+
+class TestGrep:
+    def test_finds_a_literal(self, project):
+        db, _ = project
+        result = CliRunner().invoke(
+            main, ["grep", "token signature invalid", "--db", db, "--reindex"]
+        )
+        assert result.exit_code == 0
+        assert "auth.py" in flat(result)
+
+    def test_reports_line_numbers(self, project):
+        db, _ = project
+        result = CliRunner().invoke(main, ["grep", "check_signature", "--db", db, "--reindex"])
+        assert ":2:" in flat(result) or ":4:" in flat(result)
+
+    def test_regex(self, project):
+        db, _ = project
+        result = CliRunner().invoke(
+            main, ["grep", r"def \w+_token", "--db", db, "--regex", "--reindex"]
+        )
+        assert result.exit_code == 0
+        assert "auth.py" in flat(result)
+
+    def test_json_is_parseable(self, project):
+        db, _ = project
+        CliRunner().invoke(main, ["grep", "token", "--db", db, "--reindex"])
+        result = CliRunner().invoke(main, ["grep", "token", "--db", db, "--json"])
+        payload = json.loads(result.output)
+        assert payload and {"path", "line", "text", "sha"} <= set(payload[0])
+
+    def test_no_match_says_so_rather_than_failing(self, project):
+        db, _ = project
+        result = CliRunner().invoke(main, ["grep", "zzz_absent_zzz", "--db", db, "--reindex"])
+        assert result.exit_code == 0
+        assert "No matches" in flat(result)
+
+    def test_ignore_case(self, project):
+        db, _ = project
+        CliRunner().invoke(main, ["grep", "x", "--db", db, "--reindex"])
+        result = CliRunner().invoke(main, ["grep", "VALUEERROR", "--db", db, "-i"])
+        assert "auth.py" in flat(result)
+
+
+class TestScope:
+    def test_lists_reachable_files(self, project):
+        db, _ = project
+        result = CliRunner().invoke(main, ["scope", "validate_token", "--db", db])
+        assert result.exit_code == 0
+        output = flat(result)
+        assert "auth.py" in output and "api.py" in output
+
+    def test_json_shape(self, project):
+        db, _ = project
+        result = CliRunner().invoke(main, ["scope", "validate_token", "--db", db, "--json"])
+        payload = json.loads(result.output)
+        assert payload["symbol"] == "validate_token"
+        assert any("auth.py" in f for f in payload["files"])
+
+    def test_pattern_searches_within_scope(self, project):
+        db, _ = project
+        CliRunner().invoke(main, ["grep", "x", "--db", db, "--reindex"])
+        result = CliRunner().invoke(
+            main, ["scope", "validate_token", "--db", db, "--pattern", "token"]
+        )
+        assert result.exit_code == 0
+        assert "in scope" in flat(result)
+
+    def test_unknown_symbol_is_reported_not_crashed(self, project):
+        db, _ = project
+        result = CliRunner().invoke(main, ["scope", "no_such_symbol", "--db", db])
+        assert result.exit_code == 0
+        assert "No scope found" in flat(result)
+
+
+class TestLocate:
+    def test_ranks_candidates(self, project):
+        db, _ = project
+        CliRunner().invoke(main, ["grep", "x", "--db", db, "--reindex"])
+        result = CliRunner().invoke(main, ["locate", "validate token", "--db", db])
+        assert result.exit_code == 0
+        assert "auth.py" in flat(result)
+
+    def test_json_carries_reasons(self, project):
+        db, _ = project
+        CliRunner().invoke(main, ["grep", "x", "--db", db, "--reindex"])
+        result = CliRunner().invoke(main, ["locate", "validate_token", "--db", db, "--json"])
+        payload = json.loads(result.output)
+        assert payload
+        assert all(c["reasons"] for c in payload), "a ranking without a reason is untrustworthy"
+
+    def test_nothing_found_is_not_an_error(self, project):
+        db, _ = project
+        result = CliRunner().invoke(main, ["locate", "zzz_no_such_concept", "--db", db])
+        assert result.exit_code == 0
+
+    def test_limit(self, project):
+        db, _ = project
+        CliRunner().invoke(main, ["grep", "x", "--db", db, "--reindex"])
+        result = CliRunner().invoke(main, ["locate", "token", "--db", db, "-n", "2", "--json"])
+        assert len(json.loads(result.output)) <= 2
+
+
+class TestStorageAuditRequiresAServer:
+    def test_audit_explains_itself_on_an_embedded_backend(self, project):
+        """
+        These inspect a shared server. Pointed at an embedded file they should
+        say so rather than failing obscurely.
+        """
+        db, _ = project
+        result = CliRunner().invoke(main, ["storage", "audit", "--db", db])
+        assert result.exit_code != 0
+        assert "shared server" in flat(result)
+
+    def test_prune_explains_itself_too(self, project):
+        db, _ = project
+        result = CliRunner().invoke(main, ["storage", "prune", "--db", db])
+        assert result.exit_code != 0
+        assert "shared server" in flat(result)

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -1,0 +1,196 @@
+"""
+Content-addressed source storage (#183).
+
+Against a real embedded store — the store is where two of these bugs lived,
+so mocking it would test nothing. The binary-connection case in particular
+only appears against a real Redis: the graph client decodes responses, and
+compressed bytes read back through it die on the first non-UTF-8 byte.
+"""
+
+import hashlib
+
+import pytest
+
+from navegador.graph import GraphStore
+from navegador.graph.content import ContentStore
+
+SOURCE = '''"""A module — with an em dash, which is two bytes."""
+
+
+def alpha():
+    return "first"
+
+
+def beta():
+    raise ValueError("something went wrong: %s" % name)
+'''
+
+
+def sha_of(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+@pytest.fixture
+def store(tmp_path):
+    return GraphStore.sqlite(str(tmp_path / "g.db"))
+
+
+@pytest.fixture
+def content(store):
+    return ContentStore(store, graph="graph-one")
+
+
+class TestRoundTrip:
+    def test_stores_and_returns_exactly(self, content):
+        sha = sha_of(SOURCE)
+        assert content.put(sha, SOURCE) is True
+        assert content.get(sha) == SOURCE
+
+    def test_binary_payload_survives_a_decoding_client(self, content):
+        """
+        The graph connects with decode_responses=True because Cypher results
+        are text. Compressed bytes read back through that connection raise
+        UnicodeDecodeError, so the store uses a sibling connection with
+        decoding off. Non-ASCII content is what makes it fail.
+        """
+        text = "# ✂ — ünïcode ✓\nvalue = 1\n" * 40
+        sha = sha_of(text)
+        content.put(sha, text)
+        assert content.get(sha) == text
+
+    def test_missing_blob_returns_none(self, content):
+        assert content.get("0" * 64) is None
+
+    def test_lines(self, content):
+        sha = sha_of(SOURCE)
+        content.put(sha, SOURCE)
+        assert content.lines(sha)[3] == "def alpha():"
+
+
+class TestDedup:
+    def test_second_put_of_the_same_content_writes_nothing(self, content):
+        sha = sha_of(SOURCE)
+        assert content.put(sha, SOURCE) is True
+        assert content.put(sha, SOURCE) is False
+
+    def test_two_graphs_share_one_blob(self, store):
+        """
+        A vendored copy, a fork, and the same file in three workspaces are one
+        blob. Several codebases on a shared server are indexed under more than
+        one graph name, so this is the common case, not an edge case.
+        """
+        one = ContentStore(store, graph="g1")
+        two = ContentStore(store, graph="g2")
+        sha = sha_of(SOURCE)
+
+        assert one.put(sha, SOURCE) is True
+        assert two.put(sha, SOURCE) is False
+        assert two.get(sha) == SOURCE
+
+
+class TestLineResolution:
+    def test_byte_offset_resolves_to_its_line(self, content):
+        sha = sha_of(SOURCE)
+        content.put(sha, SOURCE)
+        offset = content.byte_offset_of(sha, "def beta")
+        assert content.line_at(sha, offset) == (8, "def beta():")
+
+    def test_non_ascii_shifts_byte_offsets_away_from_string_indexes(self, content):
+        """
+        The trap this API is named against. The em dash in the first line is
+        two bytes, so a Python string index is one short of the byte offset
+        and resolves to the wrong line on a long enough file.
+        """
+        sha = sha_of(SOURCE)
+        content.put(sha, SOURCE)
+
+        string_index = SOURCE.index("def beta")
+        byte_offset = content.byte_offset_of(sha, "def beta")
+        assert byte_offset > string_index, "expected the em dash to shift the offset"
+        assert content.line_at(sha, byte_offset)[0] == 8
+
+    def test_offset_past_the_end_returns_none(self, content):
+        sha = sha_of(SOURCE)
+        content.put(sha, SOURCE)
+        assert content.line_at(sha, 10**6) is None
+
+    def test_negative_offset_returns_none(self, content):
+        sha = sha_of(SOURCE)
+        content.put(sha, SOURCE)
+        assert content.line_at(sha, -1) is None
+
+    def test_offset_of_absent_needle(self, content):
+        sha = sha_of(SOURCE)
+        content.put(sha, SOURCE)
+        assert content.byte_offset_of(sha, "no_such_symbol") is None
+
+
+class TestRefcounting:
+    def test_releasing_one_holder_keeps_shared_content(self, store):
+        """
+        Deleting a graph must not take a shared file out from under another
+        graph still pointing at it.
+        """
+        one = ContentStore(store, graph="g1")
+        two = ContentStore(store, graph="g2")
+        sha = sha_of(SOURCE)
+        one.put(sha, SOURCE)
+        two.put(sha, SOURCE)
+
+        assert one.release() == 0
+        assert two.exists(sha)
+
+    def test_last_holder_releases_the_blob(self, store):
+        one = ContentStore(store, graph="g1")
+        two = ContentStore(store, graph="g2")
+        sha = sha_of(SOURCE)
+        one.put(sha, SOURCE)
+        two.put(sha, SOURCE)
+        one.release()
+
+        assert two.release() == 1
+        assert not two.exists(sha)
+
+    def test_release_is_idempotent(self, content):
+        sha = sha_of(SOURCE)
+        content.put(sha, SOURCE)
+        assert content.release() == 1
+        assert content.release() == 0
+
+    def test_re_ingesting_does_not_inflate_the_holder_set(self, content):
+        """
+        Refs are a set, not a counter: re-ingesting the same repository twice
+        must not leave a blob that takes two releases to free.
+        """
+        sha = sha_of(SOURCE)
+        content.put(sha, SOURCE)
+        content.put(sha, SOURCE)
+        content.put(sha, SOURCE)
+        assert content.release() == 1
+        assert not content.exists(sha)
+
+
+class TestStats:
+    def test_reports_compression(self, content):
+        text = SOURCE * 50
+        sha = sha_of(text)
+        content.put(sha, text)
+
+        stats = content.stats()
+        assert stats.blobs == 1
+        assert stats.original_bytes == len(text.encode("utf-8"))
+        assert stats.compressed_bytes < stats.original_bytes
+        assert stats.ratio > 1.0
+
+    def test_empty_store(self, content):
+        stats = content.stats()
+        assert stats.blobs == 0
+        assert stats.ratio == 0.0
+
+    def test_stats_are_per_graph(self, store):
+        one = ContentStore(store, graph="g1")
+        two = ContentStore(store, graph="g2")
+        one.put(sha_of(SOURCE), SOURCE)
+
+        assert one.stats().blobs == 1
+        assert two.stats().blobs == 0

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -170,6 +170,36 @@ class TestRefcounting:
         assert not content.exists(sha)
 
 
+class TestEncoding:
+    def test_short_content_is_stored_uncompressed(self, content):
+        """
+        zlib adds a header and checksum, so a short file comes back larger
+        than it went in. Storing the worse of the two forms would make the
+        content store grow the thing it exists to shrink.
+        """
+        text = "x = 1\n"
+        sha = sha_of(text)
+        content.put(sha, text)
+
+        stats = content.stats()
+        assert stats.compressed_bytes <= stats.original_bytes + 1  # +1 for the tag
+        assert content.get(sha) == text
+
+    def test_long_content_is_compressed(self, content):
+        text = SOURCE * 50
+        sha = sha_of(text)
+        content.put(sha, text)
+
+        stats = content.stats()
+        assert stats.compressed_bytes < stats.original_bytes / 2
+
+    def test_both_forms_round_trip(self, content):
+        for text in ("tiny\n", SOURCE * 40, "ünïcode — ✓\n" * 5):
+            sha = sha_of(text)
+            content.put(sha, text)
+            assert content.get(sha) == text
+
+
 class TestStats:
     def test_reports_compression(self, content):
         text = SOURCE * 50

--- a/tests/test_gitignore_ingest.py
+++ b/tests/test_gitignore_ingest.py
@@ -1,0 +1,198 @@
+"""
+Ingest respects .gitignore (#180).
+
+The bug these cover: the walk pruned on a fixed ``_SKIP_DIRS`` list and never
+read .gitignore, so a project whose build output sat in a directory outside
+that list was indexed wholesale. On one real graph 54,543 of 54,552 File nodes
+were gitignored build output under ``bundled/``.
+
+Every test builds a real git repository on disk and runs the real walk. Git is
+the oracle for what is ignored, so the assertions here are about the ingester
+asking it and honouring the answer.
+"""
+
+import subprocess
+
+import pytest
+
+from navegador.graph import GraphStore
+from navegador.ingestion import RepoIngester
+
+
+def git(repo, *args):
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A git repo with tracked source and a gitignored build directory."""
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+    (root / "bundled" / "deep").mkdir(parents=True)
+
+    (root / "src" / "app.py").write_text("def real_function():\n    return 1\n")
+    (root / "src" / "util.py").write_text("def helper():\n    return 2\n")
+    (root / "bundled" / "vendor.py").write_text("def generated_thing():\n    return 3\n")
+    (root / "bundled" / "deep" / "more.py").write_text("def deeper_generated():\n    return 4\n")
+    (root / ".gitignore").write_text("bundled/\n")
+
+    git(root, "init", "-q")
+    git(root, "config", "user.email", "t@example.com")
+    git(root, "config", "user.name", "t")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "initial")
+    return root
+
+
+def files_in(store):
+    result = store.query("MATCH (f:File) RETURN f.path")
+    return {row[0] for row in (result.result_set or [])}
+
+
+def functions_in(store):
+    result = store.query("MATCH (n:Function) RETURN n.name")
+    return {row[0] for row in (result.result_set or [])}
+
+
+class TestGitignoreIsHonoured:
+    def test_ignored_directory_is_not_indexed(self, repo, tmp_path):
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(repo)
+
+        paths = files_in(store)
+        assert "src/app.py" in paths
+        assert "src/util.py" in paths
+        assert not [p for p in paths if p.startswith("bundled/")], (
+            f"gitignored files were indexed: {sorted(p for p in paths if 'bundled' in p)}"
+        )
+
+    def test_symbols_from_ignored_files_are_absent(self, repo, tmp_path):
+        """
+        The File node is the visible half; the real damage was agents being
+        offered generated symbols as though they were source.
+        """
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(repo)
+
+        names = functions_in(store)
+        assert "real_function" in names
+        assert "generated_thing" not in names
+        assert "deeper_generated" not in names
+
+    def test_nested_ignore_file_is_honoured(self, repo, tmp_path):
+        """
+        A .gitignore deeper in the tree also applies. Hand-rolled matchers
+        routinely miss this, which is why git is the oracle.
+        """
+        (repo / "src" / "gen").mkdir()
+        (repo / "src" / "gen" / "out.py").write_text("def nested_generated():\n    return 5\n")
+        (repo / "src" / ".gitignore").write_text("gen/\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-qm", "nested ignore")
+
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(repo)
+
+        assert "nested_generated" not in functions_in(store)
+        assert "real_function" in functions_in(store)
+
+    def test_negation_pattern_is_honoured(self, repo, tmp_path):
+        """
+        ``!bundled/keep.py`` re-includes one file from an ignored tree.
+
+        The pattern is ``bundled/*`` rather than ``bundled/``: git refuses to
+        re-include a path whose parent directory is itself excluded, because
+        it never descends into it. Exactly the kind of rule a hand-rolled
+        matcher gets wrong, and the reason git is the oracle here.
+        """
+        (repo / "bundled" / "keep.py").write_text("def kept_on_purpose():\n    return 6\n")
+        (repo / ".gitignore").write_text("bundled/*\n!bundled/keep.py\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-qm", "negation")
+
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(repo)
+
+        names = functions_in(store)
+        assert "kept_on_purpose" in names
+        assert "generated_thing" not in names
+
+    def test_untracked_but_not_ignored_is_indexed(self, repo, tmp_path):
+        """
+        A brand new file nobody has committed is still source. Indexing only
+        tracked files would hide work in progress from the agent.
+        """
+        (repo / "src" / "brand_new.py").write_text("def just_written():\n    return 7\n")
+
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(repo)
+
+        assert "just_written" in functions_in(store)
+
+
+class TestOptOut:
+    def test_no_gitignore_indexes_everything(self, repo, tmp_path):
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store, respect_gitignore=False).ingest(repo)
+
+        names = functions_in(store)
+        assert "generated_thing" in names
+        assert "deeper_generated" in names
+        assert "real_function" in names
+
+
+class TestOutsideGit:
+    def test_plain_directory_still_ingests(self, tmp_path):
+        """
+        No git repo means no opinion — the walk must fall back to indexing
+        everything rather than silently producing an empty graph.
+        """
+        root = tmp_path / "plain"
+        (root / "src").mkdir(parents=True)
+        (root / "src" / "thing.py").write_text("def plain_function():\n    return 1\n")
+
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(root)
+
+        assert "plain_function" in functions_in(store)
+
+    def test_skip_dirs_still_apply_without_git(self, tmp_path):
+        """The fixed skip list remains the floor outside a git checkout."""
+        root = tmp_path / "plain"
+        (root / "node_modules").mkdir(parents=True)
+        (root / "node_modules" / "dep.py").write_text("def vendored():\n    return 1\n")
+        (root / "app.py").write_text("def mine():\n    return 2\n")
+
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(root)
+
+        names = functions_in(store)
+        assert "mine" in names
+        assert "vendored" not in names
+
+
+class TestPruningNotFiltering:
+    def test_ignored_tree_is_never_descended_into(self, repo, tmp_path, monkeypatch):
+        """
+        Correctness alone could be had by filtering files after the walk, but
+        that reintroduces the #128 hang: a huge ignored tree would still be
+        enumerated. Assert the walk never enters it.
+        """
+        import os as os_module
+
+        entered: list[str] = []
+        real_walk = os_module.walk
+
+        def tracking_walk(top, *a, **kw):
+            for dirpath, dirnames, filenames in real_walk(top, *a, **kw):
+                entered.append(str(dirpath))
+                yield dirpath, dirnames, filenames
+
+        monkeypatch.setattr("navegador.ingestion.parser.os.walk", tracking_walk)
+
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(repo)
+
+        assert not [d for d in entered if "bundled" in d], (
+            f"walk descended into an ignored tree: {[d for d in entered if 'bundled' in d]}"
+        )

--- a/tests/test_graph_audit.py
+++ b/tests/test_graph_audit.py
@@ -1,0 +1,164 @@
+"""
+Graph audit classification (#181).
+
+The audit decides what gets deleted from a shared server, so the risk is not
+that it misses something — it is that it condemns a healthy graph. Every test
+here is about the boundary between "provably wrong" and "merely unfamiliar".
+
+The one bug found while building this is worth remembering: ``GRAPH.LIST``
+returns bytes on an undecoded connection, and ``str()`` on bytes yields
+``b'name'``, which matches no graph. Every lookup missed, every graph looked
+empty, and the audit cheerfully reported 41 of 41 graphs as reclaimable —
+including populated ones. It reported success while disagreeing with reality,
+which is the exact failure class this project keeps running into.
+"""
+
+import pytest
+
+from navegador.graph.audit import GraphAudit, mark_duplicates
+
+
+def audit(name="g", nodes=100, files_total=0, files_resolved=0, root=None, **kw):
+    return GraphAudit(
+        name=name,
+        nodes=nodes,
+        files_total=files_total,
+        files_resolved=files_resolved,
+        root=root,
+        **kw,
+    )
+
+
+class TestJunkNames:
+    @pytest.mark.parametrize("name", ["1)", "9)", "telemetry{9)}", "", "  "])
+    def test_shell_artifacts_are_junk(self, name):
+        assert audit(name=name).verdict == "junk"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "navegador",
+            "navegador_my-repo",
+            "navegador_calliope-astrolift",
+            "nav_dupe_probe",
+            "repo.git",
+        ],
+    )
+    def test_ordinary_names_are_not_junk(self, name):
+        assert audit(name=name).verdict != "junk"
+
+    def test_junk_beats_every_other_verdict(self, tmp_path):
+        """A key that is not really a graph should not be probed further."""
+        assert audit(name="1)", nodes=0).verdict == "junk"
+
+
+class TestStaleness:
+    def test_no_paths_resolving_is_stale(self, tmp_path):
+        report = audit(files_total=2000, files_resolved=0, root=tmp_path)
+        assert report.verdict == "stale"
+        assert "0/2000" in report.explain()
+
+    def test_a_little_drift_is_not_stale(self, tmp_path):
+        """
+        Files get deleted between ingests. Calling that stale would condemn
+        healthy graphs, which is the expensive direction to be wrong in.
+        """
+        report = audit(files_total=1000, files_resolved=940, root=tmp_path)
+        assert report.verdict == "healthy"
+
+    def test_boundary(self, tmp_path):
+        assert audit(files_total=1000, files_resolved=50, root=tmp_path).verdict == "stale"
+        assert audit(files_total=1000, files_resolved=51, root=tmp_path).verdict == "healthy"
+
+    def test_no_checkout_is_unknown_not_stale(self):
+        """
+        A graph we cannot check is not the same as a graph we know is wrong.
+        Assuming stale here would delete data on the strength of the auditor
+        not having looked in the right place.
+        """
+        report = audit(files_total=0, files_resolved=0, root=None)
+        assert report.verdict == "unknown"
+        assert not report.reclaimable
+
+    def test_resolution_is_none_without_a_root(self):
+        assert audit(files_total=10, files_resolved=5, root=None).resolution is None
+
+
+class TestEmpty:
+    def test_zero_nodes_is_empty(self):
+        assert audit(nodes=0).verdict == "empty"
+
+    def test_empty_is_reclaimable(self):
+        assert audit(nodes=0).reclaimable
+
+
+class TestDuplicates:
+    def test_same_repository_set_is_flagged(self):
+        big = audit(name="big", nodes=500, repositories=["repo-a"])
+        small = audit(name="small", nodes=100, repositories=["repo-a"])
+        mark_duplicates([big, small])
+
+        assert small.duplicate_of == "big"
+        assert big.duplicate_of is None
+        assert small.verdict == "duplicate"
+
+    def test_larger_graph_keeps_its_identity(self):
+        small = audit(name="small", nodes=10, repositories=["r"])
+        big = audit(name="big", nodes=999, repositories=["r"])
+        mark_duplicates([small, big])
+        assert small.duplicate_of == "big"
+
+    def test_tie_is_broken_deterministically(self):
+        """Same server, same answer — not whatever order the dict yielded."""
+        first = audit(name="aaa", nodes=100, repositories=["r"])
+        second = audit(name="bbb", nodes=100, repositories=["r"])
+        mark_duplicates([second, first])
+        assert first.duplicate_of is None
+        assert second.duplicate_of == "aaa"
+
+    def test_different_repositories_are_not_duplicates(self):
+        a = audit(name="a", nodes=100, repositories=["repo-a"])
+        b = audit(name="b", nodes=100, repositories=["repo-b"])
+        mark_duplicates([a, b])
+        assert a.duplicate_of is None and b.duplicate_of is None
+
+    def test_duplicates_are_not_reclaimable(self):
+        """
+        Two graphs of one repository may differ by ingest settings or age.
+        Which one wins is the operator's call, so this reports and stops.
+        """
+        big = audit(name="big", nodes=500, repositories=["r"])
+        small = audit(name="small", nodes=100, repositories=["r"])
+        mark_duplicates([big, small])
+        assert not small.reclaimable
+
+    def test_empty_graphs_do_not_claim_a_repository(self):
+        empty = audit(name="empty", nodes=0, repositories=["r"])
+        real = audit(name="real", nodes=100, repositories=["r"])
+        mark_duplicates([empty, real])
+        assert real.duplicate_of is None
+
+
+class TestReclaimable:
+    @pytest.mark.parametrize(
+        "report,expected",
+        [
+            (GraphAudit(name="1)"), True),
+            (GraphAudit(name="ok", nodes=0), True),
+            (GraphAudit(name="ok", nodes=5), False),
+        ],
+    )
+    def test_reclaimable(self, report, expected):
+        assert report.reclaimable is expected
+
+    def test_healthy_is_never_reclaimable(self, tmp_path):
+        assert not audit(files_total=100, files_resolved=100, root=tmp_path).reclaimable
+
+
+class TestSerialisation:
+    def test_to_dict_carries_the_reasoning(self, tmp_path):
+        payload = audit(files_total=10, files_resolved=0, root=tmp_path).to_dict()
+        assert payload["verdict"] == "stale"
+        assert payload["reclaimable"] is True
+        assert payload["resolution"] == 0.0
+        assert "explanation" in payload

--- a/tests/test_graph_audit.py
+++ b/tests/test_graph_audit.py
@@ -162,3 +162,157 @@ class TestSerialisation:
         assert payload["reclaimable"] is True
         assert payload["resolution"] == 0.0
         assert "explanation" in payload
+
+
+# ── Against a real store ──────────────────────────────────────────────────────
+#
+# The classification tests above are pure. These exercise the code that talks
+# to a server, which is where the one real bug lived: GRAPH.LIST returns bytes
+# and str() on bytes yields "b'name'", so every lookup missed and every graph
+# looked empty. An embedded store is a real Redis over a unix socket, so it
+# exercises the same paths without needing a server on the machine.
+
+
+@pytest.fixture
+def live(tmp_path):
+    """An embedded store with a populated graph and a checkout on disk."""
+    from navegador.graph import GraphStore
+    from navegador.ingestion import RepoIngester
+
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "app.py").write_text("def alpha():\n    return 1\n")
+    (root / "src" / "util.py").write_text("def beta():\n    return 2\n")
+
+    store = GraphStore.sqlite(str(tmp_path / "g.db"))
+    RepoIngester(store).ingest(root)
+    return store, root
+
+
+class TestAuditGraphAgainstAStore:
+    def test_healthy_graph_with_resolving_paths(self, live):
+        from navegador.graph.audit import audit_graph
+
+        store, root = live
+        report = audit_graph(store._client, store._client.connection, store.graph_name, root=root)
+        assert report.nodes > 0
+        assert report.files_total > 0
+        assert report.files_resolved == report.files_total
+        assert report.verdict == "healthy"
+
+    def test_graph_whose_checkout_vanished_is_stale(self, live, tmp_path):
+        """The 45 MB case found on the live server, in miniature."""
+        from navegador.graph.audit import audit_graph
+
+        store, _ = live
+        report = audit_graph(
+            store._client,
+            store._client.connection,
+            store.graph_name,
+            root=tmp_path / "moved-away",
+        )
+        assert report.verdict == "stale"
+        assert report.reclaimable
+
+    def test_without_a_root_the_verdict_is_unknown(self, live):
+        from navegador.graph.audit import audit_graph
+
+        store, _ = live
+        report = audit_graph(store._client, store._client.connection, store.graph_name)
+        assert report.verdict == "unknown"
+        assert not report.reclaimable
+
+    def test_repositories_are_collected(self, live):
+        from navegador.graph.audit import audit_graph
+
+        store, root = live
+        report = audit_graph(store._client, store._client.connection, store.graph_name, root=root)
+        assert report.repositories
+
+    def test_size_is_measured(self, live):
+        """
+        DUMP, because MEMORY USAGE returns a meaningless 48 bytes for a graph
+        key — Redis cannot size a module type.
+        """
+        from navegador.graph.audit import audit_graph
+
+        store, root = live
+        report = audit_graph(store._client, store._client.connection, store.graph_name, root=root)
+        assert report.size_bytes > 48
+
+    def test_sampling_bounds_the_path_check(self, live):
+        from navegador.graph.audit import audit_graph
+
+        store, root = live
+        report = audit_graph(
+            store._client, store._client.connection, store.graph_name, root=root, sample=1
+        )
+        assert report.files_total == 1
+
+    def test_junk_named_key_is_not_queried(self, live):
+        """A junk key may not be a graph at all; probing it would raise."""
+        from navegador.graph.audit import audit_graph
+
+        store, _ = live
+        report = audit_graph(store._client, store._client.connection, "1)")
+        assert report.verdict == "junk"
+
+
+class TestGraphSizeBytes:
+    def test_missing_key_is_zero(self, live):
+        from navegador.graph.audit import graph_size_bytes
+
+        store, _ = live
+        assert graph_size_bytes(store._client.connection, "no_such_graph_here") == 0
+
+
+class TestPruneAgainstAStore:
+    def test_empty_graph_is_deleted(self, live):
+        from navegador.graph.audit import GraphAudit, prune
+
+        store, _ = live
+        connection = store._client.connection
+        connection.set("nav_empty_probe", "x")
+        report = GraphAudit(name="nav_empty_probe", nodes=0)
+
+        assert prune(connection, [report]) == ["nav_empty_probe"]
+        assert not connection.exists("nav_empty_probe")
+
+    def test_healthy_graph_is_left_alone(self, live, tmp_path):
+        from navegador.graph.audit import GraphAudit, prune
+
+        store, _ = live
+        report = GraphAudit(
+            name=store.graph_name, nodes=10, files_total=5, files_resolved=5, root=tmp_path
+        )
+        assert prune(store._client.connection, [report]) == []
+        assert store.node_count() > 0
+
+    def test_stale_is_held_back_by_default(self, live, tmp_path):
+        """
+        A moved checkout and a deleted one look identical from here, and one
+        of them is recoverable by re-ingesting.
+        """
+        from navegador.graph.audit import GraphAudit, prune
+
+        store, _ = live
+        report = GraphAudit(
+            name=store.graph_name, nodes=10, files_total=5, files_resolved=0, root=tmp_path
+        )
+        assert prune(store._client.connection, [report]) == []
+        assert store.node_count() > 0
+
+    def test_stale_goes_when_asked_explicitly(self, live, tmp_path):
+        from navegador.graph.audit import GraphAudit, prune
+
+        store, _ = live
+        report = GraphAudit(
+            name=store.graph_name, nodes=10, files_total=5, files_resolved=0, root=tmp_path
+        )
+        assert prune(store._client.connection, [report], include_stale=True) == [store.graph_name]
+
+    def test_url_form_still_accepted(self):
+        """The CLI passes a URL; only tests pass a connection."""
+        from navegador.graph.audit import prune
+
+        assert prune("redis://127.0.0.1:1", []) == []

--- a/tests/test_ingest_deletions.py
+++ b/tests/test_ingest_deletions.py
@@ -192,3 +192,38 @@ class TestPruneIsConservative:
         stats = ing.ingest(repo, clear=True)
         assert stats["removed"] == 0
         assert any(n[1] == "zeta_compute" for n in names(store))
+
+
+class TestProseIsPrunedToo:
+    """
+    FileText nodes (#185) are keyed by path and go stale with the file.
+
+    This reintroduced #168 for a node type added after that fix was written:
+    the deletion sweep knew about File, Document and Import and nothing had
+    told it about the new label, so a maintained graph quietly stopped
+    matching a clean rebuild. Caught by the equality test, not by any test
+    that looked at prose directly — which is the argument for keeping that
+    equality assertion around.
+    """
+
+    def test_prose_node_is_removed_with_its_file(self, store, tmp_path):
+        repo = write_repo(tmp_path)
+        RepoIngester(store).ingest(repo)
+        before = store.query("MATCH (t:FileText) RETURN t.path ORDER BY t.path").result_set
+        assert any("zeta" in (row[0] or "") for row in before or [])
+
+        (repo / "pkg" / "zeta.py").unlink()
+        RepoIngester(store).ingest(repo, incremental=True)
+
+        after = store.query("MATCH (t:FileText) RETURN t.path").result_set or []
+        assert not any("zeta" in (row[0] or "") for row in after)
+
+    def test_surviving_files_keep_their_prose(self, store, tmp_path):
+        """Pruning must not take the neighbours with it."""
+        repo = write_repo(tmp_path)
+        RepoIngester(store).ingest(repo)
+        (repo / "pkg" / "zeta.py").unlink()
+        RepoIngester(store).ingest(repo, incremental=True)
+
+        remaining = store.query("MATCH (t:FileText) RETURN t.path").result_set or []
+        assert any("alpha" in (row[0] or "") for row in remaining)

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -14,6 +14,7 @@ All LLM providers are mocked — no real API calls are made.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,7 @@ import pytest
 from click.testing import CliRunner
 
 from navegador.cli.commands import main
+from navegador.graph import GraphStore
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -47,169 +49,162 @@ def _mock_provider(complete_return="mocked answer", embed_return=None):
     return provider
 
 
-# ── SemanticSearch: _cosine_similarity ────────────────────────────────────────
+# ── SemanticSearch ────────────────────────────────────────────────────────────
+#
+# These run against a real embedded store and a real vector index. The previous
+# versions mocked the store and asserted the old implementation's internals —
+# JSON-encoded vectors and a Python cosine loop — so they could not survive
+# moving the k-NN search into the database (#182), and would not have noticed
+# if it returned nothing.
 
 
-class TestCosineSimilarity:
-    def setup_method(self):
-        from navegador.intelligence.search import SemanticSearch
+class DeterministicProvider:
+    """
+    A real embedding function with no network: hash tokens into buckets.
 
-        self.cls = SemanticSearch
+    Similar text lands in overlapping buckets, so ranking is meaningful and
+    reproducible without an API key or a recorded fixture.
+    """
 
-    def test_identical_vectors_return_one(self):
-        v = [1.0, 0.0, 0.0]
-        assert self.cls._cosine_similarity(v, v) == pytest.approx(1.0)
+    def __init__(self, dimension: int = 16) -> None:
+        self.dimension = dimension
+        self.calls = 0
 
-    def test_orthogonal_vectors_return_zero(self):
-        a = [1.0, 0.0]
-        b = [0.0, 1.0]
-        assert self.cls._cosine_similarity(a, b) == pytest.approx(0.0)
-
-    def test_opposite_vectors_return_minus_one(self):
-        a = [1.0, 0.0]
-        b = [-1.0, 0.0]
-        assert self.cls._cosine_similarity(a, b) == pytest.approx(-1.0)
-
-    def test_zero_vector_returns_zero(self):
-        a = [0.0, 0.0]
-        b = [1.0, 2.0]
-        assert self.cls._cosine_similarity(a, b) == 0.0
-
-    def test_different_length_vectors_return_zero(self):
-        a = [1.0, 2.0]
-        b = [1.0, 2.0, 3.0]
-        assert self.cls._cosine_similarity(a, b) == 0.0
-
-    def test_known_similarity(self):
-        a = [1.0, 1.0]
-        b = [1.0, 0.0]
-        # cos(45°) = 1/sqrt(2)
-        expected = 1.0 / math.sqrt(2)
-        assert self.cls._cosine_similarity(a, b) == pytest.approx(expected, abs=1e-6)
-
-    def test_general_non_unit_vectors(self):
-        a = [3.0, 4.0]
-        b = [3.0, 4.0]
-        # Same direction → 1.0 regardless of magnitude
-        assert self.cls._cosine_similarity(a, b) == pytest.approx(1.0)
+    def embed(self, text: str) -> list[float]:
+        self.calls += 1
+        vector = [0.0] * self.dimension
+        for token in text.lower().replace("_", " ").replace("—", " ").split():
+            vector[int(hashlib.md5(token.encode()).hexdigest(), 16) % self.dimension] += 1.0
+        norm = math.sqrt(sum(v * v for v in vector)) or 1.0
+        return [v / norm for v in vector]
 
 
-# ── SemanticSearch: index ─────────────────────────────────────────────────────
+@pytest.fixture
+def store(tmp_path):
+    return GraphStore.sqlite(str(tmp_path / "g.db"))
+
+
+@pytest.fixture
+def populated(store):
+    store.query(
+        "CREATE (:Function {name:'validate_jwt_token', file_path:'auth.py', "
+        "docstring:'verify a signed token'})"
+    )
+    store.query(
+        "CREATE (:Function {name:'render_template', file_path:'views.py', "
+        "docstring:'produce html output'})"
+    )
+    store.query(
+        "CREATE (:Class {name:'TokenValidator', file_path:'auth.py', docstring:'validates tokens'})"
+    )
+    return store
 
 
 class TestSemanticSearchIndex:
-    def test_index_embeds_and_stores(self):
+    def test_index_embeds_every_labelled_node(self, populated):
         from navegador.intelligence.search import SemanticSearch
 
-        rows = [
-            ["Function", "my_func", "app.py", "Does something important"],
-            ["Class", "MyClass", "app.py", "A useful class"],
-        ]
-        store = _mock_store(rows)
-        provider = _mock_provider(embed_return=[0.1, 0.2, 0.3])
+        provider = DeterministicProvider()
+        assert SemanticSearch(populated, provider).index() == 3
+        assert provider.calls == 3
 
-        ss = SemanticSearch(store, provider)
-        count = ss.index(limit=10)
-
-        assert count == 2
-        # embed called once per node
-        assert provider.embed.call_count == 2
-        # SET query called for each node
-        assert store.query.call_count >= 3  # 1 fetch + 2 set
-
-    def test_index_skips_nodes_without_text(self):
+    def test_reindexing_unchanged_content_embeds_nothing(self, populated):
+        """
+        The old index() re-embedded everything on every call, re-paying the
+        whole bill to learn nothing had changed.
+        """
         from navegador.intelligence.search import SemanticSearch
 
-        rows = [
-            ["Function", "no_doc", "app.py", ""],  # empty text
-            ["Class", "HasDoc", "app.py", "Some docstring"],
-        ]
-        store = _mock_store(rows)
-        provider = _mock_provider(embed_return=[0.1, 0.2])
-
-        ss = SemanticSearch(store, provider)
-        count = ss.index()
-
-        assert count == 1  # only the node with text
-        assert provider.embed.call_count == 1
-
-    def test_index_returns_zero_for_empty_graph(self):
-        from navegador.intelligence.search import SemanticSearch
-
-        store = _mock_store([])
-        provider = _mock_provider()
-        ss = SemanticSearch(store, provider)
+        ss = SemanticSearch(populated, DeterministicProvider())
+        ss.index()
         assert ss.index() == 0
-        provider.embed.assert_not_called()
 
-
-# ── SemanticSearch: search ────────────────────────────────────────────────────
-
-
-class TestSemanticSearchSearch:
-    def test_search_returns_sorted_results(self):
+    def test_changed_content_is_re_embedded(self, populated):
         from navegador.intelligence.search import SemanticSearch
 
-        # Two nodes with known embeddings
-        # Node A: parallel to query → similarity 1.0
-        # Node B: orthogonal to query → similarity 0.0
-        query_vec = [1.0, 0.0]
-        node_a_vec = [1.0, 0.0]  # sim = 1.0
-        node_b_vec = [0.0, 1.0]  # sim = 0.0
+        ss = SemanticSearch(populated, DeterministicProvider())
+        ss.index()
+        populated.query(
+            "MATCH (n:Function {name:'render_template'}) SET n.docstring = 'now does something else'"
+        )
+        assert ss.index() == 1
 
-        rows = [
-            ["Function", "node_a", "a.py", "doc a", json.dumps(node_a_vec)],
-            ["Class", "node_b", "b.py", "doc b", json.dumps(node_b_vec)],
-        ]
-        store = _mock_store(rows)
-        provider = _mock_provider(embed_return=query_vec)
-
-        ss = SemanticSearch(store, provider)
-        results = ss.search("find something", limit=10)
-
-        assert len(results) == 2
-        assert results[0]["name"] == "node_a"
-        assert results[0]["score"] == pytest.approx(1.0)
-        assert results[1]["name"] == "node_b"
-        assert results[1]["score"] == pytest.approx(0.0)
-
-    def test_search_respects_limit(self):
+    def test_nodes_without_a_docstring_are_still_indexed(self, store):
+        """
+        Only docstring-bearing nodes used to be embeddable, which made most
+        real functions invisible. A name carries meaning on its own.
+        """
         from navegador.intelligence.search import SemanticSearch
 
-        rows = [
-            ["Function", f"func_{i}", "app.py", f"doc {i}", json.dumps([float(i), 0.0])]
-            for i in range(1, 6)
-        ]
-        store = _mock_store(rows)
-        provider = _mock_provider(embed_return=[1.0, 0.0])
+        store.query("CREATE (:Function {name:'parse_import_statement', file_path:'p.py'})")
+        assert SemanticSearch(store, DeterministicProvider()).index() == 1
 
-        ss = SemanticSearch(store, provider)
-        results = ss.search("query", limit=3)
-        assert len(results) == 3
-
-    def test_search_handles_invalid_embedding_json(self):
+    def test_index_returns_zero_for_empty_graph(self, store):
         from navegador.intelligence.search import SemanticSearch
 
-        rows = [
-            ["Function", "bad_node", "app.py", "doc", "not-valid-json"],
-            ["Function", "good_node", "app.py", "doc", json.dumps([1.0, 0.0])],
-        ]
-        store = _mock_store(rows)
-        provider = _mock_provider(embed_return=[1.0, 0.0])
+        provider = DeterministicProvider()
+        assert SemanticSearch(store, provider).index() == 0
+        assert provider.calls == 0
 
-        ss = SemanticSearch(store, provider)
-        results = ss.search("q", limit=10)
-        # Only good_node should appear
-        assert len(results) == 1
-        assert results[0]["name"] == "good_node"
-
-    def test_search_empty_graph_returns_empty_list(self):
+    def test_limit_is_honoured(self, populated):
         from navegador.intelligence.search import SemanticSearch
 
-        store = _mock_store([])
-        provider = _mock_provider()
-        ss = SemanticSearch(store, provider)
-        assert ss.search("anything") == []
+        assert SemanticSearch(populated, DeterministicProvider()).index(limit=2) == 2
+
+
+class TestSemanticSearchQuery:
+    def test_nearest_match_ranks_first(self, populated):
+        from navegador.intelligence.search import SemanticSearch
+
+        ss = SemanticSearch(populated, DeterministicProvider())
+        ss.index()
+        results = ss.search("validate token", limit=3)
+
+        assert results, "vector index returned nothing"
+        assert results[0]["name"] == "validate_jwt_token"
+
+    def test_results_are_sorted_by_descending_score(self, populated):
+        """
+        The index returns cosine *distance*, where lower is nearer. Passing
+        that through unchanged would invert every ranking.
+        """
+        from navegador.intelligence.search import SemanticSearch
+
+        ss = SemanticSearch(populated, DeterministicProvider())
+        ss.index()
+        scores = [r["score"] for r in ss.search("validate token", limit=5)]
+        assert scores == sorted(scores, reverse=True)
+        assert all(0.0 <= s <= 1.0 for s in scores)
+
+    def test_limit_is_respected(self, populated):
+        from navegador.intelligence.search import SemanticSearch
+
+        ss = SemanticSearch(populated, DeterministicProvider())
+        ss.index()
+        assert len(ss.search("token", limit=2)) <= 2
+
+    def test_results_span_labels(self, populated):
+        """
+        A FalkorDB node pattern takes one label and an index is per label, so
+        the query fans out; a bug there silently drops whole node types.
+        """
+        from navegador.intelligence.search import SemanticSearch
+
+        ss = SemanticSearch(populated, DeterministicProvider())
+        ss.index()
+        types = {r["type"] for r in ss.search("token validation", limit=10)}
+        assert "Class" in types and "Function" in types
+
+    def test_search_before_indexing_returns_empty(self, populated):
+        """No index yet is not an error — it is simply no answer."""
+        from navegador.intelligence.search import SemanticSearch
+
+        assert SemanticSearch(populated, DeterministicProvider()).search("anything") == []
+
+    def test_search_empty_graph_returns_empty_list(self, store):
+        from navegador.intelligence.search import SemanticSearch
+
+        assert SemanticSearch(store, DeterministicProvider()).search("anything") == []
 
 
 # ── CommunityDetector ─────────────────────────────────────────────────────────
@@ -249,8 +244,10 @@ class TestCommunityDetector:
             [4, "func_e", "b.py", "Function"],
         ]
         edge_rows = [
-            [0, 1], [1, 2], [0, 2],  # triangle
-            [3, 4],                  # pair
+            [0, 1],
+            [1, 2],
+            [0, 2],  # triangle
+            [3, 4],  # pair
         ]
         store = self._make_store(node_rows, edge_rows)
         detector = CommunityDetector(store)
@@ -343,12 +340,19 @@ class TestCommunityDetector:
         # 4-node clique + 2-node pair with a bridge → label propagation may merge
         # Use two fully disconnected groups of sizes 4 and 2
         node_rows = [
-            [0, "a", "", "F"], [1, "b", "", "F"], [2, "c", "", "F"], [3, "d", "", "F"],
-            [4, "e", "", "F"], [5, "f", "", "F"],
+            [0, "a", "", "F"],
+            [1, "b", "", "F"],
+            [2, "c", "", "F"],
+            [3, "d", "", "F"],
+            [4, "e", "", "F"],
+            [5, "f", "", "F"],
         ]
         edge_rows = [
-            [0, 1], [1, 2], [2, 3], [0, 3],  # 4-cycle (all same community)
-            [4, 5],                            # pair
+            [0, 1],
+            [1, 2],
+            [2, 3],
+            [0, 3],  # 4-cycle (all same community)
+            [4, 5],  # pair
         ]
         store = self._make_store(node_rows, edge_rows)
         detector = CommunityDetector(store)
@@ -445,12 +449,16 @@ class TestNLPEngine:
         from navegador.intelligence.nlp import NLPEngine
 
         expected_docs = "## my_func\nDoes great things."
-        store = _mock_store([
-            ["Function", "my_func", "app.py", "Does great things.", "def my_func():"]
-        ])
+        store = _mock_store(
+            [["Function", "my_func", "app.py", "Does great things.", "def my_func():"]]
+        )
         # Make subsequent query calls (callers, callees) also return empty
         store.query.side_effect = [
-            MagicMock(result_set=[["Function", "my_func", "app.py", "Does great things.", "def my_func():"]]),
+            MagicMock(
+                result_set=[
+                    ["Function", "my_func", "app.py", "Does great things.", "def my_func():"]
+                ]
+            ),
             MagicMock(result_set=[]),
             MagicMock(result_set=[]),
         ]
@@ -612,8 +620,10 @@ class TestDocGeneratorLLMMode:
 class TestSemanticSearchCLI:
     def test_search_outputs_table(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store") as mock_store_fn, \
-             patch("navegador.llm.auto_provider") as mock_auto:
+        with (
+            patch("navegador.cli.commands._get_store") as mock_store_fn,
+            patch("navegador.llm.auto_provider") as mock_auto,
+        ):
             store = _mock_store([])
             mock_store_fn.return_value = store
             mock_provider = _mock_provider(embed_return=[1.0, 0.0])
@@ -621,22 +631,28 @@ class TestSemanticSearchCLI:
 
             # search returns no results
             from navegador.intelligence.search import SemanticSearch
+
             with patch.object(SemanticSearch, "search", return_value=[]):
                 result = runner.invoke(main, ["semantic-search", "test query"])
                 assert result.exit_code == 0
 
     def test_search_with_index_flag(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store") as mock_store_fn, \
-             patch("navegador.llm.auto_provider") as mock_auto:
+        with (
+            patch("navegador.cli.commands._get_store") as mock_store_fn,
+            patch("navegador.llm.auto_provider") as mock_auto,
+        ):
             store = _mock_store([])
             mock_store_fn.return_value = store
             mock_provider = _mock_provider()
             mock_auto.return_value = mock_provider
 
             from navegador.intelligence.search import SemanticSearch
-            with patch.object(SemanticSearch, "index", return_value=5) as mock_index, \
-                 patch.object(SemanticSearch, "search", return_value=[]):
+
+            with (
+                patch.object(SemanticSearch, "index", return_value=5) as mock_index,
+                patch.object(SemanticSearch, "search", return_value=[]),
+            ):
                 result = runner.invoke(main, ["semantic-search", "test", "--index"])
                 assert result.exit_code == 0
                 mock_index.assert_called_once()
@@ -646,13 +662,16 @@ class TestSemanticSearchCLI:
         fake_results = [
             {"type": "Function", "name": "foo", "file_path": "a.py", "text": "doc", "score": 0.95}
         ]
-        with patch("navegador.cli.commands._get_store") as mock_store_fn, \
-             patch("navegador.llm.auto_provider") as mock_auto:
+        with (
+            patch("navegador.cli.commands._get_store") as mock_store_fn,
+            patch("navegador.llm.auto_provider") as mock_auto,
+        ):
             store = _mock_store([])
             mock_store_fn.return_value = store
             mock_auto.return_value = _mock_provider()
 
             from navegador.intelligence.search import SemanticSearch
+
             with patch.object(SemanticSearch, "search", return_value=fake_results):
                 result = runner.invoke(main, ["semantic-search", "foo", "--json"])
                 assert result.exit_code == 0
@@ -678,6 +697,7 @@ class TestCommunitiesCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.community import CommunityDetector
+
             with patch.object(CommunityDetector, "detect", return_value=self._make_communities()):
                 result = runner.invoke(main, ["communities"])
                 assert result.exit_code == 0
@@ -687,6 +707,7 @@ class TestCommunitiesCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.community import CommunityDetector
+
             with patch.object(CommunityDetector, "detect", return_value=self._make_communities()):
                 result = runner.invoke(main, ["communities", "--json"])
                 assert result.exit_code == 0
@@ -699,6 +720,7 @@ class TestCommunitiesCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.community import CommunityDetector
+
             with patch.object(CommunityDetector, "detect", return_value=[]) as mock_detect:
                 runner.invoke(main, ["communities", "--min-size", "5"])
                 mock_detect.assert_called_once_with(min_size=5)
@@ -708,6 +730,7 @@ class TestCommunitiesCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.community import CommunityDetector
+
             with patch.object(CommunityDetector, "detect", return_value=[]):
                 result = runner.invoke(main, ["communities"])
                 assert result.exit_code == 0
@@ -718,8 +741,11 @@ class TestCommunitiesCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.community import CommunityDetector
-            with patch.object(CommunityDetector, "detect", return_value=self._make_communities()), \
-                 patch.object(CommunityDetector, "store_communities", return_value=5) as mock_store:
+
+            with (
+                patch.object(CommunityDetector, "detect", return_value=self._make_communities()),
+                patch.object(CommunityDetector, "store_communities", return_value=5) as mock_store,
+            ):
                 result = runner.invoke(main, ["communities", "--store-labels"])
                 assert result.exit_code == 0
                 mock_store.assert_called_once()
@@ -731,12 +757,15 @@ class TestCommunitiesCLI:
 class TestAskCLI:
     def test_ask_prints_answer(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store") as mock_store_fn, \
-             patch("navegador.llm.auto_provider") as mock_auto:
+        with (
+            patch("navegador.cli.commands._get_store") as mock_store_fn,
+            patch("navegador.llm.auto_provider") as mock_auto,
+        ):
             mock_store_fn.return_value = _mock_store()
             mock_auto.return_value = _mock_provider()
 
             from navegador.intelligence.nlp import NLPEngine
+
             with patch.object(NLPEngine, "natural_query", return_value="The answer is 42."):
                 result = runner.invoke(main, ["ask", "What is the answer?"])
                 assert result.exit_code == 0
@@ -744,16 +773,17 @@ class TestAskCLI:
 
     def test_ask_with_explicit_provider(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store") as mock_store_fn, \
-             patch("navegador.llm.get_provider") as mock_get:
+        with (
+            patch("navegador.cli.commands._get_store") as mock_store_fn,
+            patch("navegador.llm.get_provider") as mock_get,
+        ):
             mock_store_fn.return_value = _mock_store()
             mock_get.return_value = _mock_provider()
 
             from navegador.intelligence.nlp import NLPEngine
+
             with patch.object(NLPEngine, "natural_query", return_value="Answer."):
-                result = runner.invoke(
-                    main, ["ask", "question", "--provider", "openai"]
-                )
+                result = runner.invoke(main, ["ask", "question", "--provider", "openai"])
                 assert result.exit_code == 0
                 mock_get.assert_called_once_with("openai", model="")
 
@@ -764,12 +794,15 @@ class TestAskCLI:
 class TestGenerateDocsCLI:
     def test_generate_docs_prints_output(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store") as mock_store_fn, \
-             patch("navegador.llm.auto_provider") as mock_auto:
+        with (
+            patch("navegador.cli.commands._get_store") as mock_store_fn,
+            patch("navegador.llm.auto_provider") as mock_auto,
+        ):
             mock_store_fn.return_value = _mock_store()
             mock_auto.return_value = _mock_provider()
 
             from navegador.intelligence.nlp import NLPEngine
+
             with patch.object(NLPEngine, "generate_docs", return_value="## my_func\nDocs here."):
                 result = runner.invoke(main, ["generate-docs", "my_func"])
                 assert result.exit_code == 0
@@ -777,16 +810,17 @@ class TestGenerateDocsCLI:
 
     def test_generate_docs_with_file_option(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store") as mock_store_fn, \
-             patch("navegador.llm.auto_provider") as mock_auto:
+        with (
+            patch("navegador.cli.commands._get_store") as mock_store_fn,
+            patch("navegador.llm.auto_provider") as mock_auto,
+        ):
             mock_store_fn.return_value = _mock_store()
             mock_auto.return_value = _mock_provider()
 
             from navegador.intelligence.nlp import NLPEngine
+
             with patch.object(NLPEngine, "generate_docs", return_value="Docs.") as mock_gd:
-                runner.invoke(
-                    main, ["generate-docs", "my_func", "--file", "app.py"]
-                )
+                runner.invoke(main, ["generate-docs", "my_func", "--file", "app.py"])
                 mock_gd.assert_called_once_with("my_func", file_path="app.py")
 
 
@@ -799,7 +833,10 @@ class TestDocsCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.docgen import DocGenerator
-            with patch.object(DocGenerator, "generate_file_docs", return_value="# File docs") as mock_fd:
+
+            with patch.object(
+                DocGenerator, "generate_file_docs", return_value="# File docs"
+            ) as mock_fd:
                 result = runner.invoke(main, ["docs", "app/store.py"])
                 assert result.exit_code == 0
                 mock_fd.assert_called_once_with("app/store.py")
@@ -809,7 +846,10 @@ class TestDocsCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.docgen import DocGenerator
-            with patch.object(DocGenerator, "generate_module_docs", return_value="# Module docs") as mock_md:
+
+            with patch.object(
+                DocGenerator, "generate_module_docs", return_value="# Module docs"
+            ) as mock_md:
                 result = runner.invoke(main, ["docs", "navegador.graph"])
                 assert result.exit_code == 0
                 mock_md.assert_called_once_with("navegador.graph")
@@ -819,7 +859,10 @@ class TestDocsCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.docgen import DocGenerator
-            with patch.object(DocGenerator, "generate_project_docs", return_value="# Project") as mock_pd:
+
+            with patch.object(
+                DocGenerator, "generate_project_docs", return_value="# Project"
+            ) as mock_pd:
                 result = runner.invoke(main, ["docs", ".", "--project"])
                 assert result.exit_code == 0
                 mock_pd.assert_called_once()
@@ -829,6 +872,7 @@ class TestDocsCLI:
         with patch("navegador.cli.commands._get_store") as mock_store_fn:
             mock_store_fn.return_value = _mock_store()
             from navegador.intelligence.docgen import DocGenerator
+
             with patch.object(DocGenerator, "generate_project_docs", return_value="# Project"):
                 result = runner.invoke(main, ["docs", ".", "--project", "--json"])
                 assert result.exit_code == 0
@@ -837,13 +881,16 @@ class TestDocsCLI:
 
     def test_docs_with_llm_provider(self):
         runner = CliRunner()
-        with patch("navegador.cli.commands._get_store") as mock_store_fn, \
-             patch("navegador.intelligence.docgen.DocGenerator.generate_file_docs", return_value="# Docs"):
+        with (
+            patch("navegador.cli.commands._get_store") as mock_store_fn,
+            patch(
+                "navegador.intelligence.docgen.DocGenerator.generate_file_docs",
+                return_value="# Docs",
+            ),
+        ):
             mock_store_fn.return_value = _mock_store()
             with patch("navegador.llm.get_provider") as mock_get:
                 mock_get.return_value = _mock_provider()
-                result = runner.invoke(
-                    main, ["docs", "app/store.py", "--provider", "openai"]
-                )
+                result = runner.invoke(main, ["docs", "app/store.py", "--provider", "openai"])
                 assert result.exit_code == 0
                 mock_get.assert_called_once_with("openai", model="")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -127,9 +127,9 @@ class TestListTools:
         self.fx = _ServerFixture()
 
     @pytest.mark.asyncio
-    async def test_returns_twenty_seven_tools(self):
+    async def test_returns_thirty_one_tools(self):
         tools = await self.fx.list_tools_fn()
-        assert len(tools) == 27
+        assert len(tools) == 31
 
     @pytest.mark.asyncio
     async def test_tool_names(self):
@@ -140,6 +140,10 @@ class TestListTools:
             "read_docs",
             "resolve_address",
             "propose_join_edges",
+            "locate",
+            "scope_for",
+            "neighbourhood",
+            "grep_code",
             "load_file_context",
             "load_function_context",
             "load_class_context",

--- a/tests/test_no_store_mocks.py
+++ b/tests/test_no_store_mocks.py
@@ -1,0 +1,127 @@
+"""
+No *new* tests may mock the graph store (#191).
+
+This is the rule that would have caught the worst bug in 1.5. Export and import
+dropped every edge for months because the tests mocked the store: a MagicMock
+``create_edge`` is always truthy, so the code checking whether the write
+succeeded passed forever. The test asserted the bug, coverage looked fine, and
+a 4,000-node round trip restored 4,000 nodes and zero edges in production.
+
+Coverage cannot catch that class of defect — those lines *were* covered. The
+only thing that catches it is asserting against a real store.
+
+55 of 103 test files already mock the store, so a hard ban is a project rather
+than a lint. This is a ratchet instead: the existing files are frozen below,
+new ones are rejected, and the list is expected to shrink. When you fix a file,
+delete its entry — the test fails on stale entries too, so the list cannot rot
+into a fiction.
+
+Real stores are cheap here. ``GraphStore.sqlite(tmp_path / "g.db")`` is an
+embedded FalkorDB and costs milliseconds; every regression test written for
+1.5 and #180 uses one.
+"""
+
+import re
+from pathlib import Path
+
+TESTS = Path(__file__).parent
+
+# Detects a mocked graph store: MagicMock(GraphStore), patch(... GraphStore),
+# or the common `store = MagicMock()` shorthand.
+STORE_MOCK = re.compile(
+    r"(MagicMock|Mock)\(\s*(spec=)?GraphStore|patch.*GraphStore|store\s*=\s*MagicMock|store\s*=\s*Mock"
+)
+
+# Frozen 2026-08-16. Shrink this list; never grow it.
+KNOWN_STORE_MOCKERS = {
+    "test_analysis.py",
+    "test_ansible_parser.py",
+    "test_bash_parser.py",
+    "test_chef_enricher.py",
+    "test_churn.py",
+    "test_cicd.py",
+    "test_cli_new_commands.py",
+    "test_cli_storage.py",
+    "test_cli.py",
+    "test_cluster.py",
+    "test_cluster2.py",
+    "test_context.py",
+    "test_coverage_boost.py",
+    "test_crossrepo.py",
+    "test_diff.py",
+    "test_diffgraph.py",
+    "test_doclink_semantic.py",
+    "test_doclink.py",
+    "test_drift.py",
+    "test_enrichment_terraform.py",
+    "test_explorer.py",
+    "test_fossil_ingester.py",
+    "test_go_parser.py",
+    "test_grammar_skip.py",
+    "test_hcl_parser.py",
+    "test_history.py",
+    "test_ingestion_code.py",
+    "test_ingestion_gaps.py",
+    "test_ingestion_planopticon.py",
+    "test_ingestion_wiki.py",
+    "test_intelligence.py",
+    "test_java_parser.py",
+    "test_language_parsers_edge_cases.py",
+    "test_lenses.py",
+    "test_markdown_parser.py",
+    "test_mcp_security.py",
+    "test_mcp_server.py",
+    "test_memory_ingester.py",
+    "test_metarepo_ingest.py",
+    "test_migrations.py",
+    "test_monorepo.py",
+    "test_nested_repo_walk.py",
+    "test_new_language_parsers.py",
+    "test_optimization.py",
+    "test_parser_dispatch.py",
+    "test_puppet_parser.py",
+    "test_python_parser.py",
+    "test_release.py",
+    "test_review.py",
+    "test_rust_parser.py",
+    "test_sdk.py",
+    "test_taskpack.py",
+    "test_typescript_parser.py",
+    "test_v04_batch3.py",
+    "test_v04_features.py",
+}
+
+
+def mocks_the_store(path: Path) -> bool:
+    return bool(STORE_MOCK.search(path.read_text(encoding="utf-8", errors="replace")))
+
+
+def current_mockers() -> set[str]:
+    # This file is excluded: it contains the pattern as a literal and would
+    # otherwise report itself.
+    return {
+        p.name
+        for p in sorted(TESTS.glob("test_*.py"))
+        if p.name != Path(__file__).name and mocks_the_store(p)
+    }
+
+
+def test_no_new_files_mock_the_graph_store():
+    new = current_mockers() - KNOWN_STORE_MOCKERS
+    assert not new, (
+        "These test files mock the graph store:\n"
+        + "".join(f"  - {name}\n" for name in sorted(new))
+        + "\nA mocked store cannot fail the way a real one does — a MagicMock "
+        "write always succeeds, which is how #173 shipped. Use "
+        'GraphStore.sqlite(str(tmp_path / "g.db")) instead; it is an embedded '
+        "FalkorDB and costs milliseconds."
+    )
+
+
+def test_the_allowlist_has_not_gone_stale():
+    """A fixed file left on the list makes the ratchet a fiction."""
+    fixed = KNOWN_STORE_MOCKERS - current_mockers()
+    assert not fixed, (
+        "These files no longer mock the store and should be removed from "
+        "KNOWN_STORE_MOCKERS:\n" + "".join(f"  - {name}\n" for name in sorted(fixed))
+    )

--- a/tests/test_prose.py
+++ b/tests/test_prose.py
@@ -1,0 +1,124 @@
+"""
+Indexing the text parsing throws away (#185).
+
+An AST keeps the name of a function and discards the error message it raises,
+the comment explaining why it exists, and the SQL in its literals. Those are
+what an agent has in hand when it goes looking — a user pastes an error, not
+a symbol name.
+
+The tests worth having here are about extraction quality rather than plumbing.
+An extractor that returns everything is as useless as one that returns
+nothing: literals full of one-word dict keys bury the error messages that
+matter, so noise rejection is asserted as carefully as recall.
+"""
+
+import pytest
+
+from navegador.graph import GraphStore
+from navegador.graph.prose import ProseIndex, extract, split_identifier
+from navegador.ingestion import RepoIngester
+
+
+class TestSplitIdentifier:
+    def test_camel_case(self):
+        assert set(split_identifier("getUserById")) >= {"get", "user", "by", "id"}
+
+    def test_snake_case(self):
+        assert set(split_identifier("parse_import_statement")) >= {
+            "parse",
+            "import",
+            "statement",
+        }
+
+    def test_original_is_kept(self):
+        """Searching the exact symbol name must still find it."""
+        assert "getuserbyid" in split_identifier("getUserById")
+
+    def test_pascal_case(self):
+        assert set(split_identifier("TokenValidator")) >= {"token", "validator"}
+
+    def test_single_letters_are_dropped(self):
+        """`x` and `i` are noise in a full-text index."""
+        assert "x" not in split_identifier("parse_x_value")
+
+
+class TestExtract:
+    def test_finds_error_messages(self):
+        extracted = extract("raise ValueError('token signature invalid')")
+        assert "token signature invalid" in extracted.literals
+
+    def test_finds_comments(self):
+        extracted = extract("# rate limiting guards the endpoint\nx = 1\n")
+        assert "rate limiting guards the endpoint" in extracted.comments
+
+    def test_comment_styles(self):
+        assert "slashes" in extract("// slashes here\n").comments
+        assert "dashes" in extract("-- dashes here\n").comments
+
+    def test_single_word_literals_are_noise(self):
+        """
+        A one-word string is usually a dict key or a flag. Keeping them buries
+        the error messages under thousands of tokens of nothing.
+        """
+        extracted = extract("d = {'name': 'id', 'kind': 'x'}")
+        assert "name" not in extracted.literals.split()
+
+    def test_triple_quoted_strings(self):
+        assert "module docstring here" in extract('"""module docstring here"""').literals
+
+    def test_identifiers_are_split(self):
+        extracted = extract("def getUserById(): pass")
+        assert "user" in extracted.identifiers.split()
+
+    def test_empty_source(self):
+        assert extract("").empty
+
+    def test_truncation_bounds_a_huge_file(self):
+        """A minified bundle must not put a megabyte into one property."""
+        extracted = extract("x = 'a long sentence of prose here' \n" * 20000)
+        assert len(extracted.literals) <= 20_000
+
+
+@pytest.fixture
+def indexed(tmp_path):
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "auth.py").write_text(
+        "# rate limiting guards the login endpoint\n"
+        "def getUserById(uid):\n"
+        "    raise ValueError('token signature invalid for user')\n"
+    )
+    (root / "src" / "views.py").write_text(
+        "def render():\n    return 'html template output here'\n"
+    )
+    store = GraphStore.sqlite(str(tmp_path / "g.db"))
+    RepoIngester(store).ingest(root)
+    return ProseIndex(store)
+
+
+class TestSearch:
+    def test_pasted_error_message_finds_its_file(self, indexed):
+        """The motivating case: a user pastes an error, not a symbol name."""
+        assert indexed.search("token signature")[0]["path"] == "src/auth.py"
+
+    def test_comment_text_is_searchable(self, indexed):
+        """ "rate limiting" appears in no symbol name, only in a comment."""
+        assert indexed.search("rate limiting")[0]["path"] == "src/auth.py"
+
+    def test_split_identifiers_close_the_gap(self, indexed):
+        """ "user id" should reach getUserById."""
+        assert any(h["path"] == "src/auth.py" for h in indexed.search("user id"))
+
+    def test_ranking_separates_files(self, indexed):
+        assert indexed.search("html template")[0]["path"] == "src/views.py"
+
+    def test_nothing_matching_returns_empty(self, indexed):
+        assert indexed.search("quantum chromodynamics") == []
+
+    def test_search_without_an_index_returns_empty(self, tmp_path):
+        """No index is an absence of answer, not an error."""
+        store = GraphStore.sqlite(str(tmp_path / "empty.db"))
+        assert ProseIndex(store).search("anything") == []
+
+    def test_stats(self, indexed):
+        assert indexed.stats()["indexed_files"] == 2

--- a/tests/test_retrieval_telemetry.py
+++ b/tests/test_retrieval_telemetry.py
@@ -1,0 +1,261 @@
+"""
+Tests for the retrieval telemetry tool (#187).
+
+The tool decides whether weeks of work on #184 and #188 are justified, so its
+classification rules need to be right. Two are load-bearing and easy to get
+wrong, and both are asserted here:
+
+- a search binary downstream of a pipe filters stdout and is not a disk read
+- long human-away pauses must not count as agent working time
+
+Transcripts are synthesised rather than read from disk so the assertions are
+about the logic, not about whoever's machine runs the suite.
+"""
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from retrieval_telemetry import (  # noqa: E402
+    Session,
+    collect,
+    leading_command,
+    percentiles,
+)
+
+START = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def tool_use(name, tool_input, offset_s):
+    return {
+        "type": "assistant",
+        "timestamp": (START + timedelta(seconds=offset_s)).isoformat().replace("+00:00", "Z"),
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": name, "input": tool_input}],
+        },
+    }
+
+
+def user_turn(text, offset_s):
+    return {
+        "type": "user",
+        "timestamp": (START + timedelta(seconds=offset_s)).isoformat().replace("+00:00", "Z"),
+        "message": {"role": "user", "content": text},
+    }
+
+
+def tool_result(offset_s):
+    """A tool result is also a user message — it must not start an episode."""
+    return {
+        "type": "user",
+        "timestamp": (START + timedelta(seconds=offset_s)).isoformat().replace("+00:00", "Z"),
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "x", "content": "ok"}],
+        },
+    }
+
+
+def write_session(directory, events, name="session.jsonl"):
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text("\n".join(json.dumps(e) for e in events))
+    return path
+
+
+class TestPipelineClassification:
+    """The rule that roughly triples the read rate when it is wrong."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("grep -r foo .", "grep"),
+            ("rg --files", "rg"),
+            ("git log | grep foo", "git"),
+            ("gh pr view 1 --json body | jq .body | head -20", "gh"),
+            ("cat file.txt", "cat"),
+            ("FOO=bar grep x .", "grep"),
+            ("/usr/bin/find . -name x", "find"),
+        ],
+    )
+    def test_leading_command(self, command, expected):
+        assert leading_command(command) == expected
+
+    def test_grep_after_pipe_is_not_a_read(self, tmp_path):
+        events = [
+            user_turn("go", 0),
+            tool_use("Bash", {"command": "git log --oneline | grep fix"}, 1),
+        ]
+        session = Session(write_session(tmp_path / "p", events))
+        assert [c.is_read for c in session.calls] == [False]
+
+    def test_grep_leading_is_a_read(self, tmp_path):
+        events = [user_turn("go", 0), tool_use("Bash", {"command": "grep -rn foo src/"}, 1)]
+        session = Session(write_session(tmp_path / "p", events))
+        assert [c.is_read for c in session.calls] == [True]
+
+    def test_sed_in_place_is_not_a_read(self, tmp_path):
+        events = [user_turn("go", 0), tool_use("Bash", {"command": "sed -i s/a/b/ f.py"}, 1)]
+        session = Session(write_session(tmp_path / "p", events))
+        assert [c.is_read for c in session.calls] == [False]
+
+    def test_unparseable_command_does_not_crash(self, tmp_path):
+        events = [user_turn("go", 0), tool_use("Bash", {"command": "grep 'unbalanced ."}, 1)]
+        session = Session(write_session(tmp_path / "p", events))
+        assert len(session.calls) == 1
+
+
+class TestActiveTime:
+    def test_idle_gap_is_excluded(self, tmp_path):
+        events = [
+            user_turn("go", 0),
+            tool_use("Read", {"file_path": "a.py"}, 10),
+            tool_use("Read", {"file_path": "b.py"}, 20),
+            tool_use("Read", {"file_path": "c.py"}, 4000),  # an hour away
+        ]
+        session = Session(write_session(tmp_path / "p", events))
+        minutes = session.active_minutes(120.0)
+        assert minutes == pytest.approx(20 / 60, abs=0.01), (
+            "the hour-long pause was counted as working time"
+        )
+
+    def test_wall_time_would_have_been_much_larger(self, tmp_path):
+        events = [user_turn("go", 0), tool_use("Read", {"file_path": "a.py"}, 7200)]
+        session = Session(write_session(tmp_path / "p", events))
+        assert session.active_minutes(120.0) == 0
+
+
+class TestEpisodes:
+    def test_tool_result_does_not_start_an_episode(self, tmp_path):
+        events = [
+            user_turn("do the thing", 0),
+            tool_use("Read", {"file_path": "a.py"}, 1),
+            tool_result(2),
+            tool_use("Edit", {"file_path": "a.py"}, 3),
+        ]
+        session = Session(write_session(tmp_path / "p", events))
+        assert len(session.episodes()) == 1
+
+    def test_second_user_turn_starts_a_new_episode(self, tmp_path):
+        events = [
+            user_turn("first", 0),
+            tool_use("Read", {"file_path": "a.py"}, 1),
+            user_turn("second", 2),
+            tool_use("Read", {"file_path": "b.py"}, 3),
+        ]
+        session = Session(write_session(tmp_path / "p", events))
+        assert len(session.episodes()) == 2
+
+
+class TestThesisMetrics:
+    def test_turns_to_first_target_counts_calls_before_touching_it(self, tmp_path):
+        """Three misses, then the file that gets edited — index 3."""
+        events = [
+            user_turn("fix the bug", 0),
+            tool_use("Bash", {"command": "grep -r wrong src/"}, 1),
+            tool_use("Read", {"file_path": "src/decoy_a.py"}, 2),
+            tool_use("Read", {"file_path": "src/decoy_b.py"}, 3),
+            tool_use("Read", {"file_path": "src/real.py"}, 4),
+            tool_use("Edit", {"file_path": "src/real.py"}, 5),
+        ]
+        session = Session(write_session(tmp_path / "p", events))
+        assert session.turns_to_first_target() == [3]
+
+    def test_files_read_but_never_edited_are_not_scored(self, tmp_path):
+        """
+        Reading for context is legitimate. Only files the episode actually
+        edits count, or the metric would punish an agent for understanding.
+        """
+        events = [
+            user_turn("go", 0),
+            tool_use("Read", {"file_path": "context.py"}, 1),
+            tool_use("Read", {"file_path": "target.py"}, 2),
+            tool_use("Edit", {"file_path": "target.py"}, 3),
+        ]
+        session = Session(write_session(tmp_path / "p", events))
+        assert session.turns_to_first_target() == [1]
+
+    def test_orientation_turns_stop_at_first_edit(self, tmp_path):
+        events = [
+            user_turn("go", 0),
+            tool_use("Read", {"file_path": "a.py"}, 1),
+            tool_use("Read", {"file_path": "b.py"}, 2),
+            tool_use("Edit", {"file_path": "b.py"}, 3),
+            tool_use("Read", {"file_path": "c.py"}, 4),
+        ]
+        session = Session(write_session(tmp_path / "p", events))
+        assert session.orientation_turns() == [2]
+
+    def test_episode_with_no_edit_is_not_scored(self, tmp_path):
+        """A question-answering turn has no target and should not dilute the median."""
+        events = [user_turn("what does this do", 0), tool_use("Read", {"file_path": "a.py"}, 1)]
+        session = Session(write_session(tmp_path / "p", events))
+        assert session.orientation_turns() == []
+        assert session.turns_to_first_target() == []
+
+    def test_reread_ratio(self, tmp_path):
+        events = [
+            user_turn("go", 0),
+            tool_use("Read", {"file_path": "a.py"}, 1),
+            tool_use("Read", {"file_path": "b.py"}, 2),
+            tool_use("Read", {"file_path": "a.py"}, 3),
+        ]
+        session = Session(write_session(tmp_path / "p", events))
+        assert session.reread_ratio() == pytest.approx(1.5)
+
+    def test_reread_ratio_is_none_without_reads(self, tmp_path):
+        events = [user_turn("go", 0), tool_use("Bash", {"command": "ls"}, 1)]
+        session = Session(write_session(tmp_path / "p", events))
+        assert session.reread_ratio() is None
+
+
+def busy_session(count=12, spacing=10):
+    """A session long enough to clear the one-minute active-time floor."""
+    return [user_turn("go", 0)] + [
+        tool_use("Read", {"file_path": f"f{i}.py"}, (i + 1) * spacing) for i in range(count)
+    ]
+
+
+class TestCollect:
+    def test_a_real_session_is_counted(self, tmp_path):
+        write_session(tmp_path / "proj", busy_session())
+        _, report = collect(tmp_path, min_calls=10, idle=120.0)
+        assert report["sample"]["sessions"] == 1
+
+    def test_subagent_transcripts_are_excluded(self, tmp_path):
+        """Subagent runs have no independent session semantics."""
+        write_session(tmp_path / "proj", busy_session())
+        write_session(tmp_path / "subagents", busy_session(), name="sub.jsonl")
+
+        _, report = collect(tmp_path, min_calls=10, idle=120.0)
+        assert report["sample"]["sessions"] == 1
+
+    def test_trivial_sessions_are_ignored(self, tmp_path):
+        write_session(tmp_path / "proj", [user_turn("go", 0), tool_use("Read", {}, 1)])
+        _, report = collect(tmp_path, min_calls=10, idle=120.0)
+        assert report["sample"]["sessions"] == 0
+
+    def test_session_below_the_active_time_floor_is_ignored(self, tmp_path):
+        """
+        Twelve calls in twelve seconds is a burst, not a working session, and
+        would produce a wild per-minute rate.
+        """
+        write_session(tmp_path / "proj", busy_session(spacing=1))
+        _, report = collect(tmp_path, min_calls=10, idle=120.0)
+        assert report["sample"]["sessions"] == 0
+
+
+class TestPercentiles:
+    def test_empty(self):
+        assert percentiles([]) == {}
+
+    def test_shape(self):
+        stats = percentiles([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        assert stats["n"] == 10
+        assert stats["p50"] == pytest.approx(5.5)

--- a/tests/test_targeting.py
+++ b/tests/test_targeting.py
@@ -225,3 +225,28 @@ class TestHashesForPaths:
 
     def test_unknown_path(self, targeting):
         assert targeting.hashes_for_paths(["nope.py"]) == set()
+
+
+class TestEdgeProvenance:
+    """
+    An agent should be able to tell a fact from a good guess (#188).
+
+    tree-sitter is syntax only — no name resolution, no types — so a call edge
+    is an import heuristic that is usually right. Two of the eight bugs fixed
+    in 1.5 came from treating those guesses as certainties, so the graph now
+    records which is which.
+    """
+
+    def test_call_edges_are_marked_inferred(self, project):
+        rows = project.query("MATCH ()-[r:CALLS]->() RETURN DISTINCT r.resolution").result_set
+        assert [row[0] for row in rows] == ["inferred"]
+
+    def test_neighbourhood_surfaces_resolution(self, targeting):
+        callers = targeting.neighbourhood("validate_token")["callers"]
+        assert callers
+        assert all(c.get("resolution") == "inferred" for c in callers)
+
+    def test_defined_in_carries_no_resolution(self, targeting):
+        """A definition is a fact about the file; there is no edge to qualify."""
+        defined = targeting.neighbourhood("validate_token")["defined_in"]
+        assert defined and "resolution" not in defined[0]

--- a/tests/test_targeting.py
+++ b/tests/test_targeting.py
@@ -1,0 +1,227 @@
+"""
+Targeting: return the scope, not the answer (#186).
+
+These tools exist because the expensive thing an agent does is working out
+*where* to look — 206 tool calls in a median session, 32% of reads re-opening
+a file already read, and a frozen baseline of 13 turns to first correct
+target. Grep is not the problem; aimlessness is.
+
+So the tests are about whether the scope is right, and specifically about the
+two ways it can be wrong in a way that would go unnoticed:
+
+- a scope that quietly widens to everything is not a scope, and would make the
+  reduction a lie while still returning plausible results
+- a fusion that lets one source dominate turns a multi-source ranking into a
+  single-source one with extra steps
+
+Real store throughout; a mocked store cannot produce a traversal.
+"""
+
+import pytest
+
+from navegador.graph import GraphStore
+from navegador.ingestion import RepoIngester
+from navegador.targeting import RRF_K, WEIGHTS, Candidate, Targeting, _fuse
+
+
+@pytest.fixture
+def project(tmp_path):
+    """
+    Two connected modules and one unrelated one.
+
+    The unrelated module is the point: it shares vocabulary with the others,
+    so anything that returns it inside a scope has stopped scoping.
+    """
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "auth.py").write_text(
+        "def validate_token(token):\n"
+        "    return check_signature(token)\n"
+        "\n"
+        "def check_signature(token):\n"
+        "    raise ValueError('token signature invalid')\n"
+    )
+    (root / "src" / "api.py").write_text(
+        "from src.auth import validate_token\n"
+        "\n"
+        "def handle_request(request):\n"
+        "    return validate_token(request.token)\n"
+    )
+    (root / "src" / "unrelated.py").write_text(
+        "def compute_token_budget():\n    return 'token budget unrelated'\n"
+    )
+
+    store = GraphStore.sqlite(str(tmp_path / "g.db"))
+    RepoIngester(store).ingest(root)
+    from navegador.graph.trigram import TrigramIndex
+
+    TrigramIndex(store).index_graph()
+    return store
+
+
+@pytest.fixture
+def targeting(project):
+    return Targeting(project)
+
+
+class TestFusion:
+    def test_agreement_across_sources_outranks_a_single_strong_hit(self):
+        """
+        The reason for fusing at all. A place two sources agree on should beat
+        one that only the strongest source found.
+        """
+        agreed = Candidate(path="a.py", line=1, reasons=["exact"])
+        alone = Candidate(path="b.py", line=1, reasons=["exact"])
+        fused = _fuse(
+            {
+                "exact": [alone, agreed],
+                "symbol": [agreed],
+                "vector": [agreed],
+            }
+        )
+        assert fused[0].path == "a.py"
+
+    def test_reasons_accumulate(self):
+        fused = _fuse(
+            {
+                "exact": [Candidate(path="a.py", line=1, reasons=["text appears here"])],
+                "symbol": [Candidate(path="a.py", line=1, reasons=["function named x"])],
+            }
+        )
+        assert len(fused[0].reasons) == 2
+
+    def test_rank_position_matters(self):
+        first = Candidate(path="first.py", line=1)
+        last = Candidate(path="last.py", line=1)
+        fused = _fuse({"exact": [first, last]})
+        assert fused[0].path == "first.py"
+
+    def test_weights_favour_exact_over_vector(self):
+        """Exact text is a fact; vector similarity is a guess."""
+        assert WEIGHTS["exact"] > WEIGHTS["vector"]
+
+    def test_empty_sources_fuse_to_nothing(self):
+        assert _fuse({"exact": [], "symbol": []}) == []
+
+    def test_scores_are_bounded_by_the_rrf_constant(self):
+        fused = _fuse({"exact": [Candidate(path="a.py", line=1)]})
+        assert fused[0].score == pytest.approx(WEIGHTS["exact"] / (RRF_K + 1))
+
+
+class TestScopeFor:
+    def test_scope_includes_the_symbol_and_what_it_reaches(self, targeting):
+        paths = targeting.scope_for("validate_token")
+        assert "src/auth.py" in paths
+        assert "src/api.py" in paths
+
+    def test_scope_excludes_unconnected_files(self, targeting):
+        """
+        The whole value proposition. unrelated.py talks about tokens too, so a
+        text index would surface it; the graph knows nothing calls it.
+        """
+        assert "src/unrelated.py" not in targeting.scope_for("validate_token")
+
+    def test_defining_file_comes_first(self, targeting):
+        assert targeting.scope_for("validate_token")[0] == "src/auth.py"
+
+    def test_unknown_symbol_returns_empty(self, targeting):
+        assert targeting.scope_for("no_such_symbol_anywhere") == []
+
+    def test_depth_is_clamped(self, targeting):
+        """
+        Depth is inlined into Cypher because FalkorDB rejects a parameterised
+        variable-length bound — the bug behind traversals silently returning
+        nothing in 1.2.0. Inlined means it must be bounded.
+        """
+        assert targeting.scope_for("validate_token", depth=999) is not None
+        assert targeting.scope_for("validate_token", depth=0) is not None
+
+
+class TestSearchWithin:
+    def test_searches_only_the_scope(self, targeting):
+        """
+        'token' appears in unrelated.py as well. A scoped search must not
+        return it, or the scope means nothing.
+        """
+        hits = targeting.search_within("validate_token", "token")
+        assert hits
+        assert "src/unrelated.py" not in {h.path for h in hits}
+
+    def test_unscoped_search_does_find_the_unrelated_file(self, project):
+        """
+        Control for the test above: the match really is there, so its absence
+        from the scoped result is the scope working rather than the index
+        missing it.
+        """
+        from navegador.graph.trigram import TrigramIndex
+
+        everywhere = {h.path for h in TrigramIndex(project).search("token")}
+        assert "src/unrelated.py" in everywhere
+
+    def test_unknown_symbol_yields_nothing_rather_than_everything(self, targeting):
+        """
+        An empty scope must not fall back to the whole repository. Silently
+        widening would make every scoped search a full search.
+        """
+        assert targeting.search_within("no_such_symbol", "token") == []
+
+
+class TestNeighbourhood:
+    def test_callers(self, targeting):
+        assert "handle_request" in {
+            c["name"] for c in targeting.neighbourhood("validate_token")["callers"]
+        }
+
+    def test_callees(self, targeting):
+        assert "check_signature" in {
+            c["name"] for c in targeting.neighbourhood("validate_token")["callees"]
+        }
+
+    def test_defining_file(self, targeting):
+        defined = targeting.neighbourhood("validate_token")["defined_in"]
+        assert defined and defined[0]["path"] == "src/auth.py"
+
+    def test_unknown_symbol_returns_empty_lists_not_an_error(self, targeting):
+        result = targeting.neighbourhood("nope")
+        assert result["callers"] == [] and result["callees"] == []
+
+
+class TestLocate:
+    def test_finds_the_literal(self, targeting):
+        candidates = targeting.locate("token signature invalid")
+        assert "src/auth.py" in {c.path for c in candidates}
+
+    def test_every_candidate_states_a_reason(self, targeting):
+        """
+        A ranking without a reason is something the agent has to trust. Every
+        candidate must say why it surfaced.
+        """
+        for candidate in targeting.locate("validate_token"):
+            assert candidate.reasons
+
+    def test_finds_by_symbol_name(self, targeting):
+        assert "validate_token" in {c.symbol for c in targeting.locate("validate")}
+
+    def test_limit(self, targeting):
+        assert len(targeting.locate("token", limit=2)) <= 2
+
+    def test_nonsense_returns_empty_rather_than_noise(self, targeting):
+        assert targeting.locate("zzz_no_such_concept_zzz") == []
+
+    def test_works_without_an_llm_provider(self, targeting):
+        """
+        Vector search is an improvement, not a requirement. Without a provider
+        the other sources must still answer.
+        """
+        assert targeting.locate("token signature invalid")
+
+
+class TestHashesForPaths:
+    def test_maps_paths_to_content_hashes(self, targeting):
+        assert targeting.hashes_for_paths(["src/auth.py"])
+
+    def test_empty_input(self, targeting):
+        assert targeting.hashes_for_paths([]) == set()
+
+    def test_unknown_path(self, targeting):
+        assert targeting.hashes_for_paths(["nope.py"]) == set()

--- a/tests/test_trigram.py
+++ b/tests/test_trigram.py
@@ -1,0 +1,246 @@
+"""
+Trigram index for substring and regex search (#184).
+
+The fatal bug for a search index is a **false negative** — telling a caller a
+string does not appear when it does. Trigrams are allowed to over-select and
+then be filtered by a real match; they are never allowed to under-select. Most
+of these tests exist to pin that boundary, particularly in
+``required_trigrams`` where a run that looks mandatory but is not (inside a
+group, behind a quantifier, one branch of an alternation) would silently drop
+real results.
+
+Where ripgrep is installed, a differential test uses it as the oracle against
+this package's own source. That is worth more than any hand-written fixture:
+the two implementations share nothing.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from navegador.graph import GraphStore
+from navegador.graph.trigram import TrigramIndex, required_trigrams, trigrams
+from navegador.ingestion import RepoIngester
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def indexed(tmp_path):
+    """A small repo, ingested, with its content indexed."""
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "auth.py").write_text(
+        "def check_token():\n    raise ValueError('token expired')\n    # TODO: refresh the token\n"
+    )
+    (root / "src" / "views.py").write_text("def render():\n    return 'token expired'\n")
+    (root / "src" / "quiet.py").write_text("VALUE = 1\n")
+
+    store = GraphStore.sqlite(str(tmp_path / "g.db"))
+    RepoIngester(store).ingest(root)
+    index = TrigramIndex(store)
+    index.index_graph()
+    return index
+
+
+class TestTrigrams:
+    def test_windows(self):
+        assert trigrams("abcd") == {"abc", "bcd"}
+
+    def test_lowercased(self):
+        assert trigrams("ABC") == {"abc"}
+
+    def test_too_short(self):
+        assert trigrams("ab") == set()
+
+
+class TestRequiredTrigrams:
+    """
+    Every case here is a chance to produce a false negative. A pattern that
+    yields trigrams the text need not contain silently loses real matches.
+    """
+
+    def test_literal(self):
+        assert required_trigrams("hello", False) == {"hel", "ell", "llo"}
+
+    def test_short_literal_cannot_narrow(self):
+        assert required_trigrams("ab", False) == set()
+
+    def test_alternation_proves_nothing(self):
+        """`foo|bar` requires neither "foo" nor "bar" specifically."""
+        assert required_trigrams("foo|bar", True) == set()
+
+    def test_quantified_character_is_not_required(self):
+        """`ab?cdef` may not contain "b", so "abc" is not a required trigram."""
+        required = required_trigrams("ab?cdef", True)
+        assert "abc" not in required
+        assert {"cde", "def"} <= required
+
+    def test_group_contents_are_not_required(self):
+        """A group may be quantified later; nothing inside it is guaranteed."""
+        assert required_trigrams("(abc)def", True) == {"def"}
+
+    def test_character_class_is_not_required(self):
+        assert "a-z" not in required_trigrams("[a-z]+ghijk", True)
+        assert {"ghi", "hij", "ijk"} <= required_trigrams("[a-z]+ghijk", True)
+
+    def test_escape_breaks_the_run(self):
+        """`\\d` is a class, not the letter d."""
+        assert "abd" not in required_trigrams(r"ab\def", True)
+
+    def test_pure_metacharacters_yield_nothing(self):
+        assert required_trigrams(r"\w+\s*", True) == set()
+
+
+class TestSearch:
+    def test_literal_match_returns_path_and_line(self, indexed):
+        hits = indexed.search("token expired")
+        located = {(h.path, h.line) for h in hits}
+        assert ("src/auth.py", 2) in located
+        assert ("src/views.py", 2) in located
+
+    def test_line_text_is_returned(self, indexed):
+        hit = next(h for h in indexed.search("ValueError"))
+        assert "raise ValueError" in hit.text
+
+    def test_absent_string_returns_nothing(self, indexed):
+        assert indexed.search("no_such_string_anywhere") == []
+
+    def test_regex(self, indexed):
+        hits = indexed.search(r"TODO:?\s*\w+", is_regex=True)
+        assert [(h.path, h.line) for h in hits] == [("src/auth.py", 3)]
+
+    def test_short_pattern_still_works(self, indexed):
+        """
+        Under three characters there is no trigram to narrow with, so the
+        scope is scanned. Slower, still exact — it must not return nothing.
+        """
+        assert any(h.line == 1 for h in indexed.search("=", limit=10))
+
+    def test_invalid_regex_returns_empty_rather_than_raising(self, indexed):
+        assert indexed.search("(unclosed", is_regex=True) == []
+
+    def test_case_insensitive(self, indexed):
+        assert indexed.search("VALUEERROR", ignore_case=True)
+        assert not indexed.search("VALUEERROR")
+
+    def test_limit(self, indexed):
+        assert len(indexed.search("e", limit=2)) <= 2
+
+    def test_results_are_ordered(self, indexed):
+        hits = indexed.search("token")
+        assert hits == sorted(hits, key=lambda h: (h.path, h.line))
+
+
+class TestScoping:
+    def test_scope_restricts_the_search(self, indexed, tmp_path):
+        """
+        The reduction no flat index can compute: search only these blobs.
+        The scope joins the intersection rather than filtering after it.
+        """
+        everything = indexed.search("token expired")
+        assert len({h.path for h in everything}) == 2
+
+        one_file = {h.sha for h in everything if h.path == "src/auth.py"}
+        scoped = indexed.search("token expired", scope=one_file)
+        assert {h.path for h in scoped} == {"src/auth.py"}
+
+    def test_empty_scope_finds_nothing(self, indexed):
+        assert indexed.search("token expired", scope=set()) == []
+
+
+class TestIndexing:
+    def test_reindexing_is_a_no_op(self, indexed):
+        assert indexed.index_graph() == 0
+
+    def test_identical_content_is_indexed_once(self, tmp_path):
+        """Content-addressed: a vendored copy costs one set of postings."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        body = "def duplicated_helper():\n    return 'shared'\n"
+        (root / "one.py").write_text(body)
+        (root / "two.py").write_text(body)
+
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(root)
+        index = TrigramIndex(store)
+        assert index.index_graph() == 1
+
+    def test_both_paths_are_still_reported(self, tmp_path):
+        """
+        One blob, two paths. Dedup must not cost a result — both files really
+        do contain the line.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        body = "def duplicated_helper():\n    return 'shared'\n"
+        (root / "one.py").write_text(body)
+        (root / "two.py").write_text(body)
+
+        store = GraphStore.sqlite(str(tmp_path / "g.db"))
+        RepoIngester(store).ingest(root)
+        index = TrigramIndex(store)
+        index.index_graph()
+
+        assert {h.path for h in index.search("duplicated_helper")} == {"one.py", "two.py"}
+
+
+@pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep not installed")
+class TestAgainstRipgrep:
+    """
+    Differential test on this package's own source, with ripgrep as oracle.
+
+    Two implementations sharing no code agreeing on real input is stronger
+    evidence than any fixture. A disagreement in the `missing` direction is a
+    false negative and the bug that matters.
+    """
+
+    @pytest.fixture(scope="class")
+    @classmethod
+    def index(cls):
+        """Ingesting the whole package takes seconds, so do it once per class."""
+        store = GraphStore.sqlite(os.path.join(tempfile.mkdtemp(), "g.db"))
+        RepoIngester(store).ingest(REPO)
+        index = TrigramIndex(store)
+        index.index_graph()
+        return index
+
+    @staticmethod
+    def ripgrep(pattern: str, regex: bool) -> set[tuple[str, int]]:
+        args = ["rg", "--no-heading", "-n", "--no-messages"]
+        if not regex:
+            args.append("--fixed-strings")
+        args += [pattern, "--glob", "*.py", "."]
+        out = subprocess.run(args, cwd=REPO, capture_output=True, text=True).stdout
+        hits = set()
+        for line in out.splitlines():
+            parts = line.split(":", 2)
+            if len(parts) == 3:
+                hits.add((parts[0].lstrip("./"), int(parts[1])))
+        return hits
+
+    @pytest.mark.parametrize(
+        "pattern,regex",
+        [
+            ("content_hash", False),
+            ("def resolve", False),
+            ("GRAPH.LIST", False),
+            ("raise ValueError", False),
+            ("# noqa", False),
+            (r"def _\w+_store", True),
+            (r"self\._conn\.\w+", True),
+        ],
+    )
+    def test_matches_ripgrep_exactly(self, index, pattern, regex):
+        theirs = self.ripgrep(pattern, regex)
+        ours = {
+            (h.path, h.line)
+            for h in index.search(pattern, is_regex=regex, limit=1_000_000)
+            if h.path.endswith(".py")
+        }
+        assert not (theirs - ours), f"false negatives: {sorted(theirs - ours)[:5]}"
+        assert not (ours - theirs), f"false positives: {sorted(ours - theirs)[:5]}"


### PR DESCRIPTION
Twelve issues. Two themes: ingest was indexing the wrong files, and navegador could not answer the questions agents actually ask.

The work is measurement-gated, and the measurement is reported honestly below — including the part that does not yet support the thesis.

Closes #180, #181, #182, #183, #184, #185, #186, #187, #189, #190, #191

## The thing that was actively wrong

**#180 — ingest indexed files git ignores.** The walk pruned against a hardcoded `_SKIP_DIRS` list and never read `.gitignore`. On one real graph, **54,543 of 54,552 `File` nodes were gitignored build output** under `bundled/` — 99.98% of a 98 MiB index was generated code being offered to agents as source. Every path resolved on disk, so nothing looked broken.

Git is the oracle rather than a matcher of our own: `ls-files --cached --others --exclude-standard` is exactly the set ripgrep walks, and it gets nested ignore files, negation, anchoring and `core.excludesFile` right for free. Not theoretical — the negation test only passes with `bundled/*` rather than `bundled/`, because git refuses to re-include a path whose parent is excluded. My first version of that test was wrong.

Ignored trees are pruned during the walk, not filtered after, so the #128 hang does not return. **54,688 parseable files → 16** on the affected repo.

**#181 — nothing detected stale, duplicate or junk graphs.** With one shared server the graph list accumulates. Auditing the live server (41 graphs) found a 45 MB graph with **none** of its file paths resolving, the same repository indexed under three names, and nine empty graphs named `1)`–`9)`. New `storage audit` and `storage prune`, deliberately conservative: a graph with no checkout to check against is `unknown`, never assumed stale; stale graphs are held back unless `--include-stale`; duplicates are reported, never merged.

**#182 — semantic search scanned what it was meant to index.** Every query fetched all embedded nodes with full vectors and computed cosine in Python — roughly a gigabyte per query at 100k nodes, growing with the graph, paid again by every agent. Now native vectors behind FalkorDB's vector index: **500 nodes 1.18 ms, 5000 nodes 1.37 ms.** Ten times the graph, flat latency. Also fixed a silent `limit=1000` truncation, full re-embedding on every call, and an ambiguous name-based upsert that could write to the wrong node.

## What agents can now ask

**#183 — content store.** The graph kept structure and threw the text away, so there was nothing to match a literal against. Content lives in Redis beside the graph, addressed by the `content_hash` ingest already computes: dedup and incremental fall out for free. stdlib `zlib`, 3.83× on this package's source, and short files are stored raw because zlib made an 81-byte fixture come back as 93.

**#184 — trigram index.** Zoekt's design on Redis. Trigrams narrow, they never decide: candidates are then matched with the real pattern, so the index may over-select but never under-select. `required_trigrams` refuses to narrow on alternation, drops characters a quantifier could remove, and ignores runs inside groups and classes — each of those would be a false negative, the one failure a search index may not have.

Verified against **ripgrep on this package's own source: eight patterns including three regexes, exact agreement, zero false negatives and zero false positives.** The differential test ships.

| pattern | candidates | navegador | ripgrep |
|---|---:|---:|---:|
| `content_hash` | 16 | 7.2 ms | 11.5 ms |
| `GRAPH.LIST` | 4 | 1.9 ms | 12.6 ms |
| `queryNodes` | 1 | 1.0 ms | 12.2 ms |
| no match | 0 | **0.1 ms** | 13.2 ms |

Cost scales with matches, not corpus size. The first implementation was **slower than ripgrep at every selectivity**, with a flat 22 ms floor even when nothing matched — the scope key was rebuilt per search at one round trip per blob. Caught by benchmarking, not by reading the code.

**#185 — the text parsing discards.** Error messages, comments and camelCase/snake_case-split identifiers, behind FalkorDB's full-text index. A pasted error message finds the file that raises it; "rate limiting" finds a file where the phrase exists only in a comment; "user id" reaches `getUserById`. Noise rejection matters as much as recall — one-word string literals are dict keys, and keeping them buries the error messages.

**#186 — targeting.** `locate`, `scope_for`, `neighbourhood`, plus `grep_code` over MCP (31 tools now). These return **places and reasons, never an answer**. Sources are fused by reciprocal rank rather than added, since a trigram hit, a cosine distance and a graph traversal are not on comparable scales.

`scope_for` is the reduction no flat index can compute: on this repository it returns **2 files out of 264**. The tests are built around the failure that would go unnoticed — a scope that quietly widens — so an unknown symbol yields nothing rather than the whole repository, with a control test proving the excluded file really does contain the match.

## Measurement

**#187 — the instrument, and the frozen baseline.** From 133 sessions across 22 projects: median **13 turns to first correct target**, 5 orientation turns, 1.17 re-read ratio, and 96.5% of searches already scoped.

That last figure is why measurement leads this milestone rather than closing it, and it partly refuted the premise the work started from: agents are already good at scoping, filesystem reads run at 0.45 per active minute, and **disk is not the bottleneck at any realistic single-machine scale.** The remaining candidate explanation is turns.

**The re-run does not yet support the thesis.** `turns_to_first_target` is 14 against a baseline of 13. That is not a valid before/after — the tools shipped hours ago and no agent has used them in a real session. The instrument works; the experiment has not run. Claiming a win here would be the same species of error as the bugs this milestone fixed.

## Housekeeping

**#190 — CLI startup 137 ms → 37 ms.** `rich.markdown` (which drags in markdown_it and pygments) and `asyncio` were ~95 ms of module import, paid by every invocation including agent hooks, against a 0.45 ms graph query. Both deferred to the one function that needs them, with tests asserting they stay absent.

**#191 — coverage enforced, and the rule that actually matters.** Coverage was measured and never enforced: no `fail_under`, no CI step. Now ratcheted at 93 against a measured 94. But all eight of the 1.5 fidelity bugs shipped *inside covered lines*, so the percentage was never the lever — #173 survived for months because its tests mocked the store, and a `MagicMock` write always succeeds. `tests/test_no_store_mocks.py` freezes the 55 files that mock the store, rejects new ones, and fails on stale entries so the list cannot rot.

**#189 — dependency posture.** `pip install navegador` is the whole installation, documented and shipped in the wheel. It is why the trigram index was built rather than integrating Zoekt: the build cost is real and unchanged, but a Go binary to install, pin and audit is not.

## #188 stays open, deliberately

Edge provenance shipped: call edges carry `resolution: "inferred"`, since tree-sitter has no name resolution and `foo.bar()` cannot be proven to reach `Baz.bar`. Two of the eight 1.5 bugs came from treating those guesses as certainties. An agent can now tell a fact from a good guess.

The SCIP reader is **not** implemented. It is protobuf, so it needs either a dependency #189 rules out, or a wire-format decoder written from recollection and tested against fixtures written from the same recollection — circular, and it would pass while being silently wrong. No indexer is installed here to produce ground truth. Three unblock conditions are recorded on the issue.

## Tests

3,400+ passing. Every new test runs against a real embedded store, real git repositories and the real tree-sitter grammar. Several bugs in this PR were found only because of that:

- `GRAPH.LIST` returns bytes on an undecoded connection, and `str()` on bytes gives `b'name'` — every lookup missed and the first audit run reported **41 of 41 graphs reclaimable**, including populated ones
- the content store's sibling connection copied every pool kwarg, which worked against the embedded unix socket and raised `TypeError` against a real server
- `line_at` takes a byte offset and I passed it a string index within a minute of writing it; 187 non-ASCII characters put the two 374 bytes apart, landing nine lines off, silently
